### PR TITLE
Server: Stop opening a TCP connection for external IP detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,9 @@
 
 - Avoid screen from sleeping or starting screen saver for Mac (#834)
 
+- stop sending traffic to CloudFlare as part of the external IP detection
+  logic (#633, #1092), suggested by atsampson, coded by hoffie
+
 
 
 ### 3.6.2 (2020-12-12) ###

--- a/src/global.h
+++ b/src/global.h
@@ -109,10 +109,12 @@ LED bar:      lbr
 #define SOFTWARE_MANUAL_URL              "https://jamulus.io/wiki/Software-Manual"
 
 // determining server internal address uses well-known host and port
-// (You can change the service used here to something like Cloudflare (1.1.1.1), Google DNS (8.8.8.8), or something else reliable)
-#define WELL_KNOWN_HOST                  "1.1.1.1" // CloudFlare
-#define WELL_KNOWN_PORT                  53        // DNS
-#define IP_LOOKUP_TIMEOUT                500       // ms
+// We just need a valid, public Internet IP here. We will not send any
+// traffic there as we will only set up an UDP socket without sending any
+// data.
+#define WELL_KNOWN_HOST                  "1.1.1.1"           // CloudFlare
+#define WELL_KNOWN_PORT                  DEFAULT_PORT_NUMBER
+#define IP_LOOKUP_TIMEOUT                500                 // ms
 
 // system sample rate (the sound card and audio coder works on this sample rate)
 #define SYSTEM_SAMPLE_RATE_HZ            48000 // Hz

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -53,6 +53,7 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
         // User-supplied --serverpublicip
         qhaServerPublicIP = QHostAddress ( strServerPublicIP );
     }
+    qDebug() << "Using" << qhaServerPublicIP.toString() << "as external IP.";
     SlaveCurLocalHostAddress = CHostAddress ( qhaServerPublicIP, iNPortNum );
 
     // prepare the server info information

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1025,7 +1025,10 @@ bool NetworkUtil::ParseNetworkAddress ( QString       strAddress,
 
 CHostAddress NetworkUtil::GetLocalAddress()
 {
-    QTcpSocket socket;
+    QUdpSocket socket;
+    // As we are using UDP, the connectToHost() does not generate any traffic at all.
+    // We just require a socket which is pointed towards the Internet in
+    // order to find out the IP of our own external interface:
     socket.connectToHost ( WELL_KNOWN_HOST, WELL_KNOWN_PORT );
 
     if ( socket.waitForConnected ( IP_LOOKUP_TIMEOUT ) )

--- a/src/util.h
+++ b/src/util.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <QCoreApplication>
-#include <QTcpSocket>
+#include <QUdpSocket>
 #include <QHostAddress>
 #include <QHostInfo>
 #ifndef HEADLESS


### PR DESCRIPTION
Previously, the code for finding the current machine's external IP address created a TCP connection to Cloudflare's DNS. This is unnecessary.

Instead, just creating a socket to a non-private IP suffices to find that IP. We still use Cloudflare's IP, but we will no longer send any traffic there as we use an UDP socket without actually sending any data.

I have changed the port from DNS/53 to Jamulus' default port. In reality, the port should not matter as no traffic is sent. If the code is changed in the future and should start sending data again, it will be better to use a unique port so that Cloudflare could block such unwanted, non-DNS traffic. :)

Credit for finding this approach goes to @atsampson.
Fixes #633.
Supersedes #1011 (which also used a reserved IP).