### PR TITLE
Client name added to dialog window titles  #1352

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@
 - Bug fix: The Windows installer now correctly compiles in a path with spaces (#864)
   (contributed by @henkdegroot)
 
+- Added client name,  if defined, in dialog titles
+  (contributed by @dcorson-ticino-com)
+
 ### 3.7.0 (2021-03-17) ###
 
 - Server lists have been reorganized to make room for more servers (#875):

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -49,7 +49,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 {
     setupUi ( this );
 
-
     // Add help text to controls -----------------------------------------------
     // input level meter
     QString strInpLevH = "<b>" + tr ( "Input Level Meter" ) + ":</b> " + tr ( "This shows "
@@ -1004,6 +1003,7 @@ void CClientDlg::ShowConnectionSetupDialog()
     // show connect dialog
     bConnectDlgWasShown = true;
     ConnectDlg.show();
+    ConnectDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Connect" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
     ConnectDlg.raise();
@@ -1014,6 +1014,7 @@ void CClientDlg::ShowMusicianProfileDialog()
 {
     // show musician profile dialog
     MusicianProfileDlg.show();
+    MusicianProfileDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Musician Profile" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
     MusicianProfileDlg.raise();
@@ -1024,6 +1025,7 @@ void CClientDlg::ShowGeneralSettings()
 {
     // open general settings dialog
     ClientSettingsDlg.show();
+    ClientSettingsDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Settings" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
     ClientSettingsDlg.raise();
@@ -1033,6 +1035,7 @@ void CClientDlg::ShowGeneralSettings()
 void CClientDlg::ShowChatWindow ( const bool bForceRaise )
 {
     ChatDlg.show();
+    ChatDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Chat" ) , pClient->strClientName ) );
 
     if ( bForceRaise )
     {

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1002,50 +1002,50 @@ void CClientDlg::ShowConnectionSetupDialog()
 {
     // show connect dialog
     bConnectDlgWasShown = true;
-    ConnectDlg.show();
-    ConnectDlg.setWindowTitle( MakeClientNameTitle( tr ( "Connect" ) , pClient->strClientName ) );
+    ConnectDlg.show ();
+    ConnectDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Connect" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
-    ConnectDlg.raise();
-    ConnectDlg.activateWindow();
+    ConnectDlg.raise ();
+    ConnectDlg.activateWindow ();
 }
 
 void CClientDlg::ShowMusicianProfileDialog()
 {
     // show musician profile dialog
-    MusicianProfileDlg.show();
-    MusicianProfileDlg.setWindowTitle( MakeClientNameTitle( tr ( "Musician Profile" ) , pClient->strClientName ) );
+    MusicianProfileDlg.show ();
+    MusicianProfileDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Musician Profile" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
-    MusicianProfileDlg.raise();
-    MusicianProfileDlg.activateWindow();
+    MusicianProfileDlg.raise ();
+    MusicianProfileDlg.activateWindow ();
 }
 
 void CClientDlg::ShowGeneralSettings()
 {
     // open general settings dialog
-    ClientSettingsDlg.show();
-    ClientSettingsDlg.setWindowTitle( MakeClientNameTitle( tr ( "Settings" ) , pClient->strClientName ) );
+    ClientSettingsDlg.show ();
+    ClientSettingsDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Settings" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
-    ClientSettingsDlg.raise();
-    ClientSettingsDlg.activateWindow();
+    ClientSettingsDlg.raise ();
+    ClientSettingsDlg.activateWindow ();
 }
 
 void CClientDlg::ShowChatWindow ( const bool bForceRaise )
 {
-    ChatDlg.show();
-    ChatDlg.setWindowTitle( MakeClientNameTitle( tr ( "Chat" ) , pClient->strClientName ) );
+    ChatDlg.show ();
+    ChatDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Chat" ) , pClient->strClientName ) );
 
     if ( bForceRaise )
     {
         // make sure dialog is upfront and has focus
-        ChatDlg.showNormal();
-        ChatDlg.raise();
-        ChatDlg.activateWindow();
+        ChatDlg.showNormal ();
+        ChatDlg.raise ();
+        ChatDlg.activateWindow ();
     }
 
-    UpdateDisplay();
+    UpdateDisplay ();
 }
 
 void CClientDlg::ShowAnalyzerConsole()

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -947,7 +947,7 @@ void CClientDlg::SetMyWindowTitle ( const int iNumClients )
     {
         // if --clientname is used, the APP_NAME must be the very first word in
         // the title, otherwise some user scripts do not work anymore, see #789
-        strWinTitle += QString ( APP_NAME ) + " " + pClient->strClientName + " ";
+        strWinTitle += QString ( APP_NAME ) + " - " + pClient->strClientName + " ";
     }
 
     if ( iNumClients == 0 )
@@ -1002,50 +1002,50 @@ void CClientDlg::ShowConnectionSetupDialog()
 {
     // show connect dialog
     bConnectDlgWasShown = true;
-    ConnectDlg.show ();
+    ConnectDlg.show();
     ConnectDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Connect" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
-    ConnectDlg.raise ();
-    ConnectDlg.activateWindow ();
+    ConnectDlg.raise();
+    ConnectDlg.activateWindow();
 }
 
 void CClientDlg::ShowMusicianProfileDialog()
 {
     // show musician profile dialog
-    MusicianProfileDlg.show ();
+    MusicianProfileDlg.show();
     MusicianProfileDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Musician Profile" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
-    MusicianProfileDlg.raise ();
-    MusicianProfileDlg.activateWindow ();
+    MusicianProfileDlg.raise();
+    MusicianProfileDlg.activateWindow();
 }
 
 void CClientDlg::ShowGeneralSettings()
 {
     // open general settings dialog
-    ClientSettingsDlg.show ();
+    ClientSettingsDlg.show();
     ClientSettingsDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Settings" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
-    ClientSettingsDlg.raise ();
-    ClientSettingsDlg.activateWindow ();
+    ClientSettingsDlg.raise();
+    ClientSettingsDlg.activateWindow();
 }
 
 void CClientDlg::ShowChatWindow ( const bool bForceRaise )
 {
-    ChatDlg.show ();
+    ChatDlg.show();
     ChatDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Chat" ) , pClient->strClientName ) );
 
     if ( bForceRaise )
     {
         // make sure dialog is upfront and has focus
-        ChatDlg.showNormal ();
-        ChatDlg.raise ();
-        ChatDlg.activateWindow ();
+        ChatDlg.showNormal();
+        ChatDlg.raise();
+        ChatDlg.activateWindow();
     }
 
-    UpdateDisplay ();
+    UpdateDisplay();
 }
 
 void CClientDlg::ShowAnalyzerConsole()

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1003,7 +1003,7 @@ void CClientDlg::ShowConnectionSetupDialog()
     // show connect dialog
     bConnectDlgWasShown = true;
     ConnectDlg.show();
-    ConnectDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Connect" ) , pClient->strClientName ) );
+    ConnectDlg.setWindowTitle( MakeClientNameTitle( tr ( "Connect" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
     ConnectDlg.raise();
@@ -1014,7 +1014,7 @@ void CClientDlg::ShowMusicianProfileDialog()
 {
     // show musician profile dialog
     MusicianProfileDlg.show();
-    MusicianProfileDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Musician Profile" ) , pClient->strClientName ) );
+    MusicianProfileDlg.setWindowTitle( MakeClientNameTitle( tr ( "Musician Profile" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
     MusicianProfileDlg.raise();
@@ -1025,7 +1025,7 @@ void CClientDlg::ShowGeneralSettings()
 {
     // open general settings dialog
     ClientSettingsDlg.show();
-    ClientSettingsDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Settings" ) , pClient->strClientName ) );
+    ClientSettingsDlg.setWindowTitle( MakeClientNameTitle( tr ( "Settings" ) , pClient->strClientName ) );
 
     // make sure dialog is upfront and has focus
     ClientSettingsDlg.raise();
@@ -1035,7 +1035,7 @@ void CClientDlg::ShowGeneralSettings()
 void CClientDlg::ShowChatWindow ( const bool bForceRaise )
 {
     ChatDlg.show();
-    ChatDlg.setWindowTitle ( MakeClientNameTitle( tr ( "Chat" ) , pClient->strClientName ) );
+    ChatDlg.setWindowTitle( MakeClientNameTitle( tr ( "Chat" ) , pClient->strClientName ) );
 
     if ( bForceRaise )
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -580,7 +580,6 @@ CMusProfDlg::CMusProfDlg ( CClient* pNCliP,
     - label with combo box for skill level
     - OK button
 */
-    setWindowTitle ( tr ( "Musician Profile" ) );
     setWindowIcon ( QIcon ( QString::fromUtf8 ( ":/png/main/res/fronticon.png" ) ) );
 
     QVBoxLayout* pLayout        = new QVBoxLayout ( this );
@@ -1580,4 +1579,14 @@ QString GetVersionAndNameStr ( const bool bWithHtml )
     strVersionText += QCoreApplication::tr ( "Released under the GNU General Public License (GPL)" );
 
     return strVersionText;
+}
+
+QString MakeClientNameTitle ( QString win, QString client )
+{
+    QString sReturnString = win;
+    if( !client.isEmpty() )
+    {
+        sReturnString += " - " + client;
+    }
+    return ( sReturnString );
 }

--- a/src/util.h
+++ b/src/util.h
@@ -100,6 +100,7 @@ inline int CalcBitRateBitsPerSecFromCodedBytes ( const int iCeltNumCodedBytes,
 }
 
 QString GetVersionAndNameStr ( const bool bWithHtml = true );
+QString MakeClientNameTitle ( QString win, QString client );
 
 
 /******************************************************************************\


### PR DESCRIPTION
routine to make title string in util
4 calls in clientdlg, one for each dialog when it is shown:
Connect, Chat, Musician Profile and Settings