### PR TITLE
Reset channel mapping if number of in/out changed

### DIFF
--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -60,13 +60,10 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName,
         return tr ( "The current selected audio device is no longer present in the system." );
     }
 
-    // Save number of channels from last driver (if we're not on the first run)
+    // Save number of channels from last driver
     // Need to save these (but not the driver name) as CheckDeviceCapabilities() overwrites them
-    if ( lNumInChanPrev != INVALID_INDEX && lNumOutChanPrev != INVALID_INDEX )
-    {
-        lNumInChanPrev = lNumInChan;
-        lNumOutChanPrev = lNumOutChan;
-    }
+    long lNumInChanPrev = lNumInChan;
+    long lNumOutChanPrev = lNumOutChan;
 
     loadAsioDriver ( cDriverNames[iDriverIdx] );
 
@@ -98,10 +95,6 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName,
 
             // mapping to the defaults (first two available channels)
             ResetChannelMapping();
-
-            // save the new number of in/out channels
-            lNumInChanPrev = lNumInChan;
-            lNumOutChanPrev = lNumOutChan;
 
             // store ID of selected driver if initialization was successful
             strCurDevName = cDriverNames[iDriverIdx];

--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -80,7 +80,7 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName,
     }
 
     // check device capabilities if it fulfills our requirements
-    const QString strStat = CheckDeviceCapabilities();
+    const QString strStat = CheckDeviceCapabilities(); // also sets lNumInChan and lNumOutChan
 
     // check if device is capable
     if ( strStat.isEmpty() )

--- a/windows/sound.h
+++ b/windows/sound.h
@@ -53,7 +53,7 @@ public:
              const QString& strMIDISetup,
              const bool     ,
              const QString& );
-    
+
     virtual ~CSound() { UnloadCurrentDriver(); }
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );
@@ -93,8 +93,10 @@ protected:
     int              iASIOBufferSizeStereo;
 
     long             lNumInChan;
+    long             lNumInChanPrev = INVALID_INDEX; // number of channels of previous sound card/driver state
     long             lNumInChanPlusAddChan; // includes additional "added" channels
     long             lNumOutChan;
+    long             lNumOutChanPrev = INVALID_INDEX; 
     float            fInOutLatencyMs;
     CVector<int>     vSelectedInputChannels;
     CVector<int>     vSelectedOutputChannels;

--- a/windows/sound.h
+++ b/windows/sound.h
@@ -93,10 +93,8 @@ protected:
     int              iASIOBufferSizeStereo;
 
     long             lNumInChan;
-    long             lNumInChanPrev = INVALID_INDEX; // number of channels of previous sound card/driver state
     long             lNumInChanPlusAddChan; // includes additional "added" channels
     long             lNumOutChan;
-    long             lNumOutChanPrev = INVALID_INDEX; 
     float            fInOutLatencyMs;
     CVector<int>     vSelectedInputChannels;
     CVector<int>     vSelectedOutputChannels;


### PR DESCRIPTION
This will no longer reset channel mapping on every device change.

Fixes: https://github.com/jamulussoftware/jamulus/issues/1346 (at least I hope so)

With this https://github.com/jamulussoftware/jamulus/issues/796 does not occur