### PR TITLE
Update util.h

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -53,7 +53,7 @@
 #include "global.h"
 #ifdef _WIN32
 # include <winsock2.h>
-# include <ws2ipdef.h>
+# include <ws2tcpip.h>
 # include <windows.h>
 # include <mmsystem.h>
 #elif defined ( __APPLE__ ) || defined ( __MACOSX )


### PR DESCRIPTION
Wrong include file in /jamulus/src/util.h
Within the /jamulus/src/util.h file:
'# include <ws2ipdef.h>'
Should be replaced with:
'# include <ws2tcpip.h>'
"The Ws2def.h, Ws2ipdef.h, and Wsipv6ok.h header files should never be used directly."
This bug fix was tested ok on Windows in this thread:
[https://github.com/jamulussoftware/jamulus/discussions/1072#discussioncomment-410564](https://github.com/jamulussoftware/jamulus/discussions/1072#discussioncomment-410564)