### PR TITLE
#923 Remove ConsoleWriterFactory

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -27,7 +27,6 @@
 #include <QThread>
 #include <QDateTime>
 #include <QFile>
-#include <QTextStream>
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 # include <QVersionNumber>
 #endif

--- a/src/global.h
+++ b/src/global.h
@@ -325,16 +325,14 @@ bool    GetFlagArgument ( char**  argv,
                           QString strShortOpt,
                           QString strLongOpt );
 
-bool    GetStringArgument ( QTextStream& tsConsole,
-                            int          argc,
+bool    GetStringArgument ( int          argc,
                             char**       argv,
                             int&         i,
                             QString      strShortOpt,
                             QString      strLongOpt,
                             QString&     strArg );
 
-bool    GetNumericArgument ( QTextStream& tsConsole,
-                             int          argc,
+bool    GetNumericArgument ( int          argc,
                              char**       argv,
                              int&         i,
                              QString      strShortOpt,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,6 @@
 
 #include <QCoreApplication>
 #include <QDir>
-#include <QTextStream>
 #include "global.h"
 #ifndef HEADLESS
 # include <QApplication>
@@ -48,7 +47,6 @@
 int main ( int argc, char** argv )
 {
 
-    QTextStream&   tsConsole = *( ( new ConsoleWriterFactory() )->get() );
     QString        strArgument;
     double         rDbleArgument;
     QList<QString> CommandLineOptions;
@@ -89,6 +87,13 @@ int main ( int argc, char** argv )
     QString      strWelcomeMessage           = "";
     QString      strClientName               = "";
 
+#if !defined(HEADLESS) && defined(_WIN32)
+    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+        freopen("CONOUT$", "w", stdout);
+        freopen("CONOUT$", "w", stderr);
+    }
+#endif
+
     // QT docu: argv()[0] is the program name, argv()[1] is the first
     // argument and argv()[argc()-1] is the last argument.
     // Start with first argument, therefore "i = 1"
@@ -101,7 +106,7 @@ int main ( int argc, char** argv )
                                "--server" ) )
         {
             bIsClient = false;
-            tsConsole << "- server mode chosen" << endl;
+            qInfo() << "- server mode chosen";
             CommandLineOptions << "--server";
             continue;
         }
@@ -114,7 +119,7 @@ int main ( int argc, char** argv )
                                "--nogui" ) )
         {
             bUseGUI = false;
-            tsConsole << "- no GUI mode chosen" << endl;
+            qInfo() << "- no GUI mode chosen";
             CommandLineOptions << "--nogui";
             continue;
         }
@@ -128,7 +133,7 @@ int main ( int argc, char** argv )
         {
             // right now only the creative commons licence is supported
             eLicenceType = LT_CREATIVECOMMONS;
-            tsConsole << "- licence required" << endl;
+            qInfo() << "- licence required";
             CommandLineOptions << "--licence";
             continue;
         }
@@ -141,7 +146,8 @@ int main ( int argc, char** argv )
                                "--fastupdate" ) )
         {
             bUseDoubleSystemFrameSize = false; // 64 samples frame size
-            tsConsole << "- using " << SYSTEM_FRAME_SIZE_SAMPLES << " samples frame size mode" << endl;
+            qInfo() << qUtf8Printable( QString( "- using %1 samples frame size mode" )
+                .arg( SYSTEM_FRAME_SIZE_SAMPLES ) );
             CommandLineOptions << "--fastupdate";
             continue;
         }
@@ -154,15 +160,14 @@ int main ( int argc, char** argv )
                                "--multithreading" ) )
         {
             bUseMultithreading = true;
-            tsConsole << "- using multithreading" << endl;
+            qInfo() << "- using multithreading";
             CommandLineOptions << "--multithreading";
             continue;
         }
 
 
         // Maximum number of channels ------------------------------------------
