### PR TITLE
Add the keyboard shortcut simple control the Mute Stream checkbox

### DIFF
--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -325,6 +325,9 @@
           <property name="text">
            <string>&amp;Mute Myself</string>
           </property>
+          <property name="shortcut">
+           <string>M</string>
+          </property>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
This simple change allows controlling the mute easily by pressing the M key on the keyboard (when the main window has focus).

The motivation is to use a modified keyboard (with just the M key) as a control pedal to easily mute/unmute myself between listening/playing. 