### PR TITLE
Use "CONFIG+=noupcasename" to fix desktop file

### DIFF
--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -6,7 +6,7 @@ export QT_SELECT=qt5
 	dh $@
 
 override_dh_auto_configure:
-	mkdir -p build-gui && cd build-gui && qmake TARGET=jamulus PREFIX=/usr ../Jamulus.pro
+	mkdir -p build-gui && cd build-gui && qmake "CONFIG+=noupcasename" PREFIX=/usr ../Jamulus.pro
 	mkdir -p build-nox && cd build-nox && qmake "CONFIG+=nosound headless" TARGET=jamulus-headless PREFIX=/usr ../Jamulus.pro
 
 override_dh_auto_build:


### PR DESCRIPTION
It seems as if the created desktop file didn't use the correct target and therefore wrong binary name. See: https://github.com/nefarius2001/jamulus/pull/6/commits/00a917fb5954ec5bb6814fe2a1941d288d3f3d67