### PR TITLE
Don't insist that selected audio device is working

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -470,18 +470,8 @@ void CClient::SetAudioChannels ( const EAudChanConf eNAudChanConf )
     }
 }
 
-QString CClient::SetSndCrdDev ( const QString strNewDev )
+QString CClient::HandleDeviceChange ( bool bWasRunning, const QString& strError )
 {
-    // if client was running then first
-    // stop it and restart again after new initialization
-    const bool bWasRunning = Sound.IsRunning();
-    if ( bWasRunning )
-    {
-        Sound.Stop();
-    }
-
-    const QString strError = Sound.SetDev ( strNewDev );
-
     bLoadedDriverWithoutErrors = strError.isEmpty();
     // init again because the sound card actual buffer size might
     // be changed on new device
@@ -497,6 +487,36 @@ QString CClient::SetSndCrdDev ( const QString strNewDev )
     emit SoundDeviceChanged ( strError );
 
     return strError;
+}
+
+QString CClient::SetSndCrdDev ( const QString strNewDev )
+{
+    // if client was running then first
+    // stop it and restart again after new initialization
+    const bool bWasRunning = Sound.IsRunning();
+    if ( bWasRunning )
+    {
+        Sound.Stop();
+    }
+
+    const QString strError = Sound.SetDev ( strNewDev );
+
+    return HandleDeviceChange ( bWasRunning, strError );
+}
+
+QString CClient::TryLoadAnyDev()
+{
+    // if client was running then first
+    // stop it and restart again after new initialization
+    const bool bWasRunning = Sound.IsRunning();
+    if ( bWasRunning )
+    {
+        Sound.Stop();
+    }
+
+    const QString strError = Sound.LoadAndInitializeFirstValidDriver();
+
+    return HandleDeviceChange ( bWasRunning, strError );
 }
 
 void CClient::SetSndCrdLeftInputChannel ( const int iNewChan )

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -472,12 +472,12 @@ void CClient::SetAudioChannels ( const EAudChanConf eNAudChanConf )
 
 QString CClient::HandleDeviceChange ( bool bWasRunning, const QString& strError )
 {
-    bLoadedDriverWithoutErrors = strError.isEmpty();
+    strDriverLoadErrors = strError;
     // init again because the sound card actual buffer size might
     // be changed on new device
     Init();
 
-    if ( bWasRunning )
+    if ( strDriverLoadErrors.isEmpty() && bWasRunning )
     {
         // restart client
         Sound.Start();
@@ -626,7 +626,8 @@ void CClient::OnSndCrdReinitRequest ( int iSndCrdResetType )
             {
                 // reinit the driver if requested
                 // (we use the currently selected driver)
-                strError = Sound.SetDev ( Sound.GetDev() );
+                strError            = Sound.SetDev ( Sound.GetDev() );
+                strDriverLoadErrors = strError;
             }
 
             // init client object (must always be performed if the driver
@@ -634,7 +635,7 @@ void CClient::OnSndCrdReinitRequest ( int iSndCrdResetType )
             Init();
         }
 
-        if ( bWasRunning )
+        if ( bWasRunning && strDriverLoadErrors.isEmpty() )
         {
             // restart client
             Sound.Start();
@@ -737,6 +738,11 @@ void CClient::OnClientIDReceived ( int iChanID )
 
 void CClient::Start()
 {
+    if ( !strDriverLoadErrors.isEmpty() )
+    {
+        throw CGenErr ( tr ( "You can't connect because your current audio device configuration isn't working:\n" ) + strDriverLoadErrors );
+    }
+
     // init object
     Init();
 
@@ -788,7 +794,7 @@ void CClient::Init()
     const int iFraSizeDefault   = SYSTEM_FRAME_SIZE_SAMPLES * FRAME_SIZE_FACTOR_DEFAULT;
     const int iFraSizeSafe      = SYSTEM_FRAME_SIZE_SAMPLES * FRAME_SIZE_FACTOR_SAFE;
 
-    if ( !bLoadedDriverWithoutErrors )
+    if ( !strDriverLoadErrors.isEmpty() )
     {
         bFraSiFactPrefSupported = false;
         bFraSiFactDefSupported  = false;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -482,6 +482,7 @@ QString CClient::SetSndCrdDev ( const QString strNewDev )
 
     const QString strError = Sound.SetDev ( strNewDev );
 
+    bLoadedDriverWithoutErrors = strError.isEmpty();
     // init again because the sound card actual buffer size might
     // be changed on new device
     Init();
@@ -492,11 +493,8 @@ QString CClient::SetSndCrdDev ( const QString strNewDev )
         Sound.Start();
     }
 
-    // in case of an error inform the GUI about it
-    if ( !strError.isEmpty() )
-    {
-        emit SoundDeviceChanged ( strError );
-    }
+    // inform the GUI about change in state
+    emit SoundDeviceChanged ( strError );
 
     return strError;
 }
@@ -769,6 +767,14 @@ void CClient::Init()
     const int iFraSizePreffered = SYSTEM_FRAME_SIZE_SAMPLES * FRAME_SIZE_FACTOR_PREFERRED;
     const int iFraSizeDefault   = SYSTEM_FRAME_SIZE_SAMPLES * FRAME_SIZE_FACTOR_DEFAULT;
     const int iFraSizeSafe      = SYSTEM_FRAME_SIZE_SAMPLES * FRAME_SIZE_FACTOR_SAFE;
+
+    if ( !bLoadedDriverWithoutErrors )
+    {
+        bFraSiFactPrefSupported = false;
+        bFraSiFactDefSupported  = false;
+        bFraSiFactSafeSupported = false;
+        return;
+    }
 
 #if defined( Q_OS_IOS )
     bFraSiFactPrefSupported = true; // to reduce sound init time, because we know it's supported in iOS

--- a/src/client.h
+++ b/src/client.h
@@ -179,6 +179,7 @@ public:
     // sound card device selection
     QStringList GetSndCrdDevNames() { return Sound.GetDevNames(); }
 
+    QString TryLoadAnyDev();
     QString SetSndCrdDev ( const QString strNewDev );
     QString GetSndCrdDev() { return Sound.GetDev(); }
     void    OpenSndCrdDriverSetup() { Sound.OpenDriverSetup(); }
@@ -280,6 +281,8 @@ public:
 protected:
     // callback function must be static, otherwise it does not work
     static void AudioCallback ( CVector<short>& psData, void* arg );
+
+    QString HandleDeviceChange ( bool bWasRunning, const QString& strError );
 
     void Init();
     void ProcessSndCrdAudioData ( CVector<short>& vecsStereoSndCrd );

--- a/src/client.h
+++ b/src/client.h
@@ -182,7 +182,11 @@ public:
     QString TryLoadAnyDev();
     QString SetSndCrdDev ( const QString strNewDev );
     QString GetSndCrdDev() { return Sound.GetDev(); }
-    void    OpenSndCrdDriverSetup() { Sound.OpenDriverSetup(); }
+    void    OpenSndCrdDriverSetup()
+    {
+        if ( !GetSndCrdDev().isEmpty() )
+            Sound.OpenDriverSetup();
+    }
 
     // sound card channel selection
     int     GetSndCrdNumInputChannels() { return Sound.GetNumInputChannels(); }

--- a/src/client.h
+++ b/src/client.h
@@ -346,7 +346,8 @@ protected:
     bool bFraSiFactPrefSupported;
     bool bFraSiFactDefSupported;
     bool bFraSiFactSafeSupported;
-    bool bLoadedDriverWithoutErrors;
+
+    QString strDriverLoadErrors;
 
     int iMonoBlockSizeSam;
     int iStereoBlockSizeSam;

--- a/src/client.h
+++ b/src/client.h
@@ -343,6 +343,7 @@ protected:
     bool bFraSiFactPrefSupported;
     bool bFraSiFactDefSupported;
     bool bFraSiFactSafeSupported;
+    bool bLoadedDriverWithoutErrors;
 
     int iMonoBlockSizeSam;
     int iStereoBlockSizeSam;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1163,10 +1163,7 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
     if ( !strError.isEmpty() )
     {
         // the sound device setup has a problem, disconnect any active connection
-        if ( pClient->IsRunning() )
-        {
-            Disconnect();
-        }
+        Disconnect();
 
         // show the error message of the device setup
         QMessageBox::critical ( this, APP_NAME, strError, tr ( "Ok" ), nullptr );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1212,10 +1212,11 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
         catch ( const CGenErr& generr )
         {
             // show error message and return the function
-            QMessageBox msgBox ( QMessageBox::Critical, APP_NAME, generr.GetErrorText(),
-                                 QMessageBox::NoButton, this );
+            QMessageBox  msgBox ( QMessageBox::Critical, APP_NAME, generr.GetErrorText(), QMessageBox::NoButton, this );
             QPushButton* openSettingsButton = msgBox.addButton ( tr ( "Open Settings" ), QMessageBox::ActionRole );
-            QPushButton* autoSelectButton = msgBox.addButton ( tr ( "Auto Select Device" ), QMessageBox::ActionRole );
+            // See also CClientSettingsDlg::UpdateSoundDeviceChannelSelectionFrame()
+            QPushButton* autoSelectButton =
+                ( pClient->GetSndCrdDevNames().count() > 1 ) ? msgBox.addButton ( tr ( "Auto Select Device" ), QMessageBox::ActionRole ) : nullptr;
             QPushButton* closeButton = msgBox.addButton ( tr ( "Close" ), QMessageBox::AcceptRole );
 
             msgBox.setTextFormat ( Qt::RichText ); // Some error messages are HTML formatted

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1212,7 +1212,25 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
         catch ( const CGenErr& generr )
         {
             // show error message and return the function
-            QMessageBox::critical ( this, APP_NAME, generr.GetErrorText(), "Close", nullptr );
+            QMessageBox msgBox ( QMessageBox::Critical, APP_NAME, generr.GetErrorText(),
+                                 QMessageBox::NoButton, this );
+            QPushButton* openSettingsButton = msgBox.addButton ( tr ( "Open Settings" ), QMessageBox::ActionRole );
+            QPushButton* autoSelectButton = msgBox.addButton ( tr ( "Auto Select Device" ), QMessageBox::ActionRole );
+            QPushButton* closeButton = msgBox.addButton ( tr ( "Close" ), QMessageBox::AcceptRole );
+
+            msgBox.setTextFormat ( Qt::RichText ); // Some error messages are HTML formatted
+            msgBox.setDefaultButton ( openSettingsButton );
+            msgBox.setEscapeButton ( closeButton );
+
+            msgBox.exec();
+            if ( msgBox.clickedButton() == openSettingsButton )
+            {
+                ShowGeneralSettings ( SETTING_TAB_AUDIONET );
+            }
+            else if ( msgBox.clickedButton() == autoSelectButton )
+            {
+                ClientSettingsDlg.OnTryLoadAnyDriverClicked();
+            }
             return;
         }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -263,6 +263,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     lblGlobalInfoLabel->setStyleSheet ( ".QLabel { background: red; }" );
     lblGlobalInfoLabel->hide();
 
+    SetErrorMessage ( pNSetP->strLoadErrors );
+
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
     lblUpdateCheck->setText ( "<font color=\"red\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
@@ -1041,6 +1043,12 @@ void CClientDlg::OnLocalMuteStateChanged ( int value )
     }
 }
 
+void CClientDlg::SetErrorMessage ( const QString& message )
+{
+    lblGlobalErrorMessage->setText ( message );
+    lblGlobalErrorMessage->setVisible ( !message.isEmpty() );
+}
+
 void CClientDlg::OnTimerSigMet()
 {
     // show current level
@@ -1175,6 +1183,8 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
         TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS );
         bDetectFeedback = true;
     }
+
+    SetErrorMessage ( strError );
 
     // update the settings dialog
     ClientSettingsDlg.SetDeviceErrors ( strError );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1177,6 +1177,7 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
     }
 
     // update the settings dialog
+    ClientSettingsDlg.SetDeviceErrors ( strError );
     ClientSettingsDlg.UpdateSoundDeviceChannelSelectionFrame();
 }
 

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -121,6 +121,8 @@ protected:
     virtual void dropEvent ( QDropEvent* Event ) { ManageDragNDrop ( Event, false ); }
     void         UpdateDisplay();
 
