### PR TITLE
Escape chat messages at the server

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -167,6 +167,9 @@ MESSAGES (with connection)
     | 2 bytes number n | n bytes UTF-8 string |
     +------------------+----------------------+
 
+    - "UTF-8 string": the chat message (plain text from client to server;
+      HTML from server to client)
+
 
 - PROTMESSID_NETW_TRANSPORT_PROPS: Properties for network transport
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1395,7 +1395,7 @@ void CServer::CreateAndSendChatTextForAllConChannels ( const int      iCurChanID
         "<font color=""" + sCurColor + """>(" +
         QTime::currentTime().toString ( "hh:mm:ss AP" ) + ") <b>" +
         ChanName.toHtmlEscaped() +
-        "</b></font> " + strChatText;
+        "</b></font> " + strChatText.toHtmlEscaped();
 
 
     // Send chat text to all connected clients ---------------------------------


### PR DESCRIPTION
Update my patch to strip HTML from chat messages from #380, as discussed in #890 (@hoffie).

One thing to test with this before merging is that URLs containing `&` still get link-ified correctly.