-        if ( GetNumericArgument ( tsConsole,
-                                  argc,
+        if ( GetNumericArgument ( argc,
                                   argv,
                                   i,
                                   "-u",
@@ -173,8 +178,8 @@ int main ( int argc, char** argv )
         {
             iNumServerChannels = static_cast<int> ( rDbleArgument );
 
-            tsConsole << "- maximum number of channels: "
-                << iNumServerChannels << endl;
+            qInfo() << qUtf8Printable( QString("- maximum number of channels: %1")
+                .arg( iNumServerChannels ) );
 
             CommandLineOptions << "--numchannels";
             continue;
@@ -188,7 +193,7 @@ int main ( int argc, char** argv )
                                "--startminimized" ) )
         {
             bStartMinimized = true;
-            tsConsole << "- start minimized enabled" << endl;
+            qInfo() << "- start minimized enabled";
             CommandLineOptions << "--startminimized";
             continue;
         }
@@ -201,7 +206,7 @@ int main ( int argc, char** argv )
                                "--discononquit" ) )
         {
             bDisconnectAllClientsOnQuit = true;
-            tsConsole << "- disconnect all clients on quit" << endl;
+            qInfo() << "- disconnect all clients on quit";
             CommandLineOptions << "--discononquit";
             continue;
         }
@@ -214,7 +219,7 @@ int main ( int argc, char** argv )
                                "--nojackconnect" ) )
         {
             bNoAutoJackConnect = true;
-            tsConsole << "- disable auto Jack connections" << endl;
+            qInfo() << "- disable auto Jack connections";
             CommandLineOptions << "--nojackconnect";
             continue;
         }
@@ -227,7 +232,7 @@ int main ( int argc, char** argv )
                                "--notranslation" ) )
         {
             bUseTranslation = false;
-            tsConsole << "- translations disabled" << endl;
+            qInfo() << "- translations disabled";
             CommandLineOptions << "--notranslation";
             continue;
         }
@@ -243,7 +248,7 @@ int main ( int argc, char** argv )
                                "--showallservers" ) )
         {
             bShowComplRegConnList = true;
-            tsConsole << "- show all registered servers in server list" << endl;
+            qInfo() << "- show all registered servers in server list";
             CommandLineOptions << "--showallservers";
             continue;
         }
@@ -258,15 +263,14 @@ int main ( int argc, char** argv )
                                "--showanalyzerconsole" ) )
         {
             bShowAnalyzerConsole = true;
-            tsConsole << "- show analyzer console" << endl;
+            qInfo() << "- show analyzer console";
             CommandLineOptions << "--showanalyzerconsole";
             continue;
         }
 
 
         // Controller MIDI channel ---------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "--ctrlmidich", // no short form
@@ -274,15 +278,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strMIDISetup = strArgument;
-            tsConsole << "- MIDI controller settings: " << strMIDISetup << endl;
+            qInfo() << qUtf8Printable( QString( "- MIDI controller settings: %1" )
+                .arg( strMIDISetup ) );
             CommandLineOptions << "--ctrlmidich";
             continue;
         }
 
 
         // Use logging ---------------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-l",
@@ -290,15 +294,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strLoggingFileName = strArgument;
-            tsConsole << "- logging file name: " << strLoggingFileName << endl;
+            qInfo() << qUtf8Printable( QString( "- logging file name: %1" )
+                .arg( strLoggingFileName ) );
             CommandLineOptions << "--log";
             continue;
         }
 
 
         // Port number ---------------------------------------------------------