+    void SetErrorMessage ( const QString& message );
+
     CClientSettingsDlg ClientSettingsDlg;
     CChatDlg           ChatDlg;
     CConnectDlg        ConnectDlg;

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -565,6 +565,19 @@
            </widget>
           </item>
           <item>
+            <widget class="QLabel" name="lblGlobalErrorMessage">
+              <property name="wordWrap">
+                <bool>true</bool>
+              </property>
+              <property name="visible">
+                <bool>false</bool>
+              </property>
+              <property name="styleSheet">
+                <string>.QLabel { background: red; }</string>
+              </property>
+            </widget>
+          </item>
+          <item>
            <layout class="QVBoxLayout" name="verticalLayout_2">
             <property name="sizeConstraint">
              <enum>QLayout::SetMinimumSize</enum>

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -695,6 +695,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     QObject::connect ( butDriverSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverSetupClicked );
 #endif
     QObject::connect ( butTryLoadAnyDriver, &QPushButton::clicked, this, &CClientSettingsDlg::OnTryLoadAnyDriverClicked );
+    QObject::connect ( butDriverReset, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverResetClicked );
 
     // misc
     // sliders
@@ -910,6 +911,8 @@ void CClientSettingsDlg::SetEnableFeedbackDetection ( bool enable )
 #if defined( _WIN32 ) && !defined( WITH_JACK )
 void CClientSettingsDlg::OnDriverSetupClicked() { pClient->OpenSndCrdDriverSetup(); }
 #endif
