### PR TITLE
Client: Add support for input gain control

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -51,6 +51,7 @@ CClient::CClient ( const quint16  iPortNumber,
     iAudioInFader                    ( AUD_FADER_IN_MIDDLE ),
     bReverbOnLeftChan                ( false ),
     iReverbLevel                     ( 0 ),
+    iInputBoost                      ( 1 ),
     iSndCrdPrefFrameSizeFactor       ( FRAME_SIZE_FACTOR_DEFAULT ),
     iSndCrdFrameSizeFactor           ( FRAME_SIZE_FACTOR_DEFAULT ),
     bSndCrdConversionBufferRequired  ( false ),
@@ -1053,6 +1054,16 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
 
 
     // Transmit signal ---------------------------------------------------------
+
+    if ( iInputBoost != 1 ) {
+        // apply a general gain boost to all audio input:
+        for ( i = 0, j = 0; i < iMonoBlockSizeSam; i++, j += 2 )
+        {
+            vecsStereoSndCrd[j + 1] = static_cast<int16_t> ( iInputBoost * vecsStereoSndCrd[j + 1] );
+            vecsStereoSndCrd[j]     = static_cast<int16_t> ( iInputBoost * vecsStereoSndCrd[j] );
+        }
+    }
+
     // update stereo signal level meter (not needed in headless mode)
 #ifndef HEADLESS
     SignalLevelMeter.Update ( vecsStereoSndCrd,

--- a/src/client.h
+++ b/src/client.h
@@ -243,6 +243,8 @@ public:
     void SetRemoteChanPan ( const int iId, const float fPan )
         { Channel.SetRemoteChanPan ( iId, fPan ); }
 
+    void SetInputBoost ( const int iNewBoost ) { iInputBoost = iNewBoost; }
+
     void SetRemoteInfo() { Channel.SetRemoteInfo ( ChannelInfo ); }
 
     void CreateChatTextMes ( const QString& strChatText )
@@ -331,6 +333,7 @@ protected:
     bool                    bReverbOnLeftChan;
     int                     iReverbLevel;
     CAudioReverb            AudioReverb;
+    int                     iInputBoost;
 
     int                     iSndCrdPrefFrameSizeFactor;
     int                     iSndCrdFrameSizeFactor;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -212,6 +212,9 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     sldAudioReverb->setValue ( iCurAudReverb );
     sldAudioReverb->setTickInterval ( AUD_REVERB_MAX / 5 );
 
+    // init input boost
+    pClient->SetInputBoost ( pSettings->iInputBoost );
+
     // init reverb channel
     UpdateRevSelection();
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -253,6 +253,24 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
     edtNewClientLevel->setWhatsThis ( strNewClientLevel );
     edtNewClientLevel->setAccessibleName ( tr ( "New client level edit box" ) );
 
+    // input boost
+    QString strInputBoost = "<b>" + tr ( "Input Boost" ) + ":</b> " +
+        tr ( "This setting allows you to increase your input signal level "
+        "by factors up to 10 (+20dB)."
+        "If your sound is too quiet, first try to increase the level by "
+        "getting closer to the microphone, adjusting your sound equipment "
+        "or increasing levels in your operating system's input settings. "
+        "Only if this fails, set a factor here. "
+        "If your sound is too loud, sounds distorted and is clipping, this "
+        "option will not help. Do not use it. The distortion will still be "
+        "there. Instead, decrease your input level by getting farther away "
+        "from your microphone, adjusting your sound equipment "
+        "or by decreasing your operating system's input settings."
+        );
+    lblInputBoost->setWhatsThis ( strInputBoost );
+    cbxInputBoost->setWhatsThis ( strInputBoost );
+    cbxInputBoost->setAccessibleName ( tr ( "Input Boost combo box" ) );
+
     // custom central server address
     QString strCentrServAddr = "<b>" + tr ( "Custom Central Server Address" ) + ":</b> " +
         tr ( "Leave this blank unless you need to enter the address of a central "
@@ -348,6 +366,15 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
     // update new client fader level edit box
     edtNewClientLevel->setText ( QString::number ( pSettings->iNewClientFaderLevel ) );
 
+    // Input Boost combo box
+    cbxInputBoost->clear();
+    cbxInputBoost->addItem ( tr ( "None" ) );
+    for ( int i = 2; i <= 10; i++ ) {
+        cbxInputBoost->addItem ( QString( "%1x" ).arg( i ) );
+    }
+    // factor is 1-based while index is 0-based:
+    cbxInputBoost->setCurrentIndex ( pSettings->iInputBoost - 1 );
+
     // update enable small network buffers check box
     chbEnableOPUS64->setCheckState ( pClient->GetEnableOPUS64() ? Qt::Checked : Qt::Unchecked );
 
@@ -426,6 +453,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
 
     QObject::connect ( cbxLanguage, &CLanguageComboBox::LanguageChanged,
         this, &CClientSettingsDlg::OnLanguageChanged );
+
+    QObject::connect ( cbxInputBoost, static_cast<void (QComboBox::*) ( int )> ( &QComboBox::activated ),
+        this, &CClientSettingsDlg::OnInputBoostChanged );
 
     // buttons
     QObject::connect ( butDriverSetup, &QPushButton::clicked,
@@ -766,4 +796,11 @@ void CClientSettingsDlg::UpdateCustomCentralServerComboBox()
             cbxCentralServerAddress->addItem ( pSettings->vstrCentralServerAddress[iLEIdx], iLEIdx );
         }
     }
+}
+
+void CClientSettingsDlg::OnInputBoostChanged()
+{
+    // index is zero-based while boost factor must be 1-based:
+    pSettings->iInputBoost = cbxInputBoost->currentIndex() + 1;
+    pClient->SetInputBoost ( pSettings->iInputBoost );
 }

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -97,6 +97,7 @@ public slots:
     void OnEnableOPUS64StateChanged ( int value );
     void OnCentralServerAddressEditingFinished();
     void OnNewClientLevelEditingFinished() { pSettings->iNewClientFaderLevel = edtNewClientLevel->text().toInt(); }
+    void OnInputBoostChanged();
     void OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button );
     void OnSoundcardActivated ( int iSndDevIdx );
     void OnLInChanActivated ( int iChanIdx );

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -422,6 +422,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QLabel" name="lblInputBoost">
+            <property name="text">
+             <string>Input Boost</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="lblNewClientLevel">
             <property name="text">
              <string>New Client Level</string>
