### PR TITLE
Fix headless build regarding multicolorled.h

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -400,7 +400,6 @@ HEADERS += src/buffer.h \
     src/channel.h \
     src/client.h \
     src/global.h \
-    src/multicolorled.h \
     src/protocol.h \
     src/recorder/jamcontroller.h \
     src/server.h \
@@ -423,7 +422,8 @@ HEADERS_GUI = src/audiomixerboard.h \
     src/clientdlg.h \
     src/serverdlg.h \
     src/levelmeter.h \
-    src/analyzerconsole.h
+    src/analyzerconsole.h \
+    src/multicolorled.h
 
 HEADERS_OPUS = libs/opus/celt/arch.h \
     libs/opus/celt/bands.h \


### PR DESCRIPTION
The qmake definition incorrectly listed src/multicolorled.h in the global `HEADERS` list. However, that file includes `QLabel` which is only available when building with `QT += widgets`. This is not done in headless
builds. Therefore, the build breaks.

This PR moves the include to the `HEADERS_GUI` list and fixes the build.

src/multicolorled.h is only included by UI-related classes. It should therefore be safe to move it.

Spotted by @ann0see here:
https://github.com/jamulussoftware/jamulus/commit/aba68e07a690d0e78dee165ef69d4b1dde38fa2f#commitcomment-47243228

Should make #1014 obsolete.

cc @softins 