+
+void CClientSettingsDlg::OnDriverResetClicked() { pClient->SetSndCrdDev ( pClient->GetSndCrdDev() ); }
 
 void CClientSettingsDlg::OnNetBufValueChanged ( int value )
 {

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -844,7 +844,9 @@ void CClientSettingsDlg::UpdateSoundDeviceChannelSelectionFrame()
         cbxSoundcard->addItem ( strDevName );
     }
 
-    cbxSoundcard->setCurrentText ( pClient->GetSndCrdDev() );
+    const QString& sSndCrdName = pClient->GetSndCrdDev();
+    cbxSoundcard->setCurrentText ( sSndCrdName );
+    butDriverSetup->setEnabled ( !sSndCrdName.isEmpty() );
 
     // update input/output channel selection
 #if defined( _WIN32 ) || defined( __APPLE__ ) || defined( __MACOSX )

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -846,6 +846,9 @@ void CClientSettingsDlg::UpdateSoundDeviceChannelSelectionFrame()
     {
         cbxSoundcard->addItem ( strDevName );
     }
+    // Selecting devices automatically only makes sense if there is more than
+    // one to choose from.
+    butTryLoadAnyDriver->setVisible ( slSndCrdDevNames.count() > 1 );
 
     const QString& sSndCrdName = pClient->GetSndCrdDev();
     cbxSoundcard->setCurrentText ( sSndCrdName );

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -145,6 +145,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                TOOLTIP_COM_END_TEXT );
 #    endif
 
