### PR TITLE
allow using specific jack server instance

### DIFF
--- a/android/sound.cpp
+++ b/android/sound.cpp
@@ -33,6 +33,7 @@ CSound::CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData
                  void*          arg,
                  const QString& strMIDISetup,
                  const bool     ,
+                 const QString&,
                  const QString& ) :
     CSoundBase ( "Oboe", fpNewProcessCallback, arg, strMIDISetup )
 {

--- a/android/sound.h
+++ b/android/sound.h
@@ -43,6 +43,7 @@ public:
              void*          arg,
              const QString& strMIDISetup,
              const bool     ,
+             const QString&,
              const QString& );
     virtual ~CSound() {}
 

--- a/linux/sound.cpp
+++ b/linux/sound.cpp
@@ -28,12 +28,16 @@
 
 #ifdef WITH_SOUND
 void CSound::OpenJack ( const bool  bNoAutoJackConnect,
-                        const char* jackClientName )
+                        const char* jackClientName,
+                        const char* jackServerName )
 {
     jack_status_t JackStatus;
 
     // try to become a client of the JACK server
-    pJackClient = jack_client_open ( jackClientName, JackNullOption, &JackStatus );
+    if (strlen(jackServerName) > 0)
+        pJackClient = jack_client_open ( jackClientName, JackServerName, &JackStatus, jackServerName );
+    else
+        pJackClient = jack_client_open ( jackClientName, JackNullOption, &JackStatus );
 
     if ( pJackClient == nullptr )
     {

--- a/linux/sound.h
+++ b/linux/sound.h
@@ -66,7 +66,8 @@ public:
              void*          arg,
              const QString& strMIDISetup,
              const bool     bNoAutoJackConnect,
-             const QString& strJackClientName ) :
+             const QString& strJackClientName,
+             const QString& strJackServerName ) :
         CSoundBase ( "Jack", fpNewProcessCallback, arg, strMIDISetup ),
         iJACKBufferSizeMono ( 0 ), bJackWasShutDown ( false ), fInOutLatencyMs ( 0.0f )
     {
@@ -77,7 +78,7 @@ public:
             strJackName += " " + strJackClientName;
         }
 
-        OpenJack ( bNoAutoJackConnect, strJackName.toLocal8Bit().data() );
+        OpenJack ( bNoAutoJackConnect, strJackName.toLocal8Bit().data(), strJackServerName.toLocal8Bit().data() );
     }
 
     virtual ~CSound() { CloseJack(); }
@@ -103,7 +104,8 @@ public:
 
 protected:
     void OpenJack ( const bool  bNoAutoJackConnect,
-                    const char* jackClientName );
+                    const char* jackClientName,
+                    const char* jackServerName );
 
     void CloseJack();
 
@@ -127,6 +129,7 @@ public:
              void*          pParg,
              const QString& strMIDISetup,
              const bool     ,
+             const QString&,
              const QString& ) :
         CSoundBase ( "nosound", fpNewProcessCallback, pParg, strMIDISetup ),
         HighPrecisionTimer ( true ) { HighPrecisionTimer.Start();

--- a/mac/sound.cpp
+++ b/mac/sound.cpp
@@ -30,6 +30,7 @@ CSound::CSound ( void           (*fpNewProcessCallback) ( CVector<short>& psData
                  void*          arg,
                  const QString& strMIDISetup,
                  const bool     ,
+                 const QString&,
                  const QString& ) :
     CSoundBase ( "CoreAudio", fpNewProcessCallback, arg, strMIDISetup ),
     midiInPortRef ( static_cast<MIDIPortRef> ( NULL ) )

--- a/mac/sound.h
+++ b/mac/sound.h
@@ -43,6 +43,7 @@ public:
              void*          arg,
              const QString& strMIDISetup,
              const bool     ,
+             const QString&,
              const QString& );
 
     virtual int  Init ( const int iNewPrefMonoBufferSize );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -31,7 +31,8 @@ CClient::CClient ( const quint16  iPortNumber,
                    const QString& strMIDISetup,
                    const bool     bNoAutoJackConnect,
                    const QString& strNClientName,
-                   const bool     bNMuteMeInPersonalMix ) :
+                   const bool     bNMuteMeInPersonalMix,
+                   const QString& strJackServerName ) :
     ChannelInfo                      ( ),
     strClientName                    ( strNClientName ),
     Channel                          ( false ), /* we need a client channel -> "false" */