-        if ( GetNumericArgument ( tsConsole,
-                                  argc,
+        if ( GetNumericArgument ( argc,
                                   argv,
                                   i,
                                   "-p",
@@ -309,15 +313,15 @@ int main ( int argc, char** argv )
         {
             iPortNumber            = static_cast<quint16> ( rDbleArgument );
             bCustomPortNumberGiven = true;
-            tsConsole << "- selected port number: " << iPortNumber << endl;
+            qInfo() << qUtf8Printable( QString( "- selected port number: %1" )
+                .arg( iPortNumber ) );
             CommandLineOptions << "--port";
             continue;
         }
 
 
         // HTML status file ----------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-m",
@@ -325,15 +329,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strHTMLStatusFileName = strArgument;
-            tsConsole << "- HTML status file name: " << strHTMLStatusFileName << endl;
+            qInfo() << qUtf8Printable( QString( "- HTML status file name: %1" )
+                .arg( strHTMLStatusFileName ) );
             CommandLineOptions << "--htmlstatus";
             continue;
         }
 
 
         // Client Name ---------------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "--clientname", // no short form
@@ -341,15 +345,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strClientName = strArgument;
-            tsConsole << "- client name: " << strClientName << endl;
+            qInfo() << qUtf8Printable( QString( "- client name: %1" )
+                .arg( strClientName ) );
             CommandLineOptions << "--clientname";
             continue;
         }
 
 
         // Recording directory -------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-R",
@@ -357,7 +361,8 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strRecordingDirName = strArgument;
-            tsConsole << "- recording directory name: " << strRecordingDirName << endl;
+            qInfo() << qUtf8Printable( QString("- recording directory name: %1" )
+                .arg( strRecordingDirName ) );
             CommandLineOptions << "--recording";
             continue;
         }
@@ -370,15 +375,14 @@ int main ( int argc, char** argv )
                                "--norecord" ) )
         {
             bDisableRecording = true;
-            tsConsole << "- recording will not be enabled" << endl;
+            qInfo() << "- recording will not be enabled";
             CommandLineOptions << "--norecord";
             continue;
         }
 
 
         // Central server ------------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-e",
@@ -386,15 +390,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strCentralServer = strArgument;
-            tsConsole << "- central server: " << strCentralServer << endl;
+            qInfo() << qUtf8Printable( QString( "- central server: %1" )
+                .arg( strCentralServer ) );
             CommandLineOptions << "--centralserver";
             continue;
         }
 
 
         // Server info ---------------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-o",
@@ -402,15 +406,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strServerInfo = strArgument;
-            tsConsole << "- server info: " << strServerInfo << endl;
+            qInfo() << qUtf8Printable( QString( "- server info: %1" )
+                .arg( strServerInfo ) );
             CommandLineOptions << "--serverinfo";
             continue;
         }
 
 
         // Server list filter --------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-f",
@@ -418,15 +422,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strServerListFilter = strArgument;
-            tsConsole << "- server list filter: " << strServerListFilter << endl;
+            qInfo() << qUtf8Printable( QString( "- server list filter: %1" )
+                .arg( strServerListFilter ) );
             CommandLineOptions << "--listfilter";
             continue;
         }
 
 
         // Server welcome message ----------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-w",
@@ -434,15 +438,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strWelcomeMessage = strArgument;
-            tsConsole << "- welcome message: " << strWelcomeMessage << endl;
+            qInfo() << qUtf8Printable( QString( "- welcome message: %1" )
+                .arg( strWelcomeMessage ) );
             CommandLineOptions << "--welcomemessage";
             continue;
         }
 
 
         // Initialization file -------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-i",
@@ -450,15 +454,15 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strIniFileName = strArgument;
-            tsConsole << "- initialization file name: " << strIniFileName << endl;
+            qInfo() << qUtf8Printable( QString( "- initialization file name: %1" )
+                .arg( strIniFileName ) );
             CommandLineOptions << "--inifile";
             continue;
         }
 
 
         // Connect on startup --------------------------------------------------
-        if ( GetStringArgument ( tsConsole,
-                                 argc,
+        if ( GetStringArgument ( argc,
                                  argv,
                                  i,
                                  "-c",
@@ -466,7 +470,8 @@ int main ( int argc, char** argv )
                                  strArgument ) )
         {
             strConnOnStartupAddress = NetworkUtil::FixAddress ( strArgument );
-            tsConsole << "- connect on startup to address: " << strConnOnStartupAddress << endl;
+            qInfo() << qUtf8Printable( QString( "- connect on startup to address: %1" )
+                .arg( strConnOnStartupAddress ) );
             CommandLineOptions << "--connect";
             continue;
         }
@@ -479,7 +484,7 @@ int main ( int argc, char** argv )
                                "--mutestream" ) )
         {
             bMuteStream = true;
-            tsConsole << "- mute stream activated" << endl;
+            qInfo() << "- mute stream activated";
             CommandLineOptions << "--mutestream";
             continue;
         }
