### PR TITLE
Don't hide mute indicator in mono mode

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -285,7 +285,6 @@ bool CChannelFader::GetDisplayChannelLevel()
 
 void CChannelFader::SetDisplayPans ( const bool eNDP )
 {
-    pInfoLabel->setHidden ( !eNDP );
     pPanLabel->setHidden  ( !eNDP );
     pPan->setHidden       ( !eNDP );
 }


### PR DESCRIPTION
I'm not sure why the indicator would be hidden in mono mode, it's surely equally useful regardless.

Screenshots showing the problem:

![mute-mono](https://user-images.githubusercontent.com/287742/108596701-b4a39a80-7354-11eb-974a-a2540d98e788.png)
![mute-stereo](https://user-images.githubusercontent.com/287742/108596702-b53c3100-7354-11eb-92b4-33b2226061ef.png)
