### PR TITLE
Windows: Delay detaching from console

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,13 +89,6 @@ int main ( int argc, char** argv )
     QString      strWelcomeMessage           = "";
     QString      strClientName               = "";
 
-#if !defined(HEADLESS) && defined(_WIN32)
-    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-        freopen("CONOUT$", "w", stdout);
-        freopen("CONOUT$", "w", stderr);
-    }
-#endif
-
     // QT docu: argv()[0] is the program name, argv()[1] is the first
     // argument and argv()[argc()-1] is the last argument.
     // Start with first argument, therefore "i = 1"
@@ -625,6 +618,12 @@ int main ( int argc, char** argv )
         iPortNumber += 10; // increment by 10
     }
 
+#if defined(_WIN32)
+    if (bUseGUI && AttachConsole(ATTACH_PARENT_PROCESS)) {
+        freopen("CONOUT$", "w", stdout);
+        freopen("CONOUT$", "w", stderr);
+    }
+#endif
 
     // Application/GUI setup ---------------------------------------------------
     // Application object


### PR DESCRIPTION
This moves the call to attach to the parent process' console from the start of the main routine to a place after command line parsing.

The goal is to improve command-line-only invocations of Jamulus for non-headless builds, e.g. `Jamulus -h` or `Jamulus -n -s`.

It also modifies the logic to disable the detaching not only for headless builds but also for non-headless builds with --nogui invocations.

Hopefully fixes #1281.

Disclaimer: I cannot test this at all. I don't even know if it compiles (CI will show).

@drummer1154  Can you please do a test with the artifacts once the build has finished?

- [ ] Is #1281 fixed?
- [ ] Do startup messages still appear as they used to? https://github.com/jamulussoftware/jamulus/issues/1281#issuecomment-803160782