### PR TITLE
Revert "Client: Always update gain levels"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -49,8 +49,7 @@
   logic (#633, #1092), suggested by atsampson, coded by hoffie
 
 - bug fix: properly restore mixer levels after reconnecting to a restarted
-  server. updating the server or the client is sufficient to fix this. coded
-  by hoffie (#955, #1009, #1010)
+  server. This is a server-side fix. coded by hoffie (#955, #1010)
 
 - Improve update version detection, coded by softins (#1155)
   Check two servers instead of one (updatecheck1.jamulus.io and updatecheck2.jamulus.io).

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1182,27 +1182,30 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
                         }
                     }
 
-                    // restore gain:
-                    // the text has actually changed, search in the list of
-                    // stored settings if we have a matching entry
-                    int  iStoredFaderLevel;
-                    int  iStoredPanValue;
-                    bool bStoredFaderIsSolo;
-                    bool bStoredFaderIsMute;
-                    int  iGroupID;
-
-                    if ( GetStoredFaderSettings ( vecChanInfo[j].strName,
-                                                  iStoredFaderLevel,
-                                                  iStoredPanValue,
-                                                  bStoredFaderIsSolo,
-                                                  bStoredFaderIsMute,
-                                                  iGroupID ) )
+                    // restore gain (if new name is different from the current one)
+                    if ( vecpChanFader[i]->GetReceivedName().compare ( vecChanInfo[j].strName ) )
                     {
-                        vecpChanFader[i]->SetFaderLevel  ( iStoredFaderLevel, true ); // suppress group update
-                        vecpChanFader[i]->SetPanValue    ( iStoredPanValue );
-                        vecpChanFader[i]->SetFaderIsSolo ( bStoredFaderIsSolo );
-                        vecpChanFader[i]->SetFaderIsMute ( bStoredFaderIsMute );
-                        vecpChanFader[i]->SetGroupID     ( iGroupID ); // Must be the last to be set in the fader!
+                        // the text has actually changed, search in the list of
+                        // stored settings if we have a matching entry
+                        int  iStoredFaderLevel;
+                        int  iStoredPanValue;
+                        bool bStoredFaderIsSolo;
+                        bool bStoredFaderIsMute;
+                        int  iGroupID;
+
+                        if ( GetStoredFaderSettings ( vecChanInfo[j].strName,
+                                                      iStoredFaderLevel,
+                                                      iStoredPanValue,
+                                                      bStoredFaderIsSolo,
+                                                      bStoredFaderIsMute,
+                                                      iGroupID ) )
+                        {
+                            vecpChanFader[i]->SetFaderLevel  ( iStoredFaderLevel, true ); // suppress group update
+                            vecpChanFader[i]->SetPanValue    ( iStoredPanValue );
+                            vecpChanFader[i]->SetFaderIsSolo ( bStoredFaderIsSolo );
+                            vecpChanFader[i]->SetFaderIsMute ( bStoredFaderIsMute );
+                            vecpChanFader[i]->SetGroupID     ( iGroupID ); // Must be the last to be set in the fader!
+                        }
                     }
 
                     // set the channel infos


### PR DESCRIPTION
This reverts PR #1009 (f116811a4e9748722a2f1b8178ebfe68737b57d0) as it has unintended side effects (#1191). The Changelog is also updated accordingly.

Basically, that PR assumed that applying stored fader levels would always be a safe thing to do.
This is not the case, as changes in fader levels are currently not stored immediately, but rather in specific events only (e.g. disconnects).

PR #1009 was initially supposed to help with #955 as a client-side fix. With the revert, we still have the server-side fix from #1010.

It is planned to re-apply #1009 once fader-level storage has been fully understood and extended to cover all relevant places (#1191).