@@ -492,7 +497,7 @@ int main ( int argc, char** argv )
                                "--mutemyown" ) )
         {
             bMuteMeInPersonalMix = true;
-            tsConsole << "- mute me in my personal mix" << endl;
+            qInfo() << "- mute me in my personal mix";
             CommandLineOptions << "--mutemyown";
             continue;
         }
@@ -502,7 +507,7 @@ int main ( int argc, char** argv )
         if ( ( !strcmp ( argv[i], "--version" ) ) ||
              ( !strcmp ( argv[i], "-v" ) ) )
         {
-            tsConsole << GetVersionAndNameStr ( false ) << endl;
+            qCritical() << qUtf8Printable( GetVersionAndNameStr ( false ) );
             exit ( 1 );
         }
 
@@ -513,15 +518,14 @@ int main ( int argc, char** argv )
              ( !strcmp ( argv[i], "-?" ) ) )
         {
             const QString strHelp = UsageArguments ( argv );
-            tsConsole << strHelp << endl;
-            exit ( 1 );
+            qInfo() << qUtf8Printable( strHelp );
+            exit ( 0 );
         }
 
 
         // Unknown option ------------------------------------------------------
-        tsConsole << argv[0] << ": ";
-        tsConsole << "Unknown option '" <<
-            argv[i] << "' -- use '--help' for help" << endl;
+        qCritical() << qUtf8Printable( QString( "%1: Unknown option '%2' -- use '--help' for help" )
+            .arg( argv[0] ).arg( argv[i] ) );
 
 // clicking on the Mac application bundle, the actual application
 // is called with weird command line args -> do not exit on these
@@ -536,7 +540,7 @@ int main ( int argc, char** argv )
     if ( bUseGUI )
     {
         bUseGUI = false;
-        tsConsole << "No GUI support compiled. Running in headless mode." << endl;
+        qWarning() << "No GUI support compiled. Running in headless mode.";
     }
     Q_UNUSED ( bStartMinimized )       // avoid compiler warnings
     Q_UNUSED ( bShowComplRegConnList ) // avoid compiler warnings
@@ -547,14 +551,14 @@ int main ( int argc, char** argv )
     // the inifile is not supported for the headless server mode
     if ( !bIsClient && !bUseGUI && !strIniFileName.isEmpty() )
     {
-        tsConsole << "No initialization file support in headless server mode." << endl;
+        qWarning() << "No initialization file support in headless server mode.";
     }
 
     // mute my own signal in personal mix is only supported for headless mode
     if ( bIsClient && bUseGUI && bMuteMeInPersonalMix )
     {
         bMuteMeInPersonalMix = false;
-        tsConsole << "Mute my own signal in my personal mix is only supported in headless mode." << endl;
+        qWarning() << "Mute my own signal in my personal mix is only supported in headless mode.";
     }
 
     // per definition: if we are in "GUI" server mode and no central server
@@ -677,7 +681,7 @@ int main ( int argc, char** argv )
 #endif
             {
                 // only start application without using the GUI
-                tsConsole << GetVersionAndNameStr ( false ) << endl;
+                qInfo() << qUtf8Printable( GetVersionAndNameStr ( false ) );
 
                 pApp->exec();
             }
@@ -736,7 +740,7 @@ int main ( int argc, char** argv )
 #endif
             {
                 // only start application without using the GUI
-                tsConsole << GetVersionAndNameStr ( false ) << endl;
+                qInfo() << qUtf8Printable( GetVersionAndNameStr ( false ) );
 
                 // update serverlist
                 Server.UpdateServerList();
@@ -761,7 +765,9 @@ int main ( int argc, char** argv )
         else
 #endif
         {
-            tsConsole << generr.GetErrorText() << endl;
+            qCritical() << qUtf8Printable( QString( "%1: %2" )
+                .arg( APP_NAME ).arg( generr.GetErrorText() ) );
+            exit ( 1 );
         }
     }
 
