### PR TITLE
Fix git submodule usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "libs/oboe"]
 	path = libs/oboe
-	url = ../../github.com/google/oboe.git
+	url = ../../google/oboe.git
 [submodule "tools/jamulus-php"]
 	path = tools/jamulus-php
-	url = ../../github.com/softins/jamulus-php
+	url = ../../softins/jamulus-php
 [submodule "tools/jamulus-web"]
 	path = tools/jamulus-web
-	url = ../../github.com/softins/jamulus-web
+	url = ../../softins/jamulus-web
 [submodule "tools/jamulus-wireshark"]
 	path = tools/jamulus-wireshark
-	url = ../../github.com/softins/jamulus-wireshark
+	url = ../../softins/jamulus-wireshark
 [submodule "tools/jamulus-historytool"]
 	path = tools/jamulus-historytool
-	url = ../../github.com/pljones/jamulus-historytool
+	url = ../../pljones/jamulus-historytool
 [submodule "tools/jamulus-jamexporter"]
 	path = tools/jamulus-jamexporter
-	url = ../../github.com/pljones/jamulus-jamexporter
+	url = ../../pljones/jamulus-jamexporter
 [submodule "tools/jamulus-docker"]
 	path = tools/jamulus-docker
-	url = ../../github.com/grundic/jamulus-docker
+	url = ../../grundic/jamulus-docker
 [submodule "tools/jamulus-server-remote"]
 	path = tools/jamulus-server-remote
-	url = ../../github.com/vdellamea/jamulus-server-remote
+	url = ../../vdellamea/jamulus-server-remote


### PR DESCRIPTION
The relative paths in .gitmodules contained a stray github.com/ path component which broke submodule resolution.

Got broken in #934.
Fixes #984.

cc @ann0see @pljones @nefarius2001

