### PR TITLE
Windows servers: Use Qt::PreciseTimer for maximal precision

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -58,6 +58,8 @@ CHighPrecisionTimer::CHighPrecisionTimer ( const bool bNewUseDoubleSystemFrameSi
     veciTimeOutIntervals[1] = 1;
     veciTimeOutIntervals[2] = 0;
 
+    Timer.setTimerType ( Qt::PreciseTimer );
+
     // connect timer timeout signal
     QObject::connect ( &Timer, &QTimer::timeout,
         this, &CHighPrecisionTimer::OnTimer );


### PR DESCRIPTION
I'm not sure if this makes a real difference, but I don't see any reason not to use the best precision available here.

```
According to https://doc.qt.io/qt-5/qtimer.html#timerType-prop

    The default value for this property is Qt::CoarseTimer.

According to https://doc.qt.io/qt-5/qt.html#TimerType-enum

    On Windows, Qt will use Windows's Multimedia timer facility (if
    available) for Qt::PreciseTimer and normal Windows timers for
    Qt::CoarseTimer
```