### PR TITLE
Exit properly in client mode with nosound

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -340,7 +340,10 @@ win32 {
     DEFINES += HAVE_STDINT_H
 
     # only include jack support if CONFIG nosound is not set
-    !contains(CONFIG, "nosound") {
+    contains(CONFIG, "nosound") {
+        message(Restricting build to server-only due to CONFIG+=nosound.)
+        DEFINES += SERVER_ONLY
+    } else {
         message(Jack Audio Interface Enabled.)
 
         contains(CONFIG, "raspijamulus") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -565,6 +565,14 @@ int main ( int argc, char** argv )
     Q_UNUSED ( bMuteStream )           // avoid compiler warnings
 #endif
 
+#ifdef SERVER_ONLY
+    if ( bIsClient )
+    {
+        qCritical() << "Only --server mode is supported in this build with nosound.";
+        exit ( 1 );
+    }
+#endif
+
     // the inifile is not supported for the headless server mode
     if ( !bIsClient && !bUseGUI && !strIniFileName.isEmpty() )
     {


### PR DESCRIPTION
In builds with CONFIG+="nosound" the only supported mode is server mode.
Error out properly instead of crashing.

Fixes #1291