### PR TITLE
Jamulus.pro: Support CONFIG+=debug

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -8,11 +8,11 @@ contains(CONFIG, "noupcasename") {
 
 # allow detailed version info for intermediate builds (#475)
 contains(VERSION, .*dev.*) {
-    exists(".git/config"){
+    exists(".git/config") {
         GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty) # the match should never match
         VERSION = "$$VERSION"-$$GIT_DESCRIPTION
         message("building version \"$$VERSION\" (intermediate in git repository)")
-    }else{
+    } else {
         VERSION = "$$VERSION"-nogit
         message("building version \"$$VERSION\" (intermediate without git repository)")
     }

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -22,8 +22,7 @@ contains(VERSION, .*dev.*) {
 
 CONFIG += qt \
     thread \
-    lrelease \
-    release
+    lrelease
 
 QT += network \
     xml \


### PR DESCRIPTION
Previously, there was -- to my knowledge -- no way to create non-release builds without editing Jamulus.pro. This commit only adds CONFIG+=release when CONFIG does not contain "debug".

Per the [docs](https://doc.qt.io/qt-5/qmake-project-files.html#general-configuration):
> The project can be built in release mode or debug mode, or both. If debug and release are both specified, the last one takes effect.

----

A second commit in this PR fixes some whitespace in Jamulus.pro.