### PR TITLE
Server: Stop using Cloudflare for IP detection

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -108,11 +108,10 @@ LED bar:      lbr
 #define SERVER_GETTING_STARTED_URL       "https://jamulus.io/wiki/Running-a-Server"
 #define SOFTWARE_MANUAL_URL              "https://jamulus.io/wiki/Software-Manual"
 
-// determining server internal address uses well-known host and port
-// (You can change the service used here to something like Cloudflare (1.1.1.1), Google DNS (8.8.8.8), or something else reliable)
-#define WELL_KNOWN_HOST                  "1.1.1.1" // CloudFlare
-#define WELL_KNOWN_PORT                  53        // DNS
-#define IP_LOOKUP_TIMEOUT                500       // ms
+// determining the server's external address requires setting
+// up a socket to a public IP address.
+#define WELL_KNOWN_HOST                  "192.0.2.1" // Reserved IP as per RFC 5737
+#define IP_LOOKUP_TIMEOUT                500         // ms
 
 // system sample rate (the sound card and audio coder works on this sample rate)
 #define SYSTEM_SAMPLE_RATE_HZ            48000 // Hz

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,6 @@ int main ( int argc, char** argv )
         freopen("CONOUT$", "w", stderr);
     }
 #endif
-
     // QT docu: argv()[0] is the program name, argv()[1] is the first
     // argument and argv()[argc()-1] is the last argument.
     // Start with first argument, therefore "i = 1"

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -53,6 +53,7 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
         // User-supplied --serverpublicip
         qhaServerPublicIP = QHostAddress ( strServerPublicIP );
     }
+    qDebug() << "Using" << qhaServerPublicIP.toString() << "as public IP.";
     SlaveCurLocalHostAddress = CHostAddress ( qhaServerPublicIP, iNPortNum );
 
     // prepare the server info information

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1024,8 +1024,11 @@ bool NetworkUtil::ParseNetworkAddress ( QString       strAddress,
 
 CHostAddress NetworkUtil::GetLocalAddress()
 {
-    QTcpSocket socket;
-    socket.connectToHost ( WELL_KNOWN_HOST, WELL_KNOWN_PORT );
+    QUdpSocket socket;
+    // As we are using UDP, the connectToHost() does not generate any traffic at all.
+    // We just require a socket which is pointed towards the Internet in
+    // order to find our the IP of our own external interface.
+    socket.connectToHost ( WELL_KNOWN_HOST, DEFAULT_PORT_NUMBER );
 
     if ( socket.waitForConnected ( IP_LOOKUP_TIMEOUT ) )
     {

--- a/src/util.h
+++ b/src/util.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <QCoreApplication>
-#include <QTcpSocket>
+#include <QUdpSocket>
 #include <QHostAddress>
 #include <QHostInfo>
 #ifndef HEADLESS


### PR DESCRIPTION
Previously, the code for finding the current machine's external IP address created a TCP connection to Cloudflare. This is unnecessary. Instead, just creating a socket to a non-private IP suffices to find
that IP. We now use a reserved IP for that and use UDP in order to avoid triggering any traffic at all.

All credit goes to @atsampson.
Fixes #633.

To be done:
- Verify functionality on Windows/Mac
- Decide whether to keep the new qDebug() line
- Confirm that using a reserved IP is the best option
- Confirm that using the Jamulus default port is a good idea