### PR TITLE
Clarify filter text

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -145,7 +145,7 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP,
     }
 
     // set a placeholder text to explain how to filter occupied servers (#397)
-    edtFilter->setPlaceholderText ( tr ( "Type # for occupied servers" ) );
+    edtFilter->setPlaceholderText ( tr ( "Filter text, or # for occupied servers" ) );
 
     // setup timers
     TimerInitialSort.setSingleShot ( true ); // only once after list request


### PR DESCRIPTION
This is intended to make it clearer what the filter box is to be used for.  At the moment, the only _visible_ prompt is about the special case use of `#`.