### PR TITLE
Basic audio feedback detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@
 - Automatic channel fader adjustment simplifies mixer setup by using the channel level meters (#1071).
   (contributed by @JohannesBrx)
 
+- Added basic audio feedback detection (#1179).
+  (contributed by @JohannesBrx)
+
 - The mute button is now also shown in mono mode (#1074)
   (contributed by @npostavs)
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1726,3 +1726,8 @@ void CAudioMixerBoard::SetChannelLevels ( const CVector<uint16_t>& vecChannelLev
         }
     }
 }
+
+void CAudioMixerBoard::MuteMyChannel()
+{
+    SetFaderIsMute ( iMyChannelID, true );
+}

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -201,6 +201,7 @@ public:
     void            SetPanIsSupported();
     void            SetRemoteFaderIsMute ( const int iChannelIdx, const bool bIsMute );
     void            SetMyChannelID ( const int iChannelIdx ) { iMyChannelID = iChannelIdx; }
+    int             GetMyChannelID() const { return iMyChannelID; }
 
     void            SetFaderLevel ( const int iChannelIdx,
                                     const int iValue );
@@ -229,6 +230,8 @@ public:
     void            StoreAllFaderSettings();
     void            LoadAllFaderSettings();
     void            AutoAdjustAllFaderLevels();
+
+    void            MuteMyChannel();
 
 protected:
     class CMixerBoardScrollArea : public QScrollArea

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1146,7 +1146,7 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
         TimerCheckAudioDeviceOk.start ( CHECK_AUDIO_DEV_OK_TIME_MS );
     }
 
-    if ( TimerDetectFeedback.isActive() )
+    if ( pSettings->bEnableFeedbackDetection && TimerDetectFeedback.isActive() )
     {
         TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS );
         bDetectFeedback = true;
@@ -1205,10 +1205,13 @@ void CClientDlg::Connect ( const QString& strSelectedAddress,
         TimerBuffersLED.start         ( BUFFER_LED_UPDATE_TIME_MS );
         TimerPing.start               ( PING_UPDATE_TIME_MS );
         TimerCheckAudioDeviceOk.start ( CHECK_AUDIO_DEV_OK_TIME_MS ); // is single shot timer
-        TimerDetectFeedback.start     ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
 
-        // enable audio feedback detection
-        bDetectFeedback = true;
+        // audio feedback detection
+        if ( pSettings->bEnableFeedbackDetection )
+        {
+            TimerDetectFeedback.start     ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
+            bDetectFeedback = true;
+        }
     }
 }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1032,16 +1032,35 @@ void CClientDlg::OnTimerSigMet()
     lbrInputLevelL->SetValue ( pClient->GetLevelForMeterdBLeft() );
     lbrInputLevelR->SetValue ( pClient->GetLevelForMeterdBRight() );
 
