### PR TITLE
Advise not to edit service file directly

### DIFF
--- a/distributions/debian/jamulus-headless.service
+++ b/distributions/debian/jamulus-headless.service
@@ -14,7 +14,7 @@ Nice=-20
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
 
-#### Change this to publish this server, set genre, location and other parameters. It is recommended to overwrite this file via `systemctl edit jamulus-headless.service`
+#### Change this to publish this server, set genre, location and other parameters. It is recommended to override this file via `systemctl edit jamulus-headless.service`
 #### See https://jamulus.io/wiki/Command-Line-Options ####
 # ExecStart=/bin/sh -c '/usr/bin/jamulus-headless -s -n'
 

--- a/distributions/debian/jamulus-headless.service
+++ b/distributions/debian/jamulus-headless.service
@@ -14,9 +14,9 @@ Nice=-20
 IOSchedulingClass=realtime
 IOSchedulingPriority=0
 
-#### Change this to publish this server, set genre, location and other parameters.
+#### Change this to publish this server, set genre, location and other parameters. It is recommended to overwrite this file via `systemctl edit jamulus-headless.service`
 #### See https://jamulus.io/wiki/Command-Line-Options ####
-ExecStart=/bin/sh -c '/usr/bin/jamulus-headless -s -n'
+# ExecStart=/bin/sh -c '/usr/bin/jamulus-headless -s -n'
 
 
 Restart=on-failure


### PR DESCRIPTION
Fixes: https://github.com/jamulussoftware/jamulus/issues/1285

You should not change this file since it gets overwritten on updates. It is recommended to use systemctl edit jamulus-headless.service to create a override file. This should contain something like:
```
[Service]

#### See https://jamulus.io/wiki/Command-Line-Options ####
ExecStart=/bin/sh -c '/usr/bin/jamulus-headless -s -n -F -T'
```