### PR TITLE
Server: Update statusfile on exit

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -722,6 +722,11 @@ void CServer::OnAboutToQuit()
     {
         UnregisterSlaveServer();
     }
+
+    if ( bWriteStatusHTMLFile )
+    {
+        WriteHTMLServerQuit();
+    }
 }
 
 void CServer::OnHandledSignal ( int sigNum )
@@ -1740,6 +1745,21 @@ void CServer::WriteHTMLChannelList()
             streamFileOut << "</ul>\n";
         }
     }
+}
+
+void CServer::WriteHTMLServerQuit()
+{
+    // prepare file and stream
+    QFile serverFileListFile ( strServerHTMLFileListName );
+
+    if ( !serverFileListFile.open ( QIODevice::WriteOnly | QIODevice::Text ) )
+    {
+        return;
+    }
+
+    QTextStream streamFileOut ( &serverFileListFile );
+    streamFileOut << "  Server terminated\n";
+    serverFileListFile.close();
 }
 
 void CServer::customEvent ( QEvent* pEvent )

--- a/src/server.h
+++ b/src/server.h
@@ -306,6 +306,7 @@ protected:
     inline void connectChannelSignalsToServerSlots();
 
     void WriteHTMLChannelList();
+    void WriteHTMLServerQuit();
 
     void DecodeReceiveDataBlocks ( const int iStartChanCnt,
                                    const int iStopChanCnt,


### PR DESCRIPTION
If the server terminates, empty the status file to avoid signalling that there are still clients connected.

@drummer1154 Can you test this?

Fixes #1423