-    if ( bDetectFeedback && pClient->GetLevelForMeterdBLeft() > 7.5 )
+    if ( bDetectFeedback &&
+        ( pClient->GetLevelForMeterdBLeft() > NUM_STEPS_LED_BAR - 0.5  ||
+        pClient->GetLevelForMeterdBRight() > NUM_STEPS_LED_BAR - 0.5 ) )
     {
         // mute locally and mute channel
         chbLocalMute->setCheckState ( Qt::Checked );
         MainMixerBoard->MuteMyChannel();
 
-        QMessageBox::warning ( this, APP_NAME, tr ( "Audio feedback detected.\n"
+        // show message box about feedback issue
+        QCheckBox* chb = new QCheckBox ( tr ( "Enable feedback detection" ) );
+        chb->setCheckState ( pSettings->bEnableFeedbackDetection ?
+            Qt::Checked : Qt::Unchecked );
+        QMessageBox msgbox;
+        msgbox.setText ( tr ( "Audio feedback detected.\n\n"
             "We muted your channel and activated 'Mute Myself'. Please "
             "solve the feedback issue first and unmute yourself afterwards. "
             "Did you plug-in earphones?") );
+        msgbox.setIcon ( QMessageBox::Icon::Warning );
+        msgbox.addButton ( QMessageBox::Ok );
+        msgbox.setDefaultButton ( QMessageBox::Ok );
+        msgbox.setCheckBox ( chb );
+
+        QObject::connect( chb, &QCheckBox::stateChanged, [this](int state)
+            {
+                ClientSettingsDlg.SetEnableFeedbackDetection ( state == Qt::Checked );
+            }
+        );
+
+        msgbox.exec();
     }
 }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1045,7 +1045,7 @@ void CClientDlg::OnTimerSigMet()
         chb->setCheckState ( pSettings->bEnableFeedbackDetection ?
             Qt::Checked : Qt::Unchecked );
         QMessageBox msgbox;
-        msgbox.setText ( tr ( "Audio feedback detected.\n\n"
+        msgbox.setText ( tr ( "Audio feedback or loud signal detected.\n\n"
             "We muted your channel and activated 'Mute Myself'. Please "
             "solve the feedback issue first and unmute yourself afterwards. "
             "Did you plug-in earphones?") );
@@ -1228,7 +1228,7 @@ void CClientDlg::Connect ( const QString& strSelectedAddress,
         // audio feedback detection
         if ( pSettings->bEnableFeedbackDetection )
         {
-            TimerDetectFeedback.start     ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
+            TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
             bDetectFeedback = true;
         }
     }

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1046,9 +1046,8 @@ void CClientDlg::OnTimerSigMet()
             Qt::Checked : Qt::Unchecked );
         QMessageBox msgbox;
         msgbox.setText ( tr ( "Audio feedback or loud signal detected.\n\n"
-            "We muted your channel and activated 'Mute Myself'. Please "
-            "solve the feedback issue first and unmute yourself afterwards. "
-            "Did you plug-in earphones?") );
+            "We muted your channel and activated 'Mute Myself'. Please solve "
+            "the feedback issue first and unmute yourself afterwards." ) );
         msgbox.setIcon ( QMessageBox::Icon::Warning );
         msgbox.addButton ( QMessageBox::Ok );
         msgbox.setDefaultButton ( QMessageBox::Ok );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1054,11 +1054,8 @@ void CClientDlg::OnTimerSigMet()
         msgbox.setDefaultButton ( QMessageBox::Ok );
         msgbox.setCheckBox ( chb );
 
-        QObject::connect( chb, &QCheckBox::stateChanged, [this](int state)
-            {
-                ClientSettingsDlg.SetEnableFeedbackDetection ( state == Qt::Checked );
-            }
-        );
+        QObject::connect ( chb, &QCheckBox::stateChanged,
+            this, &CClientDlg::OnFeedbackDetectionChanged );
 
         msgbox.exec();
     }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -195,6 +195,9 @@ public slots:
     void OnReverbSelRClicked()
         { pClient->SetReverbOnLeftChan ( false ); }
 
+    void OnFeedbackDetectionChanged ( int state )
+        { ClientSettingsDlg.SetEnableFeedbackDetection ( state == Qt::Checked ); }
+
     void OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );
     void OnChatTextReceived ( QString strChatText );
     void OnLicenceRequired ( ELicenceType eLicenceType );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -64,6 +64,7 @@
 #define BUFFER_LED_UPDATE_TIME_MS   300   // ms
 #define LED_BAR_UPDATE_TIME_MS      1000  // ms
 #define CHECK_AUDIO_DEV_OK_TIME_MS  5000  // ms
+#define DETECT_FEEDBACK_TIME_MS     3000  // ms
 
 // number of ping times > upper bound until error message is shown
 #define NUM_HIGH_PINGS_UNTIL_ERROR  5
@@ -106,6 +107,7 @@ protected:
     bool               bConnected;
     bool               bConnectDlgWasShown;
     bool               bMIDICtrlUsed;
