### PR TITLE
Use aqtinstall instead of brew

### DIFF
--- a/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
@@ -7,5 +7,11 @@
 ###################
 
 echo "Install dependencies..."
-brew install qt5
-brew link qt5 --force
+python3 -m pip install aqtinstall
+python3 -m aqt install --outputdir /usr/local/opt/qt 5.9.9 mac desktop
+
+# add the qt binaries to the path
+export -p PATH=/usr/local/opt/qt/5.9.9/clang_64/bin:"${PATH}"
+echo "::set-env name=PATH::${PATH}"
+echo "the path is ${PATH}"
+

--- a/autobuild/mac/codeQL/autobuild_mac_2_build.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_2_build.sh
@@ -7,12 +7,13 @@
 ###  PARAMETERS  ###
 ####################
 
-echo working dir `pwd`
-echo '${0}' is "'${0}'"
-echo '${BASH_SOURCE[0]}' is "'${BASH_SOURCE[0]}'"
-echo '$THIS_JAMULUS_PROJECT_PATH' is "'${THIS_JAMULUS_PROJECT_PATH}'"
+#echo working dir `pwd`
+#echo '${0}' is "'${0}'"
+#echo '${BASH_SOURCE[0]}' is "'${BASH_SOURCE[0]}'"
+#echo '$THIS_JAMULUS_PROJECT_PATH' is "'${THIS_JAMULUS_PROJECT_PATH}'"
 
-source "$(dirname $(readlink "${0}"))/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
+#source "$(dirname $(readlink "${0}"))/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################
 ###  PROCEDURE  ###

--- a/autobuild/mac/codeQL/autobuild_mac_2_build.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_2_build.sh
@@ -7,7 +7,7 @@
 ###  PARAMETERS  ###
 ####################
 
-source $(dirname $(readlink "${0}"))/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh
+source "$(dirname $(readlink "${0}"))/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################
 ###  PROCEDURE  ###
@@ -17,12 +17,7 @@ cd "${THIS_JAMULUS_PROJECT_PATH}"
 
 
 echo "Building... qmake"
-if [-x /Users/runner/work/jamulus/jamulus/Qt/5.9.9/clang_64/bin/qmake]
-then
-    /Users/runner/work/jamulus/jamulus/Qt/5.9.9/clang_64/bin/qmake
-else
-    qmake
-fi
+qmake
 
 echo "Building... make"
 make

--- a/autobuild/mac/codeQL/autobuild_mac_2_build.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_2_build.sh
@@ -7,6 +7,11 @@
 ###  PARAMETERS  ###
 ####################
 
+echo working dir `pwd`
+echo '${0}' is "'${0}'"
+echo '${BASH_SOURCE[0]}' is "'${BASH_SOURCE[0]}'"
+echo '$THIS_JAMULUS_PROJECT_PATH' is "'${THIS_JAMULUS_PROJECT_PATH}'"
+
 source "$(dirname $(readlink "${0}"))/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################

--- a/autobuild/mac/codeQL/autobuild_mac_2_build.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_2_build.sh
@@ -17,9 +17,9 @@ cd "${THIS_JAMULUS_PROJECT_PATH}"
 
 
 echo "Building... qmake"
-if [-x /Users/runner/work/jamulus/jamulus/Qt/5.15.2/clang_64/bin/qmake]
+if [-x /Users/runner/work/jamulus/jamulus/Qt/5.9.9/clang_64/bin/qmake]
 then
-    /Users/runner/work/jamulus/jamulus/Qt/5.15.2/clang_64/bin/qmake
+    /Users/runner/work/jamulus/jamulus/Qt/5.9.9/clang_64/bin/qmake
 else
     qmake
 fi

--- a/autobuild/mac/codeQL/autobuild_mac_2_build.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_2_build.sh
@@ -7,12 +7,6 @@
 ###  PARAMETERS  ###
 ####################
 
-#echo working dir `pwd`
-#echo '${0}' is "'${0}'"
-#echo '${BASH_SOURCE[0]}' is "'${BASH_SOURCE[0]}'"
-#echo '$THIS_JAMULUS_PROJECT_PATH' is "'${THIS_JAMULUS_PROJECT_PATH}'"
-
-#source "$(dirname $(readlink "${0}"))/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################


### PR DESCRIPTION
CodeQL for Mac is now failing with `brew`. This PR uses the same `aqtinstall` as the artifact build scripts, and makes CodeQL succeed again.