### PR TITLE
Auto-adjustment of channel faders

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 
 ### 3.7.0dev <- NOTE: the release version number will be 3.7.1 ###
 
-
+- Automatic channel fader adjustment simplifies mixer setup by using the channel level meters (#1071).
+  (contributed by @JohannesBrx)
 
 ### 3.7.0 (2021-03-17) ###
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -857,7 +857,7 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent ) :
     // create all mixer controls and make them invisible
     vecpChanFader.Init ( MAX_NUM_CHANNELS );
 
-    vecAvgLevels.Init ( MAX_NUM_CHANNELS );
+    vecAvgLevels.Init ( MAX_NUM_CHANNELS, 0.0f );
 
     for ( int i = 0; i < MAX_NUM_CHANNELS; i++ )
     {
@@ -1147,6 +1147,7 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
                     {
                         // the fader was not in use, reset everything for new client
                         vecpChanFader[i]->Reset();
+                        vecAvgLevels[i] = 0.0f;
 
                         // check if this is my own fader and set fader property
                         if ( i == iMyChannelID )

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1327,7 +1327,7 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
 
             // do not adjust channels with zero level to full level since
             // the channel might simply be silent at the moment
-            if ( leveldB < AUTO_FADER_NOISE_THRESHOLD_DB )
+            if ( leveldB > AUTO_FADER_NOISE_THRESHOLD_DB )
             {
                 // compute new level
                 float newdBLevel = -leveldB + AUTO_FADER_TARGET_LEVEL_DB;

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1340,7 +1340,9 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
 
             int group = vecpChanFader[i]->GetGroupID();
             if ( group == INVALID_INDEX )
-                group = 4;
+            {
+                group = MAX_NUM_FADER_GROUPS;
+            }
 
             if ( leveldB >= AUTO_FADER_NOISE_THRESHOLD_DB )
             {
@@ -1392,7 +1394,9 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
         // get median level
         int cntChannels = levels[i].Size();
         if ( cntChannels == 0 )
+        {
             continue;
+        }
         float refLevel = levels[i][cntChannels / 2];
 
         // since we can only attenuate channels but not amplify, we have to
@@ -1440,7 +1444,7 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
                 }
                 else
                 {
-                    group = 4;
+                    group = MAX_NUM_FADER_GROUPS;
                 }
             }
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1399,8 +1399,8 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
     // very weak channels would actually require strong channels to be
     // attenuated to a large amount; however, the attenuation is limited by
     // the faders
-    if ( minFader < -35.0f )
-        levelOffset += -35.0f - minFader;
+    if ( minFader < -AUD_MIX_FADER_RANGE_DB )
+        levelOffset += -AUD_MIX_FADER_RANGE_DB - minFader;
 
     // adjust all levels
     for ( int i = 0; i < MAX_NUM_CHANNELS; ++i )
@@ -1428,8 +1428,8 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
 
                 // map range from decibels to fader level
                 // (this inverts MathUtils::CalcFaderGain)
-                float newFaderLevel = ( newdBLevel + 35.0f ) / 35.0f *
-                    AUD_MIX_FADER_MAX;
+                float newFaderLevel = ( newdBLevel / AUD_MIX_FADER_RANGE_DB +
+                    1.0f ) * AUD_MIX_FADER_MAX;
 
                 // limit fader
                 newFaderLevel = fmin ( fmax ( newFaderLevel, 0.0f),

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1420,7 +1420,9 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
     // attenuated to a large amount; however, the attenuation is limited by
     // the faders
     if ( minFader < -AUD_MIX_FADER_RANGE_DB )
+    {
         levelOffset += -AUD_MIX_FADER_RANGE_DB - minFader;
+    }
 
     // adjust all levels
     for ( int i = 0; i < MAX_NUM_CHANNELS; ++i )

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1360,7 +1360,9 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
 
     // only my channel is active, nothing to do
     if ( cntActiveGroups == 0 )
+    {
         return;
+    }
 
     // compute target level for each group
     // (prevent clipping when each group contributes at maximum level)

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1435,7 +1435,7 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
                     float ( AUD_MIX_FADER_MAX ) );
 
                 // set fader level
-                vecpChanFader[i]->SetFaderLevel ( newFaderLevel, false );
+                vecpChanFader[i]->SetFaderLevel ( newFaderLevel, true );
             }
         }
     }

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1548,9 +1548,9 @@ void CAudioMixerBoard::SetChannelLevels ( const CVector<uint16_t>& vecChannelLev
         if ( vecpChanFader[iChId]->IsVisible() && ( i < iNumChannelLevels ) )
         {
             // compute exponential moving average
-            float alpha = AUTO_FADER_ADJUST_ALPHA;
-            vecAvgLevels[iChId] = (1.0f - alpha) * vecAvgLevels[iChId] +
-                alpha * vecChannelLevel[i];
+            vecAvgLevels[iChId] =
+                (1.0f - AUTO_FADER_ADJUST_ALPHA) * vecAvgLevels[iChId] +
+                AUTO_FADER_ADJUST_ALPHA * vecChannelLevel[i];
 
             vecpChanFader[iChId]->SetChannelLevel ( vecChannelLevel[i++] );
 

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -232,6 +232,7 @@ public:
     void            SetAllFaderLevelsToNewClientLevel();
     void            StoreAllFaderSettings();
     void            LoadAllFaderSettings();
+    void            AutoAdjustAllFaderLevels();
 
 protected:
     class CMixerBoardScrollArea : public QScrollArea
@@ -276,6 +277,7 @@ protected:
     ERecorderState          eRecorderState;
     QMutex                  Mutex;
     EChSortType             eChSortType;
+    CVector<float>          vecAvgLevels;
 
     virtual void UpdateGainValue ( const int    iChannelIdx,
                                    const float  fValue,

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -340,6 +340,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pEditMenu->addAction ( tr ( "Set All Faders to New Client &Level" ), this,
         SLOT ( OnSetAllFadersToNewClientLevel() ), QKeySequence ( Qt::CTRL + Qt::Key_L ) );
 
+    pEditMenu->addAction ( tr ( "Auto-Adjust all &Faders" ), this,
+        SLOT ( OnAutoAdjustAllFaderLevels() ), QKeySequence ( Qt::CTRL + Qt::Key_F ) );
 
     // Main menu bar -----------------------------------------------------------
     QMenuBar* pMenu = new QMenuBar ( this );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -177,6 +177,7 @@ public slots:
     void OnUseTowRowsForMixerPanel ( bool Checked ) { MainMixerBoard->SetNumMixerPanelRows ( Checked ? 2 : 1 ); }
     void OnClearAllStoredSoloMuteSettings();
     void OnSetAllFadersToNewClientLevel() { MainMixerBoard->SetAllFaderLevelsToNewClientLevel(); }
+    void OnAutoAdjustAllFaderLevels() { MainMixerBoard->AutoAdjustAllFaderLevels(); }
 
     void OnSettingsStateChanged ( int value );
     void OnChatStateChanged ( int value );

--- a/src/global.h
+++ b/src/global.h
@@ -152,6 +152,9 @@ LED bar:      lbr
 #define AUD_MIX_FADER_MAX                100
 #define AUD_MIX_PAN_MAX                  100
 
+// coefficient for averaging channel levels for automatic fader adjustment
+#define AUTO_FADER_ADJUST_ALPHA          0.2
+
 // maximum number of fader groups (must be consistent to audiomixerboard implementation)
 #define MAX_NUM_FADER_GROUPS             4
 

--- a/src/global.h
+++ b/src/global.h
@@ -152,6 +152,9 @@ LED bar:      lbr
 #define AUD_MIX_FADER_MAX                100
 #define AUD_MIX_PAN_MAX                  100
 
+// range of audio mixer fader
+#define AUD_MIX_FADER_RANGE_DB           35.0f
+
 // coefficient for averaging channel levels for automatic fader adjustment
 #define AUTO_FADER_ADJUST_ALPHA          0.2f
 

--- a/src/global.h
+++ b/src/global.h
@@ -153,7 +153,14 @@ LED bar:      lbr
 #define AUD_MIX_PAN_MAX                  100
 
 // coefficient for averaging channel levels for automatic fader adjustment
-#define AUTO_FADER_ADJUST_ALPHA          0.2
+#define AUTO_FADER_ADJUST_ALPHA          0.2f
+
+// target level for auto fader adjustment in decibels
+#define AUTO_FADER_TARGET_LEVEL_DB       -30.0f
+
+// threshold in decibels below which the channel is considered as noise
+// and not adjusted
+#define AUTO_FADER_NOISE_THRESHOLD_DB    -40.0f
 
 // maximum number of fader groups (must be consistent to audiomixerboard implementation)
 #define MAX_NUM_FADER_GROUPS             4

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -485,6 +485,7 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
         "<p>David Kastrup (<a href=\"https://github.com/dakhubgit\">dakhubgit</a>)</p>"
         "<p>Jordan Lum (<a href=\"https://github.com/mulyaj\">mulyaj</a>)</p>"
         "<p>Noam Postavsky (<a href=\"https://github.com/npostavs\">npostavs</a>)</p>"
+        "<p>Johannes Brauers (<a href=\"https://github.com/JohannesBrx\">JohannesBrx</a>)</p>"
         "<br>" + tr ( "For details on the contributions check out the " ) +
         "<a href=\"https://github.com/jamulussoftware/jamulus/graphs/contributors\">" + tr ( "Github Contributors list" ) + "</a>." );
 

--- a/src/util.h
+++ b/src/util.h
@@ -1281,7 +1281,8 @@ public:
         }
         else
         {
-            return powf ( 10.0f, ( fInValueRange0_1 * 35.0f - 35.0f ) / 20.0f );
+            return powf ( 10.0f, ( fInValueRange0_1 - 1.0f ) *
+                AUD_MIX_FADER_RANGE_DB / 20.0f );
         }
     }
 };


