### PR TITLE
Feature midi pan issue 95

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,10 @@
 
 - Highlight the fact that the server is recording in the Mixerboard title (#968), coded by dcorson-ticino.com
 
+- Implement new --ctrlmidich syntax allowing to specify fader, pan, mute,
+  solo buttons (#945).  Implementation for mute&solo buttons for now is
+  only for toggle controllers and does not support headless operation yet.
+
 TODO fix crash if settings are changed in ASIO4All during a connection (contained in #796)
 
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1246,6 +1246,20 @@ void CAudioMixerBoard::SetFaderLevel ( const int iChannelIdx,
     }
 }
 
+void CAudioMixerBoard::SetPanValue ( const int iChannelIdx,
+                                     const int iValue )
+{
+    // only apply new pan value if channel index is valid and the panner is visible
+    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS )
+           && bDisplayPans )
+    {
+        if ( vecpChanFader[iChannelIdx]->IsVisible() )
+        {
+            vecpChanFader[iChannelIdx]->SetPanValue ( iValue );
+        }
+    }
+}
+
 void CAudioMixerBoard::SetAllFaderLevelsToNewClientLevel()
 {
     QMutexLocker locker ( &Mutex );

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1260,6 +1260,33 @@ void CAudioMixerBoard::SetPanValue ( const int iChannelIdx,
     }
 }
 
+void CAudioMixerBoard::SetFaderIsSolo ( const int iChannelIdx,
+                                        const bool bIsSolo )
+{
+    // only apply solo if channel index is valid and the fader is visible
+    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS ) )
+
+    {
+        if ( vecpChanFader[iChannelIdx]->IsVisible() )
+        {
+            vecpChanFader[iChannelIdx]->SetFaderIsSolo ( bIsSolo );
+        }
+    }
+}
+
+void CAudioMixerBoard::SetFaderIsMute ( const int iChannelIdx,
+                                        const bool bIsMute )
+{
+    // only apply mute if channel index is valid and the fader is visible
+    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS ) )
+    {
+        if ( vecpChanFader[iChannelIdx]->IsVisible() )
+        {
+            vecpChanFader[iChannelIdx]->SetFaderIsMute ( bIsMute );
+        }
+    }
+}
+
 void CAudioMixerBoard::SetAllFaderLevelsToNewClientLevel()
 {
     QMutexLocker locker ( &Mutex );

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -210,6 +210,9 @@ public:
     void            SetFaderLevel ( const int iChannelIdx,
                                 const int iValue );
 
+    void            SetPanValue ( const int iChannelIdx,
+                                  const int iValue );
+
     void            SetNumMixerPanelRows ( const int iNNumMixerPanelRows );
     int             GetNumMixerPanelRows() { return iNumMixerPanelRows; }
 

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -208,10 +208,16 @@ public:
     void            SetMyChannelID ( const int iChannelIdx ) { iMyChannelID = iChannelIdx; }
 
     void            SetFaderLevel ( const int iChannelIdx,
-                                const int iValue );
+                                    const int iValue );
 
     void            SetPanValue ( const int iChannelIdx,
                                   const int iValue );
+
+    void            SetFaderIsSolo ( const int iChannelIdx,
+                                     const bool bIsSolo );
+
+    void            SetFaderIsMute ( const int iChannelIdx,
+                                     const bool bIsMute );
 
     void            SetNumMixerPanelRows ( const int iNNumMixerPanelRows );
     int             GetNumMixerPanelRows() { return iNumMixerPanelRows; }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -184,6 +184,9 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &Sound, &CSound::ControllerInFaderLevel,
         this, &CClient::OnControllerInFaderLevel );
 
+    QObject::connect ( &Sound, &CSound::ControllerInPanValue,
+        this, &CClient::OnControllerInPanValue );
+
     QObject::connect ( &Socket, &CHighPrioSocket::InvalidPacketReceived,
         this, &CClient::OnInvalidPacketReceived );
 
@@ -705,6 +708,19 @@ void CClient::OnControllerInFaderLevel ( int iChannelIdx,
 #endif
 
     emit ControllerInFaderLevel ( iChannelIdx, iValue );
+}
+
+void CClient::OnControllerInPanValue ( int iChannelIdx,
+                                       int iValue )
+{
+    // in case of a headless client the panners cannot be moved so we need
+    // to send the controller information directly to the server
+#ifdef HEADLESS
+    // channel index is valid
+    SetRemoteChanPan ( iChannelIdx, static_cast<float>( iValue ) / AUD_MIX_PAN_MAX);
+#endif
+
+    emit ControllerInPanValue ( iChannelIdx, iValue );
 }
 
 void CClient::OnClientIDReceived ( int iChanID )

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -187,6 +187,12 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &Sound, &CSound::ControllerInPanValue,
         this, &CClient::OnControllerInPanValue );
 
