### PR TITLE
Remove "using namespace std;"

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -413,10 +413,10 @@ void CChannelFader::SetFaderLevel ( const double dLevel,
         // server about the change (block the signal of the fader since we want to
         // call SendFaderLevelToServer with a special additional parameter)
         pFader->blockSignals ( true );
-        pFader->setValue     ( min ( AUD_MIX_FADER_MAX, MathUtils::round ( dLevel ) ) );
+        pFader->setValue     ( std::min ( AUD_MIX_FADER_MAX, MathUtils::round ( dLevel ) ) );
         pFader->blockSignals ( false );
 
-        SendFaderLevelToServer ( min ( static_cast<double> ( AUD_MIX_FADER_MAX ), dLevel ), bIsGroupUpdate );
+        SendFaderLevelToServer ( std::min ( static_cast<double> ( AUD_MIX_FADER_MAX ), dLevel ), bIsGroupUpdate );
 
         if ( dLevel > AUD_MIX_FADER_MAX )
         {

--- a/src/util.h
+++ b/src/util.h
@@ -51,7 +51,6 @@
 #include <vector>
 #include <algorithm>
 #include "global.h"
-using namespace std; // because of the library: "vector"
 #ifdef _WIN32
 # include <winsock2.h>
 # include <ws2ipdef.h>


### PR DESCRIPTION
Importing everything from the `std` namespace is likely to cause problems, since it contains lots of common names and more get added with new C++ versions.

The Jamulus code usually qualifies `std::` names explicitly where needed; this also fixes the few places where it doesn't. (~~Only tested on Linux so far, so wait for the CI to check out the other platforms...~~ CI seems happy on all platforms.)

Related to #1098.