+    lblErrors->setText ( pSettings->strLoadErrors );
+    lblErrors->setWordWrap ( true );
+
     // sound card input/output channel mapping
     QString strSndCrdChanMapp = "<b>" + tr ( "Sound Card Channel Mapping" ) + ":</b> " +
                                 tr ( "If the selected sound card device offers more than one "
@@ -784,6 +787,8 @@ QString CClientSettingsDlg::GenSndCrdBufferDelayString ( const int iFrameSize, c
     return QString().setNum ( static_cast<double> ( iFrameSize ) * 2 * 1000 / SYSTEM_SAMPLE_RATE_HZ, 'f', 2 ) + " ms (" +
            QString().setNum ( iFrameSize ) + strAddText + ")";
 }
+
+void CClientSettingsDlg::SetDeviceErrors ( const QString& strError ) { lblErrors->setText ( strError ); }
 
 void CClientSettingsDlg::UpdateSoundCardFrame()
 {

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -264,6 +264,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     butDriverSetup->setToolTip ( strSndCardDriverSetupTT );
 #endif
 
+    butDriverReset->setIcon ( butDriverReset->style()->standardIcon ( QStyle::SP_BrowserReload ) );
+
     // fancy skin
     lblSkin->setWhatsThis ( "<b>" + tr ( "Skin" ) + ":</b> " + tr ( "Select the skin to be used for the main window." ) );
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -694,6 +694,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     // Driver Setup button is only available for Windows when JACK is not used
     QObject::connect ( butDriverSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverSetupClicked );
 #endif
+    QObject::connect ( butTryLoadAnyDriver, &QPushButton::clicked, this, &CClientSettingsDlg::OnTryLoadAnyDriverClicked );
 
     // misc
     // sliders
@@ -918,6 +919,14 @@ void CClientSettingsDlg::OnNetBufServerValueChanged ( int value )
 {
     pClient->SetServerSockBufNumFrames ( value );
     UpdateJitterBufferFrame();
+}
+
+void CClientSettingsDlg::OnTryLoadAnyDriverClicked()
+{
+    pClient->TryLoadAnyDev();
+
+    UpdateSoundDeviceChannelSelectionFrame();
+    UpdateDisplay();
 }
 
 void CClientSettingsDlg::OnSoundcardActivated ( int iSndDevIdx )

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -98,6 +98,7 @@ public slots:
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnMeterStyleActivated ( int iMeterStyleIdx );
     void OnDriverSetupClicked();
+    void OnDriverResetClicked();
     void OnTryLoadAnyDriverClicked();
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnAliasTextChanged ( const QString& strNewName );

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -97,7 +97,6 @@ public slots:
     void OnAudioQualityActivated ( int iQualityIdx );
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnMeterStyleActivated ( int iMeterStyleIdx );
-    void OnDriverSetupClicked();
     void OnDriverResetClicked();
     void OnTryLoadAnyDriverClicked();
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -97,6 +97,8 @@ public slots:
     void OnAudioQualityActivated ( int iQualityIdx );
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnMeterStyleActivated ( int iMeterStyleIdx );
+    void OnDriverSetupClicked();
+    void OnTryLoadAnyDriverClicked();
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnAliasTextChanged ( const QString& strNewName );
     void OnInstrumentActivated ( int iCntryListItem );

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -58,6 +58,7 @@ public:
 
     void UpdateUploadRate();
     void UpdateDisplay();
+    void SetDeviceErrors ( const QString& strError );
     void UpdateSoundDeviceChannelSelectionFrame();
 
     void SetEnableFeedbackDetection ( bool enable );

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -369,6 +369,10 @@
             </spacer>
            </item>
            <item>
+             <widget class="QLabel" name="lblErrors">
+             </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="butDriverSetup">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -396,6 +396,13 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="butDriverReset">
+             <property name="text">
+              <string>Reset Driver</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_5">
              <property name="orientation">
               <enum>Qt::Vertical</enum>

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -337,20 +337,31 @@
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="cbxSoundcard">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout_Soundcard">
+               <item>
+                 <widget class="QComboBox" name="cbxSoundcard">
+                   <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                     </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                     <size>
+                       <width>0</width>
+                       <height>0</height>
+                     </size>
+                   </property>
+                 </widget>
+               </item>
+               <item>
+                 <widget class="QToolButton" name="butDriverReset">
+                   <property name="toolTip">
+                     <string>Reset Driver</string>
+                   </property>
+                 </widget>
+               </item>
+             </layout>
            </item>
            <item>
             <spacer name="verticalSpacer_3">
@@ -392,13 +403,6 @@
              </property>
              <property name="autoDefault">
               <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="butDriverReset">
-             <property name="text">
-              <string>Reset Driver</string>
              </property>
             </widget>
            </item>

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -373,6 +373,13 @@
              </widget>
            </item>
            <item>
+             <widget class="QPushButton" name="butTryLoadAnyDriver">
+               <property name="text">
+                 <string>Auto Select Device</string>
+               </property>
+             </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="butDriverSetup">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -331,9 +331,15 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     }
 
     // sound card selection
-    const QString strError = pClient->SetSndCrdDev ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "client", "auddev_base64", "" ) ) );
-
-    strLoadErrors = strError;
+    const QString strDevName = FromBase64ToString ( GetIniSetting ( IniXMLDocument, "client", "auddev_base64", "" ) );
+    if ( strDevName.isEmpty() )
+    {
+        strLoadErrors = pClient->TryLoadAnyDev();
+    }
+    else
+    {
+        strLoadErrors = pClient->SetSndCrdDev ( strDevName );
+    }
 
     // sound card channel mapping settings: make sure these settings are
     // set AFTER the sound card device is set, otherwise the settings are

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -333,14 +333,7 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     // sound card selection
     const QString strError = pClient->SetSndCrdDev ( FromBase64ToString ( GetIniSetting ( IniXMLDocument, "client", "auddev_base64", "" ) ) );
 