+    QObject::connect ( &Sound, &CSound::ControllerInFaderIsSolo,
+        this, &CClient::OnControllerInFaderIsSolo );
+
+    QObject::connect ( &Sound, &CSound::ControllerInFaderIsMute,
+        this, &CClient::OnControllerInFaderIsMute );
+
     QObject::connect ( &Socket, &CHighPrioSocket::InvalidPacketReceived,
         this, &CClient::OnInvalidPacketReceived );
 
@@ -721,6 +727,30 @@ void CClient::OnControllerInPanValue ( int iChannelIdx,
 #endif
 
     emit ControllerInPanValue ( iChannelIdx, iValue );
+}
+
+void CClient::OnControllerInFaderIsSolo ( int iChannelIdx,
+                                          bool bIsSolo )
+{
+    // in case of a headless client the buttons are not displayed so we need
+    // to send the controller information directly to the server
+#ifdef HEADLESS
+    // FIXME: no idea what to do here.
+#endif
+
+    emit ControllerInFaderIsSolo ( iChannelIdx, bIsSolo );
+}
+
+void CClient::OnControllerInFaderIsMute ( int iChannelIdx,
+                                          bool bIsMute )
+{
+    // in case of a headless client the buttons are not displayed so we need
+    // to send the controller information directly to the server
+#ifdef HEADLESS
+    // FIXME: no idea what to do here.
+#endif
+
+    emit ControllerInFaderIsMute ( iChannelIdx, bIsMute );
 }
 
 void CClient::OnClientIDReceived ( int iChanID )

--- a/src/client.h
+++ b/src/client.h
@@ -392,6 +392,8 @@ protected slots:
     void OnSndCrdReinitRequest ( int iSndCrdResetType );
     void OnControllerInFaderLevel ( int iChannelIdx, int iValue );
     void OnControllerInPanValue ( int iChannelIdx, int iValue );
+    void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
+    void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
     void OnClientIDReceived ( int iChanID );
 
 signals:
@@ -428,4 +430,6 @@ signals:
     void SoundDeviceChanged ( QString strError );
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );
     void ControllerInPanValue ( int iChannelIdx, int iValue );
+    void ControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
+    void ControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
 };

--- a/src/client.h
+++ b/src/client.h
@@ -391,6 +391,7 @@ protected slots:
 
     void OnSndCrdReinitRequest ( int iSndCrdResetType );
     void OnControllerInFaderLevel ( int iChannelIdx, int iValue );
+    void OnControllerInPanValue ( int iChannelIdx, int iValue );
     void OnClientIDReceived ( int iChanID );
 
 signals:
@@ -426,4 +427,5 @@ signals:
     void Disconnected();
     void SoundDeviceChanged ( QString strError );
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );
+    void ControllerInPanValue ( int iChannelIdx, int iValue );
 };

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -487,6 +487,9 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QObject::connect ( pClient, &CClient::ControllerInFaderLevel,
         this, &CClientDlg::OnControllerInFaderLevel );
 
+    QObject::connect ( pClient, &CClient::ControllerInPanValue,
+        this, &CClientDlg::OnControllerInPanValue );
+
     QObject::connect ( pClient, &CClient::CLChannelLevelListReceived,
         this, &CClientDlg::OnCLChannelLevelListReceived );
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -490,6 +490,12 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QObject::connect ( pClient, &CClient::ControllerInPanValue,
         this, &CClientDlg::OnControllerInPanValue );
 
+    QObject::connect ( pClient, &CClient::ControllerInFaderIsSolo,
+        this, &CClientDlg::OnControllerInFaderIsSolo );
+
+    QObject::connect ( pClient, &CClient::ControllerInFaderIsMute,
+        this, &CClientDlg::OnControllerInFaderIsMute );
+
     QObject::connect ( pClient, &CClient::CLChannelLevelListReceived,
         this, &CClientDlg::OnCLChannelLevelListReceived );
 

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -143,6 +143,10 @@ public slots:
                                     const int iValue ) { MainMixerBoard->SetFaderLevel ( iChannelIdx,
                                                                                          iValue ); }
 
+    void OnControllerInPanValue ( const int iChannelIdx,
+                                  const int iValue ) { MainMixerBoard->SetPanValue ( iChannelIdx,
+                                                                                     iValue ); }
+
     void OnVersionAndOSReceived ( COSUtil::EOpSystemType ,
                                   QString                strVersion );
 

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -147,6 +147,14 @@ public slots:
                                   const int iValue ) { MainMixerBoard->SetPanValue ( iChannelIdx,
                                                                                      iValue ); }
 
