### PR TITLE
No display sleep for Jamulus on Mac

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,7 +42,7 @@
 
 - bug fix: fix crash if settings are changed in ASIO4ALL during a connection (contained in #796). Reverts #727 for Windows
 
-
+- Avoid screen from sleeping or starting screen saver for Mac (#834)
 
 
 

--- a/mac/activity.mm
+++ b/mac/activity.mm
@@ -40,7 +40,7 @@ CActivity::~CActivity()
 
 void CActivity::BeginActivity()
 {
-    NSActivityOptions options = NSActivityBackground | NSActivityIdleSystemSleepDisabled | NSActivityLatencyCritical;
+    NSActivityOptions options = NSActivityBackground | NSActivityIdleDisplaySleepDisabled | NSActivityIdleSystemSleepDisabled | NSActivityLatencyCritical;
     
     pActivity->activityId = [[NSProcessInfo processInfo] beginActivityWithOptions: options reason:@"Jamulus provides low latency audio processing and should not be inturrupted by system throttling."];
 }


### PR DESCRIPTION
- This prevents the display from sleeping / screen saving on Mac while Jamulus is running. 
- Should work on iOS 7.0+ and  macOS 10.9+ (Mavericks and later). Tested on 10.14 (Mojave) 
- Addresses chrisrimple's situation described in #834, but does not close the issue completely as only for macOS with LXQt still tbd.