### PR TITLE
Update Dutch translation in 3.7.0rc1

### DIFF
--- a/src/res/translation/translation_nl_NL.ts
+++ b/src/res/translation/translation_nl_NL.ts
@@ -997,7 +997,7 @@
     <message>
         <location filename="../../clientdlg.cpp" line="659"/>
         <source>Center</source>
-        <translation>Centrum</translation>
+        <translation>Midden</translation>
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="672"/>
@@ -1091,7 +1091,7 @@
     <message>
         <location filename="../../clientdlgbase.ui" line="392"/>
         <source>Center</source>
-        <translation>Centrum</translation>
+        <translation>Midden</translation>
     </message>
     <message>
         <location filename="../../clientdlgbase.ui" line="466"/>


### PR DESCRIPTION
Not necessarily wrong, but "Midden" is more common in Dutch for pan/balance than "Centrum".