### PR TITLE
Fix changing GUI style.

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1102,11 +1102,6 @@ void CAudioMixerBoard::UpdateTitle()
     if ( eRecorderState == RS_RECORDING )
     {
         strTitlePrefix = "[" + tr ( "RECORDING ACTIVE" ) + "] ";
-        setStyleSheet ( AM_RECORDING_STYLE );
-    }
-    else
-    {
-        setStyleSheet ( "" );
     }
 
     setTitle ( strTitlePrefix + tr ( "Personal Mix at: " ) + strServerName );

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -184,12 +184,6 @@ protected:
 template<>
 class CAudioMixerBoardSlots<0> {};
 
-#define AM_RECORDING_STYLE "QGroupBox::title { subcontrol-origin: margin; \
-                           subcontrol-position: left top; \
-                           left: 7px; \
-                           color: rgb(255,255,255); \
-                           background-color: rgb(255,0,0); }"
-
 class CAudioMixerBoard :
     public QGroupBox,
     public CAudioMixerBoardSlots<MAX_NUM_CHANNELS>

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1327,6 +1327,9 @@ void CClientDlg::UpdateDisplay()
 
 void CClientDlg::SetGUIDesign ( const EGUIDesign eNewDesign )
 {
+    // remove any styling from the mixer board - reapply after changing skin
+    MainMixerBoard->setStyleSheet ( "" );
+
     // apply GUI design to current window
     switch ( eNewDesign )
     {


### PR DESCRIPTION
The stylesheet on the main mixer board must be removed before applying
a global stylesheet to the GUI, and then reapplied afterwards.

Fixes #1238 