### PR TITLE
Github: Fix typo in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ assignees: ''
 <!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-<! --A clear and concise description of what you want to happen. --> 
+<!--A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->


### PR DESCRIPTION
Broken comment syntax lead to the comment being shown verbatim.