### PR TITLE
Fix typo which dropped machine-specific opus sources

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -668,18 +668,18 @@ SOURCES_OPUS_X86 = libs/opus/celt/x86/celt_lpc_sse4_1.c \
 android {
     contains(ANDROID_ARCHITECTURE, arm) | contains(ANDROID_ARCHITECTURE, arm64) {
         HEADERS_OPUS += $$HEADERS_OPUS_ARM
-        SOURCE_OPUS += $$SOURCES_OPUS_ARM
+        SOURCES_OPUS += $$SOURCES_OPUS_ARM
     } else:contains(ANDROID_ARCHITECTURE, x86) | contains(ANDROID_ARCHITECTURE, x86_64) {
         HEADERS_OPUS += $$HEADERS_OPUS_X86
-        SOURCE_OPUS += $$SOURCES_OPUS_X86
+        SOURCES_OPUS += $$SOURCES_OPUS_X86
     }
 } else:win32 | unix | macx {
     contains(QT_ARCH, arm) | contains(QT_ARCH, arm64) {
         HEADERS_OPUS += $$HEADERS_OPUS_ARM
-        SOURCE_OPUS += $$SOURCES_OPUS_ARM
+        SOURCES_OPUS += $$SOURCES_OPUS_ARM
     } else:contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
         HEADERS_OPUS += $$HEADERS_OPUS_X86
-        SOURCE_OPUS += $$SOURCES_OPUS_X86
+        SOURCES_OPUS += $$SOURCES_OPUS_X86
     }
     win32 {
         HEADERS_OPUS += libs/opus/win32/config.h

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1082,6 +1082,9 @@ contains(CONFIG, "opus_shared_lib") {
 
     contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
         msvc {
+            # According to opus/win32/config.h, "no special compiler
+            # flags necessary" when using msvc.  It always supports
+            # SSE intrinsics, but doesn't auto-vectorize.
             SOURCES += $$SOURCES_OPUS_ARCH
         } else {
             # Arch-specific files need special compiler flags, but we

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -655,7 +655,16 @@ SOURCES_OPUS = libs/opus/celt/bands.c \
 
 SOURCES_OPUS_ARM = libs/opus/celt/arm/armcpu.c \
     libs/opus/celt/arm/arm_celt_map.c \
-    libs/opus/silk/arm/arm_silk_map.c
+    libs/opus/silk/arm/arm_silk_map.c \
+    libs/opus/silk/arm/arm_silk_map.c \
+    libs/opus/silk/arm/biquad_alt_neon_intr.c \
+    libs/opus/silk/arm/LPC_inv_pred_gain_neon_intr.c \
+    libs/opus/silk/arm/NSQ_del_dec_neon_intr.c \
+    libs/opus/silk/arm/NSQ_neon.c \
+    libs/opus/celt/arm/celt_neon_intr.c \
+    libs/opus/celt/arm/pitch_neon_intr.c \
+    libs/opus/celt/arm/celt_fft_ne10.c \
+    libs/opus/celt/arm/celt_mdct_ne10.c
 
 SOURCES_OPUS_X86_SSE = libs/opus/celt/x86/x86cpu.c \
     libs/opus/celt/x86/x86_celt_map.c \
@@ -670,28 +679,20 @@ SOURCES_OPUS_X86_SSE4 = libs/opus/celt/x86/celt_lpc_sse4_1.c \
      libs/opus/silk/x86/VAD_sse4_1.c \
      libs/opus/silk/x86/VQ_WMat_EC_sse4_1.c
 
-android {
-    contains(ANDROID_ARCHITECTURE, arm) | contains(ANDROID_ARCHITECTURE, arm64) {
-        HEADERS_OPUS += $$HEADERS_OPUS_ARM
-        SOURCES_OPUS += $$SOURCES_OPUS_ARM
-    } else:contains(ANDROID_ARCHITECTURE, x86) | contains(ANDROID_ARCHITECTURE, x86_64) {
-        HEADERS_OPUS += $$HEADERS_OPUS_X86
-        SOURCES_OPUS += $$SOURCES_OPUS_X86
-    }
-} else:win32 | unix | macx {
-    contains(QT_ARCH, arm) | contains(QT_ARCH, arm64) {
-        HEADERS_OPUS += $$HEADERS_OPUS_ARM
-        SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM
-    } else:contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
-        HEADERS_OPUS += $$HEADERS_OPUS_X86
-        SOURCES_OPUS_ARCH += $$SOURCES_OPUS_X86_SSE $$SOURCES_OPUS_X86_SSE2 $$SOURCES_OPUS_X86_SSE4
-        DEFINES_OPUS += OPUS_X86_MAY_HAVE_SSE OPUS_X86_MAY_HAVE_SSE2 OPUS_X86_MAY_HAVE_SSE4_1
-        # x86_64 implies SSE2
-        contains(QT_ARCH, x86_64):DEFINES_OPUS += OPUS_X86_PRESUME_SSE=1 OPUS_X86_PRESUME_SSE2=1
-        DEFINES_OPUS += CPU_INFO_BY_C
-    }
+contains(QT_ARCH, armeabi-v7a) | contains(QT_ARCH, arm64-v8a) {
+    HEADERS_OPUS += $$HEADERS_OPUS_ARM
+    SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM
+    DEFINES_OPUS += OPUS_ARM_PRESUME_NEON=1 OPUS_ARM_PRESUME_NEON_INTR=1
+    contains(QT_ARCH, arm64-v8a):DEFINES_OPUS += OPUS_ARM_PRESUME_AARCH64_NEON_INTR
+} else:contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
+    HEADERS_OPUS += $$HEADERS_OPUS_X86
+    SOURCES_OPUS_ARCH += $$SOURCES_OPUS_X86_SSE $$SOURCES_OPUS_X86_SSE2 $$SOURCES_OPUS_X86_SSE4
+    DEFINES_OPUS += OPUS_X86_MAY_HAVE_SSE OPUS_X86_MAY_HAVE_SSE2 OPUS_X86_MAY_HAVE_SSE4_1
+    # x86_64 implies SSE2
+    contains(QT_ARCH, x86_64):DEFINES_OPUS += OPUS_X86_PRESUME_SSE=1 OPUS_X86_PRESUME_SSE2=1
+    DEFINES_OPUS += CPU_INFO_BY_C
 }
-DEFINES_OPUS += OPUS_BUILD=1 USE_ALLOCA=1 OPUS_HAVE_RTCD=1
+DEFINES_OPUS += OPUS_BUILD=1 USE_ALLOCA=1 OPUS_HAVE_RTCD=1 HAVE_LRINTF=1 HAVE_LRINT=1
 
 DISTFILES += ChangeLog \
     COPYING \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -54,11 +54,10 @@ INCLUDEPATH_OPUS = libs/opus/include \
     libs/opus/celt \
     libs/opus/silk \
     libs/opus/silk/float \
-    libs/opus/silk/fixed
+    libs/opus/silk/fixed \
+    libs/opus
 
 DEFINES += APP_VERSION=\\\"$$VERSION\\\" \
-    OPUS_BUILD \
-    USE_ALLOCA \
     CUSTOM_MODES \
     _REENTRANT
 
@@ -494,7 +493,8 @@ HEADERS_OPUS_ARM = libs/opus/celt/arm/armcpu.h \
 HEADERS_OPUS_X86 = libs/opus/celt/x86/celt_lpc_sse.h \
     libs/opus/celt/x86/pitch_sse.h \
     libs/opus/celt/x86/vq_sse.h \
-    libs/opus/celt/x86/x86cpu.h
+    libs/opus/celt/x86/x86cpu.h \
+    $$files(libs/opus/silk/x86/*.h)
 
 SOURCES += src/buffer.cpp \
     src/channel.cpp \
@@ -657,13 +657,18 @@ SOURCES_OPUS_ARM = libs/opus/celt/arm/armcpu.c \
     libs/opus/celt/arm/arm_celt_map.c \
     libs/opus/silk/arm/arm_silk_map.c
 
-SOURCES_OPUS_X86 = libs/opus/celt/x86/celt_lpc_sse4_1.c \
-    libs/opus/celt/x86/pitch_sse.c \
-    libs/opus/celt/x86/pitch_sse2.c \
-    libs/opus/celt/x86/pitch_sse4_1.c \
-    libs/opus/celt/x86/vq_sse2.c \
+SOURCES_OPUS_X86_SSE = libs/opus/celt/x86/x86cpu.c \
     libs/opus/celt/x86/x86_celt_map.c \
-    libs/opus/celt/x86/x86cpu.c
+    libs/opus/celt/x86/pitch_sse.c
+SOURCES_OPUS_X86_SSE2 = libs/opus/celt/x86/pitch_sse2.c \
+     libs/opus/celt/x86/vq_sse2.c
+SOURCES_OPUS_X86_SSE4 = libs/opus/celt/x86/celt_lpc_sse4_1.c \
+     libs/opus/celt/x86/pitch_sse4_1.c \
+     libs/opus/silk/x86/NSQ_sse4_1.c \
+     libs/opus/silk/x86/NSQ_del_dec_sse4_1.c \
+     libs/opus/silk/x86/x86_silk_map.c \
+     libs/opus/silk/x86/VAD_sse4_1.c \
+     libs/opus/silk/x86/VQ_WMat_EC_sse4_1.c
 
 android {
     contains(ANDROID_ARCHITECTURE, arm) | contains(ANDROID_ARCHITECTURE, arm64) {
@@ -676,15 +681,17 @@ android {
 } else:win32 | unix | macx {
     contains(QT_ARCH, arm) | contains(QT_ARCH, arm64) {
         HEADERS_OPUS += $$HEADERS_OPUS_ARM
-        SOURCES_OPUS += $$SOURCES_OPUS_ARM
+        SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM
     } else:contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
         HEADERS_OPUS += $$HEADERS_OPUS_X86
-        SOURCES_OPUS += $$SOURCES_OPUS_X86
-    }
-    win32 {
-        HEADERS_OPUS += libs/opus/win32/config.h
+        SOURCES_OPUS_ARCH += $$SOURCES_OPUS_X86_SSE $$SOURCES_OPUS_X86_SSE2 $$SOURCES_OPUS_X86_SSE4
+        DEFINES_OPUS += OPUS_X86_MAY_HAVE_SSE OPUS_X86_MAY_HAVE_SSE2 OPUS_X86_MAY_HAVE_SSE4_1
+        # x86_64 implies SSE2
+        contains(QT_ARCH, x86_64):DEFINES_OPUS += OPUS_X86_PRESUME_SSE=1 OPUS_X86_PRESUME_SSE2=1
+        DEFINES_OPUS += CPU_INFO_BY_C
     }
 }
+DEFINES_OPUS += OPUS_BUILD=1 USE_ALLOCA=1 OPUS_HAVE_RTCD=1
 
 DISTFILES += ChangeLog \
     COPYING \
@@ -1066,10 +1073,42 @@ contains(CONFIG, "opus_shared_lib") {
         DEFINES += USE_OPUS_SHARED_LIB
     }
 } else {
+    DEFINES += $$DEFINES_OPUS
     INCLUDEPATH += $$INCLUDEPATH_OPUS
     HEADERS += $$HEADERS_OPUS
     SOURCES += $$SOURCES_OPUS
     DISTFILES += $$DISTFILES_OPUS
+
+    contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
+        msvc {
+            SOURCES += $$SOURCES_OPUS_ARCH
+        } else {
+            # Arch-specific files need special compiler flags, but we
+            # can't use those flags for other files because otherwise we
+            # might end up with vectorized code that the CPU doesn't
+            # support.  For windows, libs/opus/win32/config.h says no
+            # compiler flags are needed.
+            sse_cc.name = sse_cc
+            sse_cc.input = SOURCES_OPUS_X86_SSE
+            sse_cc.dependency_type = TYPE_C
+            sse_cc.output = ${QMAKE_VAR_OBJECTS_DIR}${QMAKE_FILE_IN_BASE}$${first(QMAKE_EXT_OBJ)}
+            sse_cc.commands = ${CC} -msse $(CFLAGS) $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
+            sse_cc.variable_out = OBJECTS
+            sse2_cc.name = sse2_cc
+            sse2_cc.input = SOURCES_OPUS_X86_SSE2
+            sse2_cc.dependency_type = TYPE_C
+            sse2_cc.output = ${QMAKE_VAR_OBJECTS_DIR}${QMAKE_FILE_IN_BASE}$${first(QMAKE_EXT_OBJ)}
+            sse2_cc.commands = ${CC} -msse2 $(CFLAGS) $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
+            sse2_cc.variable_out = OBJECTS
+            sse4_cc.name = sse4_cc
+            sse4_cc.input = SOURCES_OPUS_X86_SSE4
+            sse4_cc.dependency_type = TYPE_C
+            sse4_cc.output = ${QMAKE_VAR_OBJECTS_DIR}${QMAKE_FILE_IN_BASE}$${first(QMAKE_EXT_OBJ)}
+            sse4_cc.commands = ${CC} -msse4 $(CFLAGS) $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
+            sse4_cc.variable_out = OBJECTS
+            QMAKE_EXTRA_COMPILERS += sse_cc sse2_cc sse4_cc
+        }
+    }
 }
 
 # disable version check if requested (#370)


### PR DESCRIPTION
#85 updated the OPUS version and added these, but they're not being compiled. Actually I think fixing the `Jamulus.pro` typo isn't enough because the code is ifdef'd out. I'm not sure how to get the correct set of defines short of running `./configure` or `cmake`.

@doloopuntil since you wrote #85, any thoughts?