### PR TITLE
Autobuild: Improve release version detection

### DIFF
--- a/.github/actions_scripts/analyse_git_reference.py
+++ b/.github/actions_scripts/analyse_git_reference.py
@@ -12,6 +12,7 @@
 
 import sys
 import os
+import re
 import subprocess
 
 # get the jamulus version from the .pro file
@@ -75,14 +76,14 @@ if fullref.startswith("refs/tags/"):
     release_title="Release {}  ({})".format(release_version_name, pushed_name)
     
     if pushed_name.startswith("r"):
-        if "beta" in pushed_name:
-            print('this reference is a Beta-Release-Tag')
-            publish_to_release = True
-            is_prerelease = True
-        else:
+        if re.match(r'^r\d+_\d+_\d+$', pushed_name):
             print('this reference is a Release-Tag')
             publish_to_release = True
             is_prerelease = False
+        else:
+            print('this reference is a Non-Release-Tag')
+            publish_to_release = True
+            is_prerelease = True
     else:
         print('this reference is a Non-Release-Tag')
         publish_to_release = False

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -8,10 +8,10 @@
 #     for every pull-request to master:
 #          - do CodeQl while building for every platform
 #          - publish the created binaries/packs only as artifacts/appendix of the github-action-run (not as release), and only retain those files for limited period
-#     for every tag that starts with 'r_' and contains 'beta':
+#     for every tag that starts with 'r' and has an arbitrary suffix (e.g. beta1, rc1, etc.)
 #          - do CodeQl while building for every platform
 #          - publish the created binaries/packs only as artifacts/appendix as a prerelease
-#     for every tag that starts with 'r_' (and not contains 'beta'):
+#     for every tag that starts with 'r' and does not have any suffix:
 #          - do CodeQl while building for every platform
 #          - publish the created binaries/packs only as artifacts/appendix as a release
 #


### PR DESCRIPTION
Previously, all r* tags were considered to be final releases except for those which contained 'beta'. This did not work properly for rc releases.

This commit changes the logic to consider tags which match 'r<number>_<number>_<number>' as final releases only. All other 'r' tags are considered to be pre-releases.

Fixes #1180.

Tested:

**Previously**
```
$ GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0beta1 python3 .github/actions_scripts/analyse_git_reference.py  | grep -P '::.*(PUBLISH|IS_PRE)'
::set-output name=PUBLISH_TO_RELEASE::true
::set-output name=IS_PRERELEASE::true

$ GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0rc1 python3 .github/actions_scripts/analyse_git_reference.py  | grep -P '::.*(PUBLISH|IS_PRE)'
::set-output name=PUBLISH_TO_RELEASE::true
::set-output name=IS_PRERELEASE::false    # <- should be true

$ GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0 python3 .github/actions_scripts/analyse_git_reference.py  | grep -P '::.*(PUBLISH|IS_PRE)'
::set-output name=PUBLISH_TO_RELEASE::true
::set-output name=IS_PRERELEASE::false
```

**After this PR**
```
$ GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0beta1 python3 .github/actions_scripts/analyse_git_reference.py  | grep -P '::.*(PUBLISH|IS_PRE)'
::set-output name=PUBLISH_TO_RELEASE::true
::set-output name=IS_PRERELEASE::true

$ GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0rc1 python3 .github/actions_scripts/analyse_git_reference.py  | grep -P '::.*(PUBLISH|IS_PRE)'
::set-output name=PUBLISH_TO_RELEASE::true
::set-output name=IS_PRERELEASE::true   # <- is now true

$ GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0 python3 .github/actions_scripts/analyse_git_reference.py  | grep -P '::.*(PUBLISH|IS_PRE)'
::set-output name=PUBLISH_TO_RELEASE::true
::set-output name=IS_PRERELEASE::false
```