+    void OnControllerInFaderIsSolo ( const int iChannelIdx,
+                                     const bool bIsSolo ) { MainMixerBoard->SetFaderIsSolo ( iChannelIdx,
+                                                                                             bIsSolo ); }
+
+    void OnControllerInFaderIsMute ( const int iChannelIdx,
+                                     const bool bIsMute ) { MainMixerBoard->SetFaderIsMute ( iChannelIdx,
+                                                                                             bIsMute ); }
+
     void OnVersionAndOSReceived ( COSUtil::EOpSystemType ,
                                   QString                strVersion );
 

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -395,6 +395,20 @@ printf ( "\n" );
                                 emit ControllerInPanValue ( cCtrl.iChannel, iPanValue );
                             }
                             break;
+                        case Solo:
+                            {
+                                // We depend on toggles reflecting the desired state
+                                emit ControllerInFaderIsSolo ( cCtrl.iChannel,
+                                                               iValue >= 0x40);
+                            }
+                            break;
+                        case Mute:
+                            {
+                                // We depend on toggles reflecting the desired state
+                                emit ControllerInFaderIsMute ( cCtrl.iChannel,
+                                                               iValue >= 0x40);
+                            }
+                            break;
                         default:
                             break;
                         }

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -385,7 +385,16 @@ printf ( "\n" );
                                 emit ControllerInFaderLevel ( cCtrl.iChannel, iFaderLevel );
                             }
                             break;
+                        case Pan:
+                            {
+                                // Pan levels need to be symmetric between 1 and 127
+                                const int iPanValue = static_cast<int> (
+                                    static_cast<double> (
+                                        qMax ( iValue, 1 ) - 1) / 126 * AUD_MIX_PAN_MAX );
 
+                                emit ControllerInPanValue ( cCtrl.iChannel, iPanValue );
+                            }
+                            break;
                         default:
                             break;
                         }

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -24,6 +24,18 @@
 
 #include "soundbase.h"
 
+// This is used as a lookup table for parsing option letters, mapping
+// a single character to an EMidiCtlType
+char const sMidiCtlChar[] =
+{
+  // Has to follow order of EMidiCtlType
+  /* [EMidiCtlType::Fader] = */ 'f',
+  /* [EMidiCtlType::Pan]   = */ 'p',
+  /* [EMidiCtlType::Solo]  = */ 's',
+  /* [EMidiCtlType::Mute]  = */ 'm',
+  /* [EMidiCtlType::None]  = */ '\0'
+};
+
 
 /* Implementation *************************************************************/
 CSoundBase::CSoundBase ( const QString& strNewSystemDriverTechniqueName,
@@ -241,6 +253,20 @@ void CSoundBase::ParseCommandLineArgument ( const QString& strMIDISetup )
     // provides a definition for the controller offset of the level
     // controllers (default 70 for the sake of Behringer X-Touch)
     // [MIDI channel];[offset for level]
+    //
+    // The more verbose new form is a sequence of offsets for various
+    // controllers: at the current point, 'f', 'p', 's', and 'm' are
+    // parsed for fader, pan, solo, mute controllers respectively.
+    // However, at the current point of time only 'f' and 'p'
+    // controllers are actually implemented.  The syntax for a Korg
+    // nanoKONTROL2 with 8 fader controllers starting at offset 0 and
+    // 8 pan controllers starting at offset 16 would be
+    //
+    // [MIDI channel];f0*8;p16*8
+    //
+    // Namely a sequence of letters indicating the kind of controller,
+    // followed by the offset of the first such controller, followed
+    // by * and a count for number of controllers (if more than 1)
     if ( !strMIDISetup.isEmpty() )
     {
         // split the different parameter strings
@@ -252,17 +278,59 @@ void CSoundBase::ParseCommandLineArgument ( const QString& strMIDISetup )
             iCtrlMIDIChannel = slMIDIParams[0].toUInt();
         }
 
+        bool bSimple = true; // Indicates the legacy kind of specifying
+                             // the fader controller offset without an
+                             // indication of the count of controllers
+
+
         // [offset for level]
         if ( slMIDIParams.count() >= 2 )
         {
-            iMIDIOffsetFader = slMIDIParams[1].toUInt();
+            int i = slMIDIParams[1].toUInt ( &bSimple );
+            // if the second parameter can be parsed as a number, we
+            // have the legacy specification of controllers.
+            if ( bSimple )
+                iMIDIOffsetFader = i;
         }
 
-        for ( int i = 0; i < MAX_NUM_CHANNELS; i++ )
+        if ( bSimple )
         {
-            if ( i + iMIDIOffsetFader > 127 )
-                break;
-            aMidiCtls[i + iMIDIOffsetFader] = { EMidiCtlType::Fader, i };
+        // For the legacy specification, we consider every controller
+        // up to the maximum number of channels (or the maximum
+        // controller number) a fader.
+            for ( int i = 0; i < MAX_NUM_CHANNELS; i++ )
+            {
+                if ( i + iMIDIOffsetFader > 127 )
+                    break;
+                aMidiCtls[i + iMIDIOffsetFader] = { EMidiCtlType::Fader, i };
+            }
+            return;
+        }
+
+        // We have named controllers
+
+        for ( int i = 1; i < slMIDIParams.count(); i++ )
+        {
+            QString sParm = slMIDIParams[i].trimmed();
+            if ( sParm.isEmpty() )
+                continue;
+
+            int iCtrl = QString ( sMidiCtlChar ).indexOf ( sParm[0] );
+            if ( iCtrl < 0 )
+                continue;
+            EMidiCtlType eTyp = static_cast<EMidiCtlType> ( iCtrl );
+
+            const QStringList slP = sParm.mid ( 1 ).split ( '*' );
+            int iFirst = slP[0].toUInt();
+            int iNum = ( slP.count() > 1 ) ? slP[1].toUInt() : 1;
+            for ( int iOff = 0; iOff < iNum; iOff++ )
+            {
+                if ( iOff >= MAX_NUM_CHANNELS )
+                    break;
+                if ( iFirst + iOff >= 128 )
+                    break;
+                aMidiCtls[iFirst + iOff] = { eTyp, iOff };
+            }
         }
     }
 }