### PR DESCRIPTION
This pull request (for issue #966) adds an automatic adjustment of the channel faders depending on the volume of each channel via a new menu entry `Auto-Adjust all Faders`. This shall specifically support larger choirs to get a reasonable mixer setting, although individual adjustments might still be necessary. The function could be called during voice warm up or a uniform part of the music piece. Adjusting the large number of channels manually is quite tedious and might be required for each session because the participants might not use the same microphone levels each time.

**Latest demo version**: https://github.com/jamulussoftware/jamulus/actions/runs/627676186
(Updated Mar, 6th 2021)

### Application

The channel adjustment is best used right before the end of a warm-up singing phrase. When being called, approximately the **previous** 5 seconds are considered for channel adjustment. The shortcut CTRL+F or CMD+F is handy for quick access.

When using channel groups, all groups are equalized such that their contribution is equal. In addition to that, individual channels within a group are also equalized to contribute equally to the group.

### Implementation details

The method averages the level meters for each channel, which get their input from the server. Averaging is particularly necessary to overcome the coarse quantization of the server values: The 4 bit meter level values are given in decibels ranging from -50dB to 0dB in 9 steps from 0...8, while each step is 6.25dB. (The meter value 9 is reserved for indicating clipping.) 

![image](https://user-images.githubusercontent.com/8805876/108552005-031f4d80-72f1-11eb-993a-79ee55b582fe.png)

The adjustment computes the channel fader positions for a target volume of -30dB. Therefore, the channel fader for a channel with -30dB original volume is set to its maximum, thus not reducing its original volume. Louder channels are attenuated accordingly. Channels quieter than -30dB are too weak for a full compensation: Although the channel fader will be set its maximum for these channels, they cannot be fully compensated.

### Averaging the meter level

Averaging the current meter level `channelLevel` is currently done with code like
```
            avgLevel = (1.0f - alpha) * avgLevel + alpha * channelLevel
```
where `alpha=0.2` and `avgLevel` is the averaged level. The update of `avgLevel` can be seen in the following figure. The dots indicate the update intervals of 266 milliseconds. In practice, convergence might be faster because you would probably not start from silence.

![image](https://user-images.githubusercontent.com/8805876/108608497-84491400-73c7-11eb-825c-21b38bec9f9b.png)

### Accuracy improvement

So far, this implementation only affects the client.

However, the accuracy of this approach is negatively influenced by the low accuracy (4 bit) of the level meter value from the server, which has a resolution of 6.25dB. While (currently) not being implemented in this PR, I investigated using 8 bit instead 4 bit for the level value, resulting in a much better precision. However, this would also increase the data stream: The level is sent every 200 audio frames. Typical Jamulus UDP packages (medium quality, mono, 128 bytes audio buffer) are 88 bytes according to Wireshark. The channel level list package is 60 bytes for one channel. For a typical choir of 40 persons, the data rate would increase from 88*200+59+40/2=17679 to 88*200+59+40/2=17699, which means 0.11% increase. The bandwidth for one channel would increase from 369kbps to 369.42kbps, when I computed everything correctly.

Alternatively, one could think about a new protocol message which is used to request recommended channel fader values from the server, which would only be sent on demand.
