### PR TITLE
Add missing Q_OBJECT macros

### DIFF
--- a/android/sound.h
+++ b/android/sound.h
@@ -35,6 +35,8 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase, public oboe::AudioStreamCallback
 {
+    Q_OBJECT
+
 public:
     static const uint8_t RING_FACTOR;
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),

--- a/ios/sound.h
+++ b/ios/sound.h
@@ -33,6 +33,8 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase
 {
+    Q_OBJECT
+
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*          arg,

--- a/linux/sound.h
+++ b/linux/sound.h
@@ -59,6 +59,8 @@
 #if WITH_SOUND
 class CSound : public CSoundBase
 {
+    Q_OBJECT
+
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*          arg,

--- a/mac/sound.h
+++ b/mac/sound.h
@@ -36,6 +36,8 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase
 {
+    Q_OBJECT
+
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*          arg,

--- a/src/multicolorled.h
+++ b/src/multicolorled.h
@@ -40,6 +40,8 @@
 /* Classes ********************************************************************/
 class CMultiColorLED : public QLabel
 {
+    Q_OBJECT
+
 public:
     enum ELightColor
     {

--- a/windows/sound.h
+++ b/windows/sound.h
@@ -45,6 +45,8 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase
 {
+    Q_OBJECT
+
 public:
     CSound ( void           (*fpNewCallback) ( CVector<int16_t>& psData, void* arg ),
              void*          arg,


### PR DESCRIPTION
Fixes #1012 

Not sure what the effect is of `Q_OBJECT` being missing, but `lupdate` and `lrelease` complain about it.