### PR TITLE
Server: Send empty channel list on connect

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,10 @@
 - stop sending traffic to CloudFlare as part of the external IP detection
   logic (#633, #1092), suggested by atsampson, coded by hoffie
 
+- bug fix: properly restore mixer levels after reconnecting to a restarted
+  server. updating the server or the client is sufficient to fix this. coded
+  by hoffie (#955, #1009, #1010)
+
 
 
 ### 3.6.2 (2020-12-12) ###

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -594,6 +594,11 @@ void CServer::OnNewConnection ( int          iChID,
     // must be the first message to be sent for a new connection)
     vecChannels[iChID].CreateClientIDMes ( iChID );
 
+    // Send an empty channel list in order to force clients to reset their
+    // audio mixer state. This is required to trigger clients to re-send their
+    // gain levels upon reconnecting after server restarts.
+    vecChannels[iChID].CreateConClientListMes ( CVector<CChannelInfo> (0) );
+
     // query support for split messages in the client
     vecChannels[iChID].CreateReqSplitMessSupportMes();
 


### PR DESCRIPTION
This ensures that clients will reset their audio mixer board state upon reconnect. Otherwise, gain levels may not be sent reliably to the server.

Fixes #955.

Note: This is an alternative approach to #1009. Both PRs are compatible and can be merged together.