### PR TITLE
windows/sound.cpp: Explicitly set driverInfo to 0

### DIFF
--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -62,6 +62,11 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName,
 
     loadAsioDriver ( cDriverNames[iDriverIdx] );
 
+    // According to the docs, driverInfo.asioVersion and driverInfo.sysRef
+    // should be set, but we haven't being doing that and it seems to work
+    // okay...
+    memset ( &driverInfo, 0, sizeof driverInfo );
+
     if ( ASIOInit ( &driverInfo ) != ASE_OK )
     {
         // clean up and return error string


### PR DESCRIPTION
https://github.com/jamulussoftware/jamulus/pull/870#issuecomment-791970524

> I noticed when looking at the Jamulus' current ASIO code is that it doesn't initialize `driverInfo` before passing it to `ASIOInit`

From what I can tell looking at it in the debugger, it gets semi-accidentally set to zero by virtue of being allocated on fresh memory. It would be better to set it explicitly; IMO this could go in to the release.