Tested with http:
```
$ git clone -b fix-submodules https://github.com/hoffie/jamulus --recurse --depth=1
Cloning into 'jamulus'...
remote: Enumerating objects: 999, done.
remote: Counting objects: 100% (999/999), done.
remote: Compressing objects: 100% (957/957), done.
remote: Total 999 (delta 143), reused 556 (delta 29), pack-reused 0
Receiving objects: 100% (999/999), 4.82 MiB | 4.79 MiB/s, done.
Resolving deltas: 100% (143/143), done.
Submodule 'libs/oboe' (https://github.com/google/oboe.git) registered for path 'libs/oboe'
Submodule 'tools/jamulus-docker' (https://github.com/grundic/jamulus-docker) registered for path 'tools/jamulus-docker'
Submodule 'tools/jamulus-historytool' (https://github.com/pljones/jamulus-historytool) registered for path 'tools/jamulus-historytool'
Submodule 'tools/jamulus-jamexporter' (https://github.com/pljones/jamulus-jamexporter) registered for path 'tools/jamulus-jamexporter'
Submodule 'tools/jamulus-php' (https://github.com/softins/jamulus-php) registered for path 'tools/jamulus-php'
Submodule 'tools/jamulus-server-remote' (https://github.com/vdellamea/jamulus-server-remote) registered for path 'tools/jamulus-server-remote'
Submodule 'tools/jamulus-web' (https://github.com/softins/jamulus-web) registered for path 'tools/jamulus-web'
Submodule 'tools/jamulus-wireshark' (https://github.com/softins/jamulus-wireshark) registered for path 'tools/jamulus-wireshark'
Cloning into '/tmp/jamulus/libs/oboe'...
remote: Enumerating objects: 52, done.        
remote: Counting objects: 100% (52/52), done.        
remote: Compressing objects: 100% (46/46), done.        
remote: Total 13764 (delta 17), reused 9 (delta 1), pack-reused 13712        
Receiving objects: 100% (13764/13764), 45.82 MiB | 9.91 MiB/s, done.
Resolving deltas: 100% (8382/8382), done.
Cloning into '/tmp/jamulus/tools/jamulus-docker'...
remote: Enumerating objects: 103, done.        
remote: Total 103 (delta 0), reused 0 (delta 0), pack-reused 103        
Receiving objects: 100% (103/103), 25.65 KiB | 596.00 KiB/s, done.
Resolving deltas: 100% (39/39), done.
Cloning into '/tmp/jamulus/tools/jamulus-historytool'...
remote: Enumerating objects: 50, done.        
remote: Counting objects: 100% (50/50), done.        
remote: Compressing objects: 100% (28/28), done.        
remote: Total 50 (delta 15), reused 47 (delta 13), pack-reused 0        
Receiving objects: 100% (50/50), 26.39 KiB | 435.00 KiB/s, done.
Resolving deltas: 100% (15/15), done.
Cloning into '/tmp/jamulus/tools/jamulus-jamexporter'...
remote: Enumerating objects: 43, done.        
remote: Counting objects: 100% (43/43), done.        
remote: Compressing objects: 100% (32/32), done.        
remote: Total 43 (delta 16), reused 30 (delta 11), pack-reused 0        
Receiving objects: 100% (43/43), 26.00 KiB | 619.00 KiB/s, done.
Resolving deltas: 100% (16/16), done.
Cloning into '/tmp/jamulus/tools/jamulus-php'...
remote: Enumerating objects: 146, done.        
remote: Counting objects: 100% (146/146), done.        
remote: Compressing objects: 100% (106/106), done.        
remote: Total 146 (delta 44), reused 138 (delta 39), pack-reused 0        
Receiving objects: 100% (146/146), 36.81 KiB | 483.00 KiB/s, done.
Resolving deltas: 100% (44/44), done.
Cloning into '/tmp/jamulus/tools/jamulus-server-remote'...
remote: Enumerating objects: 108, done.        
remote: Counting objects: 100% (108/108), done.        
remote: Compressing objects: 100% (106/106), done.        
remote: Total 292 (delta 69), reused 0 (delta 0), pack-reused 184        
Receiving objects: 100% (292/292), 1.29 MiB | 2.55 MiB/s, done.
Resolving deltas: 100% (156/156), done.
Cloning into '/tmp/jamulus/tools/jamulus-web'...
remote: Enumerating objects: 220, done.        
remote: Counting objects: 100% (220/220), done.        
remote: Compressing objects: 100% (145/145), done.        
remote: Total 220 (delta 141), reused 147 (delta 72), pack-reused 0        
Receiving objects: 100% (220/220), 187.92 KiB | 1.03 MiB/s, done.
Resolving deltas: 100% (141/141), done.
Cloning into '/tmp/jamulus/tools/jamulus-wireshark'...
remote: Enumerating objects: 84, done.        
remote: Counting objects: 100% (84/84), done.        
remote: Compressing objects: 100% (55/55), done.        
remote: Total 84 (delta 31), reused 78 (delta 27), pack-reused 0        
Receiving objects: 100% (84/84), 22.73 KiB | 1.51 MiB/s, done.
Resolving deltas: 100% (31/31), done.
Submodule path 'libs/oboe': checked out '6c6bff4c5a67b5da3067dc8b1480c2e310d81a2e'
Submodule path 'tools/jamulus-docker': checked out 'c268ce2d91081413a162913120a463e4949c328c'
Submodule path 'tools/jamulus-historytool': checked out 'd5ef80df8f2f2b31fa20e78343e8e31acf60c009'
Submodule path 'tools/jamulus-jamexporter': checked out 'f89fece13d9483a19406a72f27ce5095e5e16a2b'
Submodule path 'tools/jamulus-php': checked out '65be50ca766c7a42979b19ac4d978357ad07b408'
Submodule path 'tools/jamulus-server-remote': checked out 'b6387d614b9a0797b8f779da413cb162ac17d39c'
Submodule path 'tools/jamulus-web': checked out '2112478e2e0fb83a07f592df2168ca938661994f'
Submodule path 'tools/jamulus-wireshark': checked out '593bf494119df13a0d77512ffb238c90b32b41f5'
```