@@ -790,8 +796,8 @@ QString UsageArguments ( char **argv )
         "  -v, --version         output version information and exit\n"
         "\nServer only:\n"
         "  -d, --discononquit    disconnect all clients on quit\n"
-        "  -e, --centralserver   address of the central server\n"
-        "                        (or 'localhost' to be a central server)\n"
+        "  -e, --centralserver   address of the server list on which to register\n"
+        "                        (or 'localhost' to be a server list)\n"
         "  -f, --listfilter      server list whitelist filter in the format:\n"
         "                        [IP address 1];[IP address 2];[IP address 3]; ...\n"
         "  -F, --fastupdate      use 64 samples frame size mode\n"
@@ -813,8 +819,8 @@ QString UsageArguments ( char **argv )
         "      --mutemyown       mute me in my personal mix (headless only)\n"
         "  -c, --connect         connect to given server address on startup\n"
         "  -j, --nojackconnect   disable auto Jack connections\n"
-        "  --ctrlmidich          MIDI controller channel to listen\n"
-        "  --clientname          client name (window title and jack client name)\n"
+        "      --ctrlmidich      MIDI controller channel to listen\n"
+        "      --clientname      client name (window title and jack client name)\n"
         "\nExample: " + QString ( argv[0] ) + " -s --inifile myinifile.ini\n";
 }
 
@@ -834,8 +840,7 @@ bool GetFlagArgument ( char**  argv,
     }
 }
 