@@ -47,7 +48,7 @@ CClient::CClient ( const quint16  iPortNumber,
     bMuteOutStream                   ( false ),
     fMuteOutStreamGain               ( 1.0f ),
     Socket                           ( &Channel, iPortNumber ),
-    Sound                            ( AudioCallback, this, strMIDISetup, bNoAutoJackConnect, strNClientName ),
+    Sound                            ( AudioCallback, this, strMIDISetup, bNoAutoJackConnect, strNClientName, strJackServerName ),
     iAudioInFader                    ( AUD_FADER_IN_MIDDLE ),
     bReverbOnLeftChan                ( false ),
     iReverbLevel                     ( 0 ),

--- a/src/client.h
+++ b/src/client.h
@@ -113,7 +113,8 @@ public:
               const QString& strMIDISetup,
               const bool     bNoAutoJackConnect,
               const QString& strNClientName,
-              const bool     bNMuteMeInPersonalMix );
+              const bool     bNMuteMeInPersonalMix,
+              const QString& strJackServerName );
 
     virtual ~CClient();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ int main ( int argc, char** argv )
     QString      strServerListFilter         = "";
     QString      strWelcomeMessage           = "";
     QString      strClientName               = "";
+    QString      strJackServerName           = "";
 
 #if !defined(HEADLESS) && defined(_WIN32)
     if (AttachConsole(ATTACH_PARENT_PROCESS)) {
@@ -531,6 +532,22 @@ int main ( int argc, char** argv )
             continue;
         }
 
+#ifdef WITH_SOUND
+        // Jack server name ----------------------------------------------------
+        if ( GetStringArgument ( argc,
+                               argv,
+                               i,
+                               "--jackservername", // no short form
+                               "--jackservername",
+                               strArgument ) )
+        {
+            strJackServerName = strArgument;
+            qInfo() << qUtf8Printable( QString( "- jack server name: %1" )
+                .arg( strJackServerName ) );
+            CommandLineOptions << "--jackservername";
+            continue;
+        }
+#endif
 
         // Version number ------------------------------------------------------
         if ( ( !strcmp ( argv[i], "--version" ) ) ||
@@ -697,7 +714,8 @@ int main ( int argc, char** argv )
                              strMIDISetup,
                              bNoAutoJackConnect,
                              strClientName,
-                             bMuteMeInPersonalMix );
+                             bMuteMeInPersonalMix,
+                             strJackServerName );
 
             // load settings from init-file (command line options override)
             CClientSettings Settings ( &Client, strIniFileName );
@@ -875,6 +893,9 @@ QString UsageArguments ( char **argv )
         "      --mutemyown       mute me in my personal mix (headless only)\n"
         "  -c, --connect         connect to given server address on startup\n"
         "  -j, --nojackconnect   disable auto Jack connections\n"
+#ifdef WITH_SOUND
+        "      --jackservername  use specific Jack server instance\n"
+#endif
         "      --ctrlmidich      MIDI controller channel to listen\n"
         "      --clientname      client name (window title and jack client name)\n"
         "\nExample: " + QString ( argv[0] ) + " -s --inifile myinifile.ini\n";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -487,6 +487,7 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
         "<p>Noam Postavsky (<a href=\"https://github.com/npostavs\">npostavs</a>)</p>"
         "<p>Johannes Brauers (<a href=\"https://github.com/JohannesBrx\">JohannesBrx</a>)</p>"
         "<p>Henk De Groot (<a href=\"https://github.com/henkdegroot\">henkdegroot</a>)</p>"
+        "<p>Martin Kaistra (<a href=\"https://github.com/djfun\">djfun</a>)</p>"
         "<br>" + tr ( "For details on the contributions check out the " ) +
         "<a href=\"https://github.com/jamulussoftware/jamulus/graphs/contributors\">" + tr ( "Github Contributors list" ) + "</a>." );
 

--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -518,6 +518,7 @@ CSound::CSound ( void           (*fpNewCallback) ( CVector<int16_t>& psData, voi
                  void*          arg,
                  const QString& strMIDISetup,
                  const bool     ,
+                 const QString&,
                  const QString& ) :
     CSoundBase              ( "ASIO", fpNewCallback, arg, strMIDISetup ),
     lNumInChan              ( 0 ),

--- a/windows/sound.h
+++ b/windows/sound.h
@@ -52,6 +52,7 @@ public:
              void*          arg,
              const QString& strMIDISetup,
              const bool     ,
+             const QString&,
              const QString& );
     
     virtual ~CSound() { UnloadCurrentDriver(); }


### PR DESCRIPTION
Add a new command line parameter "--jackservername <servername>", which will
be used to connect to a jack server instance with the specified name.
If the parameter is missing, connect to the default jack server.

See #1394 and #1397 

So far, I have only tested building for linux.