### PR TITLE
Codacy/Flawfinder: Document a false positive finding

### DIFF
--- a/src/signalhandler.cpp
+++ b/src/signalhandler.cpp
@@ -82,7 +82,10 @@ bool CSignalHandler::emitSignal ( int sigNum )
 void CSignalHandler::OnSocketNotify( int socket )
 {
     int sigNum;
-    if ( ::read ( socket, &sigNum, sizeof ( int ) ) == sizeof ( int ) )
+    // The following read() triggers a Codacy/flawfinder finding:
+    // "Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)"
+    // Investigation has shown that this is a false positive as the proper buffer size is enforced.
+    if ( ::read ( socket, &sigNum, sizeof ( int ) ) == sizeof ( int ) ) // Flawfinder: ignore
     {
         emitSignal ( sigNum );
     }


### PR DESCRIPTION
Add an explaining comment and a special hint at Codacy/Flawfinder to ignore the (non-)problematic line.

Special comment effectiveness has been validated here: https://github.com/hoffie/jamulus/pull/3

Related: #1081