### PR TITLE
Use exec when starting process via the shell.

### DIFF
--- a/distributions/debian/jamulus-headless.service
+++ b/distributions/debian/jamulus-headless.service
@@ -16,7 +16,7 @@ IOSchedulingPriority=0
 
 #### Change this to publish this server, set genre, location and other parameters.
 #### See https://jamulus.io/wiki/Command-Line-Options ####
-ExecStart=/bin/sh -c '/usr/bin/jamulus-headless -s -n'
+ExecStart=/bin/sh -c 'exec /usr/bin/jamulus-headless -s -n'
 
 
 Restart=on-failure

--- a/distributions/jamulus-server.service
+++ b/distributions/jamulus-server.service
@@ -8,7 +8,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=jamulus
-ExecStart=/bin/sh -c 'exec /usr/bin/jamulus -s -n -l /var/log/jamulus -e jamulus.fischvolk.de -g -o "$(uname -n);;"'
+ExecStart=/bin/sh -c 'exec /usr/bin/jamulus -s -n -l /var/log/jamulus -e anygenre3.jamulus.io -g -o "$(uname -n);;"'
 
 [Install]
 WantedBy=multi-user.target

--- a/distributions/jamulus-server.service
+++ b/distributions/jamulus-server.service
@@ -8,7 +8,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=jamulus
-ExecStart=/bin/sh -c '/usr/bin/jamulus -s -n -l /var/log/jamulus -e jamulus.fischvolk.de -g -o "$(uname -n);;"'
+ExecStart=/bin/sh -c 'exec /usr/bin/jamulus -s -n -l /var/log/jamulus -e jamulus.fischvolk.de -g -o "$(uname -n);;"'
 
 [Install]
 WantedBy=multi-user.target

--- a/distributions/raspijamulus.sh
+++ b/distributions/raspijamulus.sh
@@ -108,7 +108,7 @@ fi
 # start Jack2 and Jamulus in headless mode
 export LD_LIBRARY_PATH="distributions/${OPUS}/.libs:distributions/jack2/build:distributions/jack2/build/common"
 distributions/jack2/build/jackd -R -T --silent -P70 -p16 -t2000 -d alsa -dhw:${ADEVICE} -p 128 -n 3 -r 48000 -s &
-./Jamulus -n -i ${JAMULUSINIFILE} -c jamulus.fischvolk.de &
+./Jamulus -n -i ${JAMULUSINIFILE} -c anygenre3.jamulus.io &
 
 echo "###---------- PRESS ANY KEY TO TERMINATE THE JAMULUS SESSION ---------###"
 read -n 1 -s -r -p ""


### PR DESCRIPTION
This fixes the signal handling issue with systemctl reported in #1515,
but still allows shell substitution of environment variables.

Also changes use of `fischvolk.de` to `jamulus.io` in examples.