-    if ( !strError.isEmpty() )
-    {
-#ifndef HEADLESS
-        // special case: when settings are loaded no GUI is yet created, therefore
-        // we have to create a warning message box here directly
-        QMessageBox::warning ( nullptr, APP_NAME, strError );
-#endif
-    }
+    strLoadErrors = strError;
 
     // sound card channel mapping settings: make sure these settings are
     // set AFTER the sound card device is set, otherwise the settings are

--- a/src/settings.h
+++ b/src/settings.h
@@ -170,6 +170,8 @@ public:
     bool       bWindowWasShownConnect;
     bool       bOwnFaderFirst;
 
+    QString strLoadErrors;
+
 protected:
     // No CommandLineOptions used when reading Client inifile
     virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument ) override;

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -102,7 +102,7 @@ QString CSoundBase::SetDev ( const QString strDevName )
     return LoadAndInitializeDriver ( strDevName, false );
 }
 
-QVector<QString> CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup )
+QString CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup )
 {
     QVector<QString> vsErrorList;
 
@@ -134,7 +134,24 @@ QVector<QString> CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpe
         iDriverCnt++;
     }
 
-    return vsErrorList;
+    if ( !vsErrorList.isEmpty() )
+    {
+        // create error message with all details
+        QString sErrorMessage = "<b>" + tr ( "No usable " ) + strSystemDriverTechniqueName + tr ( " audio device (driver) found." ) + "</b><br><br>" +
+                                tr ( "In the following there is a list of all available drivers "
+                                     "with the associated error message:" ) +
+                                "<ul>";
+
+        for ( int i = 0; i < lNumDevs; i++ )
+        {
+            sErrorMessage += "<li><b>" + GetDeviceName ( i ) + "</b>: " + vsErrorList[i] + "</li>";
+        }
+        sErrorMessage += "</ul>";
+
+        return sErrorMessage;
+    }
+
+    return "";
 }
 
 /******************************************************************************\

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -86,6 +86,7 @@ public:
         QMutexLocker locker ( &MutexDevProperties );
         return strCurDevName;
     }
+    QString LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup = false );
 
     virtual int     GetNumInputChannels() { return 2; }
     virtual QString GetInputChannelName ( const int ) { return "Default"; }
@@ -113,11 +114,10 @@ public:
     void EmitReinitRequestSignal ( const ESndCrdResetType eSndCrdResetType ) { emit ReinitRequest ( eSndCrdResetType ); }
 
 protected:
-    virtual QString  LoadAndInitializeDriver ( QString, bool ) { return ""; }
-    virtual void     UnloadCurrentDriver() {}
-    QVector<QString> LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup = false );
-    void             ParseCommandLineArgument ( const QString& strMIDISetup );
-    QString          GetDeviceName ( const int iDiD ) { return strDriverNames[iDiD]; }
+    virtual QString LoadAndInitializeDriver ( QString, bool ) { return ""; }
+    virtual void    UnloadCurrentDriver() {}
+    void            ParseCommandLineArgument ( const QString& strMIDISetup );
+    QString         GetDeviceName ( const int iDiD ) { return strDriverNames[iDiD]; }
 
     static void GetSelCHAndAddCH ( const int iSelCH, const int iNumInChan, int& iSelCHOut, int& iSelAddCHOut )
     {

--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -107,8 +107,8 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName, bool bOpenDrive
                                     QMessageBox::Yes );
         }
 
-        // driver cannot be used, clean up
-        asioDrivers->removeCurrentDriver();
+        // We used to unload the driver here, but then the user won't be able
+        // open the ASIO driver settings to fix the problem.
     }
 
     return strStat;

--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -71,8 +71,7 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName, bool bOpenDrive
 
     if ( ASIOInit ( &driverInfo ) != ASE_OK )
     {
-        // clean up and return error string
-        asioDrivers->removeCurrentDriver();
+        // Don't unload the driver here, that would prevent the user from reconfiguring the device.
         return tr ( "Couldn't initialise the audio driver. Check if your audio hardware is plugged in and verify your driver settings." );
     }
 


### PR DESCRIPTION
**EDIT by maintainers:** In order to move this forward, we'd need someone with macOS background who can help debugging

```
That is, don't immediately try to select a different working device if
the current one fails to work.
```

This PR is intended to make the discussion in #1338 a bit more concrete. I think this basically handles points (1) and (3) from there. I didn't make any attempt at (2); none of the messages are different.

Here's a screenshot of what happens when I've selected a device that's turned off.

![uninitialized-device](https://user-images.githubusercontent.com/287742/112755973-16d56800-8fb1-11eb-80c6-aec3c4c98488.png)