@@ -297,10 +365,12 @@ printf ( "\n" );
                 if ( ( iStatusByte >= 0xB0 ) && ( iStatusByte < 0xC0 ) )
                 {
                     // make sure packet is long enough
-                    if ( vMIDIPaketBytes.Size() > 2 )
+                    if ( vMIDIPaketBytes.Size() > 2
+                         && vMIDIPaketBytes[1] <= uint8_t ( 127 )
+                         && vMIDIPaketBytes[2] <= uint8_t ( 127 ) )
                     {
-                        const auto &cCtrl = aMidiCtls[qMin ( vMIDIPaketBytes[1], uint8_t ( 127 ) )];
-                        const int iValue = qMin ( vMIDIPaketBytes[2], uint8_t ( 127 ) );
+                        const CMidiCtlEntry &cCtrl = aMidiCtls[vMIDIPaketBytes[1]];
+                        const int iValue = vMIDIPaketBytes[2];;
                         switch ( cCtrl.eType )
                         {
                         case Fader:

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -165,4 +165,6 @@ signals:
     void ReinitRequest ( int iSndCrdResetType );
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );
     void ControllerInPanValue ( int iChannelIdx, int iValue );
+    void ControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
+    void ControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
 };

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -43,6 +43,23 @@ enum ESndCrdResetType
     RS_RELOAD_RESTART_AND_INIT
 };
 
+enum EMidiCtlType
+{
+    Fader = 0,
+    Pan,
+    Solo,
+    Mute,
+    None
+};
+
+class CMidiCtlEntry {
+public:
+    CMidiCtlEntry ( EMidiCtlType eT = EMidiCtlType::None, int iC = 0 )
+        : eType ( eT ), iChannel ( iC )
+        { }
+    EMidiCtlType eType;
+    int iChannel;
+};
 
 /* Classes ********************************************************************/
 class CSoundBase : public QThread
@@ -138,7 +155,7 @@ protected:
 
     QString strSystemDriverTechniqueName;
     int     iCtrlMIDIChannel;
-    int     iMIDIOffsetFader;
+    QVector<CMidiCtlEntry> aMidiCtls;
 
     long    lNumDevs;
     QString strCurDevName;

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -164,4 +164,5 @@ protected:
 signals:
     void ReinitRequest ( int iSndCrdResetType );
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );
+    void ControllerInPanValue ( int iChannelIdx, int iValue );
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -482,6 +482,7 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
         "<p>bspeer (<a href=\"https://github.com/bspeer\">bspeer</a>)</p>"
         "<p>Martin Passing (<a href=\"https://github.com/passing\">passing</a>)</p>"
         "<p>DonC (<a href=\"https://github.com/dcorson-ticino-com\">dcorson</a>)</p>"
+        "<p>David Kastrup (<a href=\"https://github.com/dakhubgit\">dakhubgit</a>)</p>"
         "<br>" + tr ( "For details on the contributions check out the " ) +
         "<a href=\"https://github.com/jamulussoftware/jamulus/graphs/contributors\">" + tr ( "Github Contributors list" ) + "</a>." );
 


### PR DESCRIPTION
This implements the command line parsing for my last proposal on issue #95 .  It provides for specifying controllers for fader, pan, solo and mute buttons, but the implementation only retains the functionality for faders (though using a different framework) and in a final commit adds support for panning via MIDI.

I don't have an actual clue what I am doing, so the implementation may well be mistaken.  Also the code style seems designed to thwart all conventions and it not supported by any editor or project I know, so I had to constantly fight my editor and may have gotten parts wrong.