-bool GetStringArgument ( QTextStream& tsConsole,
-                         int          argc,
+bool GetStringArgument ( int          argc,
                          char**       argv,
                          int&         i,
                          QString      strShortOpt,
@@ -847,8 +852,8 @@ bool GetStringArgument ( QTextStream& tsConsole,
     {
         if ( ++i >= argc )
         {
-            tsConsole << argv[0] << ": ";
-            tsConsole << "'" << strLongOpt << "' needs a string argument" << endl;
+            qCritical() << qUtf8Printable( QString( "%1: '%2' needs a string argument." )
+                .arg( argv[0] ).arg( strLongOpt ) );
             exit ( 1 );
         }
 
@@ -862,8 +867,7 @@ bool GetStringArgument ( QTextStream& tsConsole,
     }
 }
 
-bool GetNumericArgument ( QTextStream& tsConsole,
-                          int          argc,
+bool GetNumericArgument ( int          argc,
                           char**       argv,
                           int&         i,
                           QString      strShortOpt,
@@ -875,14 +879,11 @@ bool GetNumericArgument ( QTextStream& tsConsole,
     if ( ( !strShortOpt.compare ( argv[i] ) ) ||
          ( !strLongOpt.compare ( argv[i] ) ) )
     {
+        QString errmsg = "%1: '%2' needs a numeric argument between '%3' and '%4'.";
         if ( ++i >= argc )
         {
-            tsConsole << argv[0] << ": ";
-
-            tsConsole << "'" <<
-                strLongOpt << "' needs a numeric argument between " <<
-                rRangeStart << " and " << rRangeStop << endl;
-
+            qCritical() << qUtf8Printable( errmsg
+                .arg( argv[0] ).arg( strLongOpt ).arg( rRangeStart ).arg( rRangeStop ) );
             exit ( 1 );
         }
 
@@ -892,12 +893,8 @@ bool GetNumericArgument ( QTextStream& tsConsole,
              ( rValue < rRangeStart ) ||
              ( rValue > rRangeStop ) )
         {
-            tsConsole << argv[0] << ": ";
-
-            tsConsole << "'" <<
-                strLongOpt << "' needs a numeric argument between " <<
-                rRangeStart << " and " << rRangeStop << endl;
-
+            qCritical() << qUtf8Printable( errmsg
+                .arg( argv[0] ).arg( strLongOpt ).arg( rRangeStart ).arg( rRangeStop ) );
             exit ( 1 );
         }
 

--- a/src/recorder/jamcontroller.cpp
+++ b/src/recorder/jamcontroller.cpp
@@ -52,10 +52,8 @@ void CJamController::SetEnableRecording  ( bool bNewEnableRecording, bool isRunn
         // message only if the state appears to change
         if ( bEnableRecording != bNewEnableRecording )
         {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qInfo()
-            qInfo() << "Recording state" << ( bNewEnableRecording ? "enabled" : "disabled" );
-#endif
+            qInfo() << qUtf8Printable( QString( "Recording state: %1" )
+                .arg( bNewEnableRecording ? "enabled" : "disabled" ) );
         }
 
         // note that this block executes regardless of whether
@@ -97,10 +95,8 @@ void CJamController::SetRecordingDir ( QString newRecordingDir,
         bRecorderInitialised = ( strRecorderErrMsg == QString::null );
         bEnableRecording = bRecorderInitialised && !bDisableRecording;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qInfo()
-        qInfo() << "Recording state" << ( bEnableRecording ? "enabled" : "disabled" );
-#endif
+        qInfo() << qUtf8Printable( QString( "Recording state: %1" )
+            .arg( bEnableRecording ? "enabled" : "disabled" ) );
     }
     else
     {
@@ -109,10 +105,7 @@ void CJamController::SetRecordingDir ( QString newRecordingDir,
         bRecorderInitialised = false;
         bEnableRecording = false;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qInfo()
         qInfo() << "Recording state not initialised";
-#endif
     }
 
     if ( bRecorderInitialised )

--- a/src/recorder/jamrecorder.cpp
+++ b/src/recorder/jamrecorder.cpp
@@ -312,29 +312,20 @@ QString CJamRecorder::Init()
 
     if ( !fi.exists() && !QDir().mkpath ( recordBaseDir.absolutePath() ) )
     {
-        errmsg = recordBaseDir.absolutePath() + " does not exist but could not be created";
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qCritical()
-        qCritical() << errmsg;
-#endif
+        errmsg = QString( "'%1' does not exist but could not be created." ).arg( recordBaseDir.absolutePath() );
+        qCritical() << qUtf8Printable( errmsg );
         return errmsg;
     }
     if (!fi.isDir())
     {
-        errmsg = recordBaseDir.absolutePath() + " exists but is not a directory";
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qCritical()
-        qCritical() << errmsg;
-#endif
+        errmsg = QString( "'%1' exists but is not a directory" ).arg( recordBaseDir.absolutePath() );
+        qCritical() << qUtf8Printable( errmsg );
         return errmsg;
     }
     if (!fi.isWritable())
     {
-        errmsg = recordBaseDir.absolutePath() + " is a directory but cannot be written to";
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-// TODO we should use the ConsoleWriterFactory() instead of qCritical()
-        qCritical() << errmsg;
-#endif
+        errmsg = QString( "'%1' is a directory but cannot be written to" ).arg( recordBaseDir.absolutePath() );
+        qCritical() << qUtf8Printable( errmsg );
         return errmsg;
     }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -716,9 +716,8 @@ void CServer::OnAboutToQuit()
 
 void CServer::OnHandledSignal ( int sigNum )
 {
-    // show the signal number on the command line (note that this does not work for the Windows command line)
-// TODO we should use the ConsoleWriterFactory() instead of qDebug()
-    qDebug() << "OnHandledSignal: " << sigNum;
+    // show the signal number on the console (note that this may not work for Windows)
+    qDebug() << qUtf8Printable( QString( "OnHandledSignal: %1" ).arg( sigNum ) );
 
 #ifdef _WIN32
     // Windows does not actually get OnHandledSignal triggered

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -31,8 +31,7 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
                                          const QString& strServerListFilter,
                                          const int      iNumChannels,
                                          CProtocol*     pNConLProt )
-    : tsConsoleStream           ( *( ( new ConsoleWriterFactory() )->get() ) ),
-      eCentralServerAddressType ( AT_CUSTOM ), // must be AT_CUSTOM for the "no GUI" case
+    : eCentralServerAddressType ( AT_CUSTOM ), // must be AT_CUSTOM for the "no GUI" case
       strMinServerVersion       ( "" ), // disable version check with empty version
       pConnLessProtocol         ( pNConLProt ),
       eSvrRegStatus             ( SRS_UNREGISTERED ),
@@ -116,7 +115,8 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
             else if ( CurWhiteListAddress.setAddress ( slWhitelistAddresses.at ( iIdx ) ) )
             {
                 vWhiteList << CurWhiteListAddress;
-                tsConsoleStream << "Whitelist entry added: " << CurWhiteListAddress.toString() << endl;
+                qInfo() << qUtf8Printable( QString( "Whitelist entry added: %1" )
+                    .arg( CurWhiteListAddress.toString() ) );
             }
         }
     }
@@ -292,7 +292,8 @@ void CServerListManager::OnTimerPollList()
 
     foreach ( const CHostAddress HostAddr, vecRemovedHostAddr )
     {
-        tsConsoleStream << "Expired entry for " << HostAddr.toString() << endl;
+        qInfo() << qUtf8Printable( QString( "Expired entry for %1" )
+            .arg( HostAddr.toString() ) );
     }
 }
 
@@ -303,9 +304,8 @@ void CServerListManager::CentralServerRegisterServer ( const CHostAddress&    In
 {
     if ( bIsCentralServer && bEnabled )
     {
-        tsConsoleStream << "Requested to register entry for "
-                        << InetAddr.toString() << " (" << LInetAddr.toString() << ")"
-                        << ": " << ServerInfo.strName << endl;
+        qInfo() << qUtf8Printable( QString( "Requested to register entry for %1 (%2): %3")
+            .arg( InetAddr.toString() ).arg( LInetAddr.toString() ).arg( ServerInfo.strName ) );
 
         // check for minimum server version
         if ( !strMinServerVersion.isEmpty() )
@@ -387,8 +387,8 @@ void CServerListManager::CentralServerUnregisterServer ( const CHostAddress& Ine
 {
     if ( bIsCentralServer && bEnabled )
     {
-        tsConsoleStream << "Requested to unregister entry for "
-                        << InetAddr.toString() << endl;
+        qInfo() << qUtf8Printable( QString( "Requested to unregister entry for " )
+            .arg( InetAddr.toString() ) );
 
         QMutexLocker locker ( &Mutex );
 
@@ -585,7 +585,8 @@ void CServerListManager::SlaveServerRegisterServer ( const bool bIsRegister )
 void CServerListManager::SetSvrRegStatus ( ESvrRegStatus eNSvrRegStatus )
 {
     // output regirstation result/update on the console
-    tsConsoleStream << "Server Registration Status update: " << svrRegStatusToString ( eNSvrRegStatus ) << endl;
+    qInfo() << qUtf8Printable( QString( "Server Registration Status update: " )
+        .arg( svrRegStatusToString ( eNSvrRegStatus ) ) );
 
     // store the state and inform the GUI about the new status
     eSvrRegStatus = eNSvrRegStatus;

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -387,7 +387,7 @@ void CServerListManager::CentralServerUnregisterServer ( const CHostAddress& Ine
 {
     if ( bIsCentralServer && bEnabled )
     {
-        qInfo() << qUtf8Printable( QString( "Requested to unregister entry for " )
+        qInfo() << qUtf8Printable( QString( "Requested to unregister entry for %1" )
             .arg( InetAddr.toString() ) );
 
         QMutexLocker locker ( &Mutex );
@@ -585,7 +585,7 @@ void CServerListManager::SlaveServerRegisterServer ( const bool bIsRegister )
 void CServerListManager::SetSvrRegStatus ( ESvrRegStatus eNSvrRegStatus )
 {
     // output regirstation result/update on the console
-    qInfo() << qUtf8Printable( QString( "Server Registration Status update: " )
+    qInfo() << qUtf8Printable( QString( "Server Registration Status update: %1" )
         .arg( svrRegStatusToString ( eNSvrRegStatus ) ) );
 
     // store the state and inform the GUI about the new status

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -190,7 +190,6 @@ protected:
     QTimer                  TimerCLRegisterServerResp;
 
     QMutex                  Mutex;
-    QTextStream&            tsConsoleStream;
 
     QList<CServerListEntry> ServerList;
 

--- a/src/serverlogging.cpp
+++ b/src/serverlogging.cpp
@@ -52,8 +52,7 @@ void CServerLogging::AddNewConnection ( const QHostAddress& ClientInetAddr,
     const QString strLogStr = CurTimeDatetoLogString() + ", " +
         ClientInetAddr.toString() + ", connected (" + QString::number ( iNumberOfConnectedClients ) + ")";
 
-    QTextStream& tsConsoleStream = *( ( new ConsoleWriterFactory() )->get() );
-    tsConsoleStream << strLogStr << endl; // on console
+    qInfo() << qUtf8Printable( strLogStr ); // on console
     *this << strLogStr; // in log file
 }
 
@@ -62,8 +61,7 @@ void CServerLogging::AddServerStopped()
     const QString strLogStr = CurTimeDatetoLogString() + ",, server idling "
         "-------------------------------------";
 
-    QTextStream& tsConsoleStream = *( ( new ConsoleWriterFactory() )->get() );
-    tsConsoleStream << strLogStr << endl; // on console
+    qInfo() << qUtf8Printable( strLogStr ); // on console
     *this << strLogStr; // in log file
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -28,7 +28,6 @@
 #include <QFile>
 #include <QSettings>
 #include <QDir>
-#include <QTextStream>
 #ifndef HEADLESS
 # include <QMessageBox>
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1508,31 +1508,6 @@ void CLocale::LoadTranslation ( const QString     strLanguage,
 }
 
 
-// Console writer factory ------------------------------------------------------
-QTextStream* ConsoleWriterFactory::get()
-{
-    if ( ptsConsole == nullptr )
-    {
-#if _WIN32
-        if ( !AttachConsole ( ATTACH_PARENT_PROCESS ) )
-        {
-            // Not run from console, dump logging to nowhere
-            static QString conout;
-            ptsConsole = new QTextStream ( &conout );
-        }
-        else
-        {
-            freopen ( "CONOUT$", "w", stdout );
-            ptsConsole = new QTextStream ( stdout );
-        }
-#else
-        ptsConsole = new QTextStream ( stdout );
-#endif
-    }
-    return ptsConsole;
-}
-
-
 /******************************************************************************\
 * Global Functions Implementation                                              *
 \******************************************************************************/

--- a/src/util.h
+++ b/src/util.h
@@ -494,19 +494,6 @@ signals:
 #endif
 
 
-// Console writer factory ------------------------------------------------------
-// this class was written by pljones
-class ConsoleWriterFactory
-{
-public:
-    ConsoleWriterFactory() : ptsConsole ( nullptr ) { }
-    QTextStream* get();
-
-private:
-    QTextStream* ptsConsole;
-};
-
-
 /******************************************************************************\
 * Other Classes/Enums                                                          *
 \******************************************************************************/


### PR DESCRIPTION
All instances of `ConsoleWriterFactory` have been removed.

In addition, on Windows (when not headless), the console has been attached once on start up to ensure messages appear.  This only happens when run from the command line - otherwise the messages don't appear.

Parameterised messages use `QString` formatting but that's needed an extra `qUtf8Printable` call to pass the result to `qInfo()` etc.

A few of the start up messages were warnings, so they're now `qWarning()`, rather than `qInfo()`.  Start up failure is now displayed as `qCritical()` messages.

As we've generally moved to `qInfo()` etc, I removed the QT version check where it was in place.

----
Unrelated bits...
* I changed the help text for `--centralserver` to use the term "server list".
* I fixed the formatting of `--ctrlmidich` and `--clientname` to be consistent with the other long opt-only options.