### PR TITLE
Revert "Add missing Q_OBJECT macros"

### DIFF
--- a/android/sound.h
+++ b/android/sound.h
@@ -35,8 +35,6 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase, public oboe::AudioStreamCallback
 {
-    Q_OBJECT
-
 public:
     static const uint8_t RING_FACTOR;
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),

--- a/ios/sound.h
+++ b/ios/sound.h
@@ -33,8 +33,6 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase
 {
-    Q_OBJECT
-
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*          arg,

--- a/linux/sound.h
+++ b/linux/sound.h
@@ -59,8 +59,6 @@
 #if WITH_SOUND
 class CSound : public CSoundBase
 {
-    Q_OBJECT
-
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*          arg,

--- a/mac/sound.h
+++ b/mac/sound.h
@@ -36,8 +36,6 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase
 {
-    Q_OBJECT
-
 public:
     CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData, void* arg ),
              void*          arg,

--- a/src/multicolorled.h
+++ b/src/multicolorled.h
@@ -40,8 +40,6 @@
 /* Classes ********************************************************************/
 class CMultiColorLED : public QLabel
 {
-    Q_OBJECT
-
 public:
     enum ELightColor
     {

--- a/windows/sound.h
+++ b/windows/sound.h
@@ -45,8 +45,6 @@
 /* Classes ********************************************************************/
 class CSound : public CSoundBase
 {
-    Q_OBJECT
-
 public:
     CSound ( void           (*fpNewCallback) ( CVector<int16_t>& psData, void* arg ),
              void*          arg,


### PR DESCRIPTION
@softins It seems as if aba68e07a690d0e78dee165ef69d4b1dde38fa2f broke the headless build. See my comment there. Probably it's not related to your PR and something else: https://github.com/jamulussoftware/jamulus/commit/aba68e07a690d0e78dee165ef69d4b1dde38fa2f#commitcomment-47243814