@@ -451,6 +458,9 @@
           </item>
           <item>
            <widget class="QComboBox" name="cbxAudioQuality"/>
+          </item>
+          <item>
+           <widget class="QComboBox" name="cbxInputBoost"/>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -682,6 +692,7 @@
   <tabstop>sldNetBufServer</tabstop>
   <tabstop>cbxAudioChannels</tabstop>
   <tabstop>cbxAudioQuality</tabstop>
+  <tabstop>cbxInputBoost</tabstop>
   <tabstop>edtNewClientLevel</tabstop>
   <tabstop>cbxSkin</tabstop>
   <tabstop>cbxLanguage</tabstop>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -270,6 +270,13 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument&   IniXMLDocument
         iNewClientFaderLevel = iValue;
     }
 
+    // input boost
+    if ( GetNumericIniSet ( IniXMLDocument, "client", "inputboost",
+         1, 10, iValue ) )
+    {
+        iInputBoost = iValue;
+    }
+
     // connect dialog show all musicians
     if ( GetFlagIniSet ( IniXMLDocument, "client", "connectdlgshowallmusicians", bValue ) )
     {
@@ -610,6 +617,10 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // new client level
     SetNumericIniSet ( IniXMLDocument, "client", "newclientlevel",
         iNewClientFaderLevel );
+
+    // input boost
+    SetNumericIniSet ( IniXMLDocument, "client", "inputboost",
+        iInputBoost );
 
     // connect dialog show all musicians
     SetFlagIniSet ( IniXMLDocument, "client", "connectdlgshowallmusicians",

--- a/src/settings.h
+++ b/src/settings.h
@@ -145,6 +145,7 @@ public:
         vecStoredFaderGroupID       ( MAX_NUM_STORED_FADER_SETTINGS, INVALID_INDEX ),
         vstrIPAddress               ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
         iNewClientFaderLevel        ( 100 ),
+        iInputBoost                 ( 1 ),
         bConnectDlgShowAllMusicians ( true ),
         eChannelSortType            ( ST_NO_SORT ),
         iNumMixerPanelRows          ( 1 ),
@@ -173,6 +174,7 @@ public:
     CVector<int>     vecStoredFaderGroupID;
     CVector<QString> vstrIPAddress;
     int              iNewClientFaderLevel;
+    int              iInputBoost;
     bool             bConnectDlgShowAllMusicians;
     EChSortType      eChannelSortType;
     int              iNumMixerPanelRows;


### PR DESCRIPTION
This adds a new client-only UI setting to apply a gain value on all audio input.

This solves the problem that some (internal?) microphones cannot be made to output louder signals using operating system mechanisms (Windows sound settings). Multiple people in my choir use builds with this code included.

This approach solves the problem as close to the source and as simple as possible. I would have preferred to permit extending the fader range in the mixer board, but this would have been a way more intrusive change (introduction of new protocol messages, etc.).

Related to: https://github.com/jamulussoftware/jamulus/discussions/1030