Tested with SSH:
```
$ git clone -b fix-submodules ssh://github.com/hoffie/jamulus --recurse --depth=1
Cloning into 'jamulus'...
remote: Enumerating objects: 999, done.
remote: Counting objects: 100% (999/999), done.
remote: Compressing objects: 100% (957/957), done.
remote: Total 999 (delta 143), reused 557 (delta 29), pack-reused 0
Receiving objects: 100% (999/999), 4.82 MiB | 5.33 MiB/s, done.
Resolving deltas: 100% (143/143), done.
Submodule 'libs/oboe' (ssh://github.com/google/oboe.git) registered for path 'libs/oboe'
Submodule 'tools/jamulus-docker' (ssh://github.com/grundic/jamulus-docker) registered for path 'tools/jamulus-docker'
Submodule 'tools/jamulus-historytool' (ssh://github.com/pljones/jamulus-historytool) registered for path 'tools/jamulus-historytool'
Submodule 'tools/jamulus-jamexporter' (ssh://github.com/pljones/jamulus-jamexporter) registered for path 'tools/jamulus-jamexporter'
Submodule 'tools/jamulus-php' (ssh://github.com/softins/jamulus-php) registered for path 'tools/jamulus-php'
Submodule 'tools/jamulus-server-remote' (ssh://github.com/vdellamea/jamulus-server-remote) registered for path 'tools/jamulus-server-remote'
Submodule 'tools/jamulus-web' (ssh://github.com/softins/jamulus-web) registered for path 'tools/jamulus-web'
Submodule 'tools/jamulus-wireshark' (ssh://github.com/softins/jamulus-wireshark) registered for path 'tools/jamulus-wireshark'
Cloning into '/tmp/jamulus/libs/oboe'...
remote: Enumerating objects: 52, done.        
remote: Counting objects: 100% (52/52), done.        
remote: Compressing objects: 100% (46/46), done.        
remote: Total 13764 (delta 17), reused 9 (delta 1), pack-reused 13712        
Receiving objects: 100% (13764/13764), 45.82 MiB | 7.39 MiB/s, done.
Resolving deltas: 100% (8382/8382), done.
Cloning into '/tmp/jamulus/tools/jamulus-docker'...
remote: Enumerating objects: 103, done.        
remote: Total 103 (delta 0), reused 0 (delta 0), pack-reused 103        
Receiving objects: 100% (103/103), 25.65 KiB | 312.00 KiB/s, done.
Resolving deltas: 100% (39/39), done.
Cloning into '/tmp/jamulus/tools/jamulus-historytool'...
remote: Enumerating objects: 50, done.        
remote: Counting objects: 100% (50/50), done.        
remote: Compressing objects: 100% (28/28), done.        
remote: Total 50 (delta 15), reused 47 (delta 13), pack-reused 0        
Receiving objects: 100% (50/50), 26.39 KiB | 355.00 KiB/s, done.
Resolving deltas: 100% (15/15), done.
Cloning into '/tmp/jamulus/tools/jamulus-jamexporter'...
remote: Enumerating objects: 43, done.        
remote: Counting objects: 100% (43/43), done.        
remote: Compressing objects: 100% (32/32), done.        
remote: Total 43 (delta 16), reused 30 (delta 11), pack-reused 0        
Receiving objects: 100% (43/43), 26.00 KiB | 345.00 KiB/s, done.
Resolving deltas: 100% (16/16), done.
Cloning into '/tmp/jamulus/tools/jamulus-php'...
remote: Enumerating objects: 146, done.        
remote: Counting objects: 100% (146/146), done.        
remote: Compressing objects: 100% (106/106), done.        
remote: Total 146 (delta 44), reused 138 (delta 39), pack-reused 0        
Receiving objects: 100% (146/146), 36.81 KiB | 380.00 KiB/s, done.
Resolving deltas: 100% (44/44), done.
Cloning into '/tmp/jamulus/tools/jamulus-server-remote'...
remote: Enumerating objects: 108, done.        
remote: Counting objects: 100% (108/108), done.        
remote: Compressing objects: 100% (106/106), done.        
remote: Total 292 (delta 69), reused 0 (delta 0), pack-reused 184        
Receiving objects: 100% (292/292), 1.29 MiB | 2.24 MiB/s, done.
Resolving deltas: 100% (156/156), done.
Cloning into '/tmp/jamulus/tools/jamulus-web'...
remote: Enumerating objects: 220, done.        
remote: Counting objects: 100% (220/220), done.        
remote: Compressing objects: 100% (145/145), done.        
remote: Total 220 (delta 141), reused 147 (delta 72), pack-reused 0        
Receiving objects: 100% (220/220), 187.92 KiB | 1.00 MiB/s, done.
Resolving deltas: 100% (141/141), done.
Cloning into '/tmp/jamulus/tools/jamulus-wireshark'...
remote: Enumerating objects: 84, done.        
remote: Counting objects: 100% (84/84), done.        
remote: Compressing objects: 100% (55/55), done.        
remote: Total 84 (delta 31), reused 78 (delta 27), pack-reused 0        
Receiving objects: 100% (84/84), 22.73 KiB | 2.27 MiB/s, done.
Resolving deltas: 100% (31/31), done.
Submodule path 'libs/oboe': checked out '6c6bff4c5a67b5da3067dc8b1480c2e310d81a2e'
Submodule path 'tools/jamulus-docker': checked out 'c268ce2d91081413a162913120a463e4949c328c'
Submodule path 'tools/jamulus-historytool': checked out 'd5ef80df8f2f2b31fa20e78343e8e31acf60c009'
Submodule path 'tools/jamulus-jamexporter': checked out 'f89fece13d9483a19406a72f27ce5095e5e16a2b'
Submodule path 'tools/jamulus-php': checked out '65be50ca766c7a42979b19ac4d978357ad07b408'
Submodule path 'tools/jamulus-server-remote': checked out 'b6387d614b9a0797b8f779da413cb162ac17d39c'
Submodule path 'tools/jamulus-web': checked out '2112478e2e0fb83a07f592df2168ca938661994f'
Submodule path 'tools/jamulus-wireshark': checked out '593bf494119df13a0d77512ffb238c90b32b41f5'

```