+    bool               bDetectFeedback;
     ERecorderState     eLastRecorderState;
     EGUIDesign         eLastDesign;
     QTimer             TimerSigMet;
@@ -113,6 +115,7 @@ protected:
     QTimer             TimerStatus;
     QTimer             TimerPing;
     QTimer             TimerCheckAudioDeviceOk;
+    QTimer             TimerDetectFeedback;
 
     virtual void       closeEvent     ( QCloseEvent*     Event );
     virtual void       dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }
@@ -129,6 +132,7 @@ public slots:
     void OnTimerSigMet();
     void OnTimerBuffersLED();
     void OnTimerCheckAudioDeviceOk();
+    void OnTimerDetectFeedback();
 
     void OnTimerStatus() { UpdateDisplay(); }
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -340,6 +340,13 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
     spnMixerRows->setWhatsThis ( strNumMixerPanelRows );
     spnMixerRows->setAccessibleName ( tr ( "Number of Mixer Panel Rows spin box" ) );
 
+    QString strDetectFeedback = "<b>" + tr ( "Feedback Protection" ) + ":</b> " +
+        tr ( "Enable feedback protection to detect acoustic feedback between "
+        "microphone and speakers." );
+    lblDetectFeedback->setWhatsThis ( strDetectFeedback );
+    chbDetectFeedback->setWhatsThis ( strDetectFeedback );
+    chbDetectFeedback->setAccessibleName ( tr ( "Feedback Protection check box" ) );
+
     // init driver button
 #ifdef _WIN32
     butDriverSetup->setText ( tr ( "ASIO Device Settings" ) );

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -416,6 +416,10 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
     // init number of mixer rows
     spnMixerRows->setValue ( pSettings->iNumMixerPanelRows );
 
+    // update feedback detection
+    chbDetectFeedback->setCheckState ( pSettings->bEnableFeedbackDetection ?
+        Qt::Checked : Qt::Unchecked );
+
     // update enable small network buffers check box
     chbEnableOPUS64->setCheckState ( pClient->GetEnableOPUS64() ? Qt::Checked : Qt::Unchecked );
 
@@ -574,6 +578,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
 
     QObject::connect ( chbEnableOPUS64, &QCheckBox::stateChanged,
         this, &CClientSettingsDlg::OnEnableOPUS64StateChanged );
+
+    QObject::connect ( chbDetectFeedback, &QCheckBox::stateChanged,
+        this, &CClientSettingsDlg::OnFeedbackDetectionChanged );
 
     // line edits
     QObject::connect ( edtNewClientLevel, &QLineEdit::editingFinished,
@@ -827,6 +834,13 @@ void CClientSettingsDlg::UpdateSoundDeviceChannelSelectionFrame()
 #endif
 }
 
+void CClientSettingsDlg::SetEnableFeedbackDetection ( bool enable )
+{
+    pSettings->bEnableFeedbackDetection = enable;
+    chbDetectFeedback->setCheckState ( pSettings->bEnableFeedbackDetection ?
+        Qt::Checked : Qt::Unchecked );
+}
+
 void CClientSettingsDlg::OnDriverSetupClicked()
 {
     pClient->OpenSndCrdDriverSetup();
@@ -906,6 +920,11 @@ void CClientSettingsDlg::OnEnableOPUS64StateChanged ( int value )
 {
     pClient->SetEnableOPUS64 ( value == Qt::Checked );
     UpdateDisplay();
+}
+
+void CClientSettingsDlg::OnFeedbackDetectionChanged ( int value )
+{
+    pSettings->bEnableFeedbackDetection = value == Qt::Checked;
 }
 
 void CClientSettingsDlg::OnCentralServerAddressEditingFinished()
@@ -1124,4 +1143,3 @@ void CClientSettingsDlg::OnAudioPanValueChanged ( int value )
     pClient->SetAudioInFader ( value );
     UpdateAudioFaderSlider();
 }
-

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -77,6 +77,8 @@ public:
     void SetTabIdx( int iIdx ) { iTabIdx = iIdx; }
     int  iTabIdx;
 
+    void SetEnableFeedbackDetection ( bool enable );
+
 protected:
     void    UpdateJitterBufferFrame();
     void    UpdateSoundCardFrame();
@@ -98,6 +100,7 @@ public slots:
     void OnNetBufServerValueChanged ( int value );
     void OnAutoJitBufStateChanged ( int value );
     void OnEnableOPUS64StateChanged ( int value );
+    void OnFeedbackDetectionChanged ( int value );
     void OnCentralServerAddressEditingFinished();
     void OnNewClientLevelEditingFinished() { pSettings->iNewClientFaderLevel = edtNewClientLevel->text().toInt(); }
     void OnInputBoostChanged();

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -1135,6 +1135,33 @@
                </property>
               </spacer>
              </item>
+             <item>
+              <widget class="QLabel" name="lblDetectFeedback">
+               <property name="text">
+                <string>Feedback Protection</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="chbDetectFeedback">
+               <property name="text">
+                <string>Enable</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_15">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
             </layout>
            </item>
            <item>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -277,6 +277,11 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument&   IniXMLDocument
         iInputBoost = iValue;
     }
 
+    if ( GetFlagIniSet ( IniXMLDocument, "client", "enablefeedbackdetection", bValue ) )
+    {
+        bEnableFeedbackDetection = bValue;
+    }
+
     // connect dialog show all musicians
     if ( GetFlagIniSet ( IniXMLDocument, "client", "connectdlgshowallmusicians", bValue ) )
     {
@@ -611,6 +616,10 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // input boost
     SetNumericIniSet ( IniXMLDocument, "client", "inputboost",
         iInputBoost );
+
+    // feedback detection
+    SetFlagIniSet ( IniXMLDocument, "client", "enablefeedbackdetection",
+        bEnableFeedbackDetection );
 
     // connect dialog show all musicians
     SetFlagIniSet ( IniXMLDocument, "client", "connectdlgshowallmusicians",

--- a/src/settings.h
+++ b/src/settings.h
@@ -151,6 +151,7 @@ public:
         iNumMixerPanelRows          ( 1 ),
         vstrCentralServerAddress    ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
         eCentralServerAddressType   ( AT_DEFAULT ),
+        bEnableFeedbackDetection    ( true ),
         vecWindowPosSettings        ( ), // empty array
         vecWindowPosChat            ( ), // empty array
         vecWindowPosConnect         ( ), // empty array
@@ -178,6 +179,7 @@ public:
     int              iNumMixerPanelRows;
     CVector<QString> vstrCentralServerAddress;
     ECSAddType       eCentralServerAddressType;
+    bool             bEnableFeedbackDetection;
 
     // window position/state settings
     QByteArray vecWindowPosSettings;


### PR DESCRIPTION
This draft PR is based on discussion #1048 and provides a very basic audio feedback protection. Feedback is detected for an interval of (currently) 3 seconds after connecting to a server and utilizes the input meter level. In case feedback is detected, the following happens:

- activate `mute myself` (protect other users)
- mute the user's channel (protect user)
- show a message box with an explanation (see below)

```
Audio feedback detected.
We muted your channel and activated 'Mute Myself'. Please
solve the feedback issue first and unmute yourself afterwards.
Did you plug-in earphones?
```

While this basically works, there are several things to be discussed:

- Shall we use more sophisticated, yet performant algorithms to detect feedback? (e.g., [this](https://dsp.stackexchange.com/a/3086))
- Feedback only occurs when there is an initial signal. When the user is silent after connecting and starts speaking several seconds later, feedback protection might already have been deactivated. Possible solution: Wait for first audio signal above threshold and check next seconds for audio feedback.
- How shall feedback protection be deactivated -- in the settings, via command line or directly via the message box?