### PR TITLE
Issue templates: Guide users to Discussions for Support/Ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,7 +11,6 @@ assignees: ''
 
 **To Reproduce**
 <!-- Steps to reproduce the behavior: -->
-
 
 **Expected behavior**
 <!-- A clear and concise description of what you expected to happen. -->
@@ -25,5 +23,6 @@ assignees: ''
 
 **Version of Jamulus**
 <!-- Get this from the Help > About menu or from the `Jamulus --version` command line -->
+
 **Additional context**
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+contact_links:
+  - name: Support Request or Question
+    url: https://github.com/jamulussoftware/jamulus/discussions/new
+    about: Please ask questions by opening a new Discussion.
+
+  - name: Idea/Feature Request
+    url: https://github.com/jamulussoftware/jamulus/discussions/new
+    about: Please open a Discussion if you have ideas for new features or functions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,11 +12,7 @@ assignees: ''
 <!-- Don't worry about requesting something that hasn't been discussed - we'll just move it to Discussion if we think it's unclear. But ideally, issues should have an agreed specification such that anyone could action it without much help. -->
 
 **Describe the solution you'd like**
-
 <!-- A clear and concise description of what you want to happen. --> 
 
 **Describe alternatives that have been considered**
 <!-- If some alternatives have been discussed, please briefly list those together with a reason(s) why they were decided against. This prevents a repeat of the previous discussions. Reference any relevant discussion threads if possible, and consider tagging the main participants. -->
-
-
-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature
+name: Specified Feature
 about: Agreed specification for a feature or enhancement
 title: ''
 labels: 'feature'


### PR DESCRIPTION
Example: https://github.com/hoffie/jamulus/issues/new/choose (last two entries only)

It would be even better to have these two entries first, but I haven't found a way to do that.