### PR TITLE
Github Workflow CodeQL: Check out submodules

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     - name: Install Qt on Linux
       run: |


### PR DESCRIPTION
(As noticed by @nefarius2001)

- Submodules are part of official releases, so it might make sense
  to run them through CodeQL as well.
- This is supposed to detect breakage with submodule inclusion
  as observed in #984.

Docs: https://github.com/actions/checkout

I'm not sure if the modified CodeQL workflow will already trigger in this PR (I suspect it won't). If it does, it will probably (correctly) fail until #985 is merged. It would be great if it did because I could then rebase and we could check if the action works as intended and passes afterwards.

Note: I have never worked with Github actions before so it might be horribly wrong what I do.