### PR TITLE
Improve version update detection.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,7 +47,9 @@
 - stop sending traffic to CloudFlare as part of the external IP detection
   logic (#633, #1092), suggested by atsampson, coded by hoffie
 
-
+- Improve update version detection (#1155)
+  Check two servers instead of one (updatecheck1.jamulus.io and updatecheck2.jamulus.io).
+  Ignore the server version if it is not a release, due to a suffix such as dev, alpha or beta.
 
 ### 3.6.2 (2020-12-12) ###
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -861,9 +861,6 @@ void CClientDlg::OnCLVersionAndOSReceived ( CHostAddress           ,
     int serverSuffixIndex;
     QVersionNumber serverVersion = QVersionNumber::fromString ( strVersion, &serverSuffixIndex );
 
-    qDebug() << "My version: " << myVersion << " suffix: " << QString( VERSION ).mid( mySuffixIndex );
-    qDebug() << "Server version: " << serverVersion << " suffix: " << strVersion.mid( serverSuffixIndex );
-
     // only compare if the server version has no suffix (such as dev or beta)
     if ( strVersion.size() == serverSuffixIndex && QVersionNumber::compare ( serverVersion, myVersion ) > 0 )
     {

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -567,23 +567,23 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
         chbLocalMute->setCheckState ( Qt::Checked );
     }
 
-    // query the central server version number needed for update check (note
+    // query the update server version number needed for update check (note
     // that the connection less message respond may not make it back but that
     // is not critical since the next time Jamulus is started we have another
     // chance and the update check is not time-critical at all)
-    CHostAddress CentServerHostAddress;
+    CHostAddress UpdateServerHostAddress;
 
     // Send the request to two servers for redundancy if either or both of them
     // has a higher release version number, the reply will trigger the notification.
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK1_ADDRESS, CentServerHostAddress ) )
+    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress ) )
     {
-        pClient->CreateCLServerListReqVerAndOSMes ( CentServerHostAddress );
+        pClient->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK2_ADDRESS, CentServerHostAddress ) )
+    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress ) )
     {
-        pClient->CreateCLServerListReqVerAndOSMes ( CentServerHostAddress );
+        pClient->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 }
 

--- a/src/global.h
+++ b/src/global.h
@@ -103,6 +103,10 @@ LED bar:      lbr
 #define CENTSERV_GENRE_CLASSICAL_FOLK    "classical.jamulus.io:22524"
 #define CENTSERV_GENRE_CHORAL            "choral.jamulus.io:22724"
 
+// servers to check for new versions
+#define UPDATECHECK1_ADDRESS             "updatecheck1.jamulus.io:22124"
+#define UPDATECHECK2_ADDRESS             "updatecheck2.jamulus.io:22324"
+
 // getting started and software manual URL
 #define CLIENT_GETTING_STARTED_URL       "https://jamulus.io/wiki/Getting-Started"
 #define SERVER_GETTING_STARTED_URL       "https://jamulus.io/wiki/Running-a-Server"

--- a/src/global.h
+++ b/src/global.h
@@ -104,8 +104,8 @@ LED bar:      lbr
 #define CENTSERV_GENRE_CHORAL            "choral.jamulus.io:22724"
 
 // servers to check for new versions
-#define UPDATECHECK1_ADDRESS             "updatecheck1.jamulus.io:22124"
-#define UPDATECHECK2_ADDRESS             "updatecheck2.jamulus.io:22324"
+#define UPDATECHECK1_ADDRESS             "updatecheck1.jamulus.io"
+#define UPDATECHECK2_ADDRESS             "updatecheck2.jamulus.io"
 
 // getting started and software manual URL
 #define CLIENT_GETTING_STARTED_URL       "https://jamulus.io/wiki/Getting-Started"

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -633,9 +633,6 @@ void CServerDlg::OnCLVersionAndOSReceived ( CHostAddress           ,
     int serverSuffixIndex;
     QVersionNumber serverVersion = QVersionNumber::fromString ( strVersion, &serverSuffixIndex );
 
-    qDebug() << "My version: " << myVersion << " suffix: " << QString( VERSION ).mid( mySuffixIndex );
-    qDebug() << "Server version: " << serverVersion << " suffix: " << strVersion.mid( serverSuffixIndex );
-
     // only compare if the server version has no suffix (such as dev or beta)
     if ( strVersion.size() == serverSuffixIndex && QVersionNumber::compare ( serverVersion, myVersion ) > 0 )
     {

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -447,23 +447,23 @@ lvwClients->setMinimumHeight ( 140 );
     // start timer for GUI controls
     Timer.start ( GUI_CONTRL_UPDATE_TIME );
 
-    // query the central server version number needed for update check (note
+    // query the update server version number needed for update check (note
     // that the connection less message respond may not make it back but that
     // is not critical since the next time Jamulus is started we have another
     // chance and the update check is not time-critical at all)
-    CHostAddress CentServerHostAddress;
+    CHostAddress UpdateServerHostAddress;
 
     // Send the request to two servers for redundancy if either or both of them
     // has a higher release version number, the reply will trigger the notification.
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK1_ADDRESS, CentServerHostAddress ) )
+    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress ) )
     {
-        pServer->CreateCLServerListReqVerAndOSMes ( CentServerHostAddress );
+        pServer->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK2_ADDRESS, CentServerHostAddress ) )
+    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress ) )
     {
-        pServer->CreateCLServerListReqVerAndOSMes ( CentServerHostAddress );
+        pServer->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 }
 


### PR DESCRIPTION
Send version requests on startup to two different central servers.
It doesn't matter if they both reply, so no need to wait and retry.
Only compare if server is running a released version (no suffix).