### PR TITLE
Favorites functionality

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -96,15 +96,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     butConnect->setAccessibleName ( tr ( "Connect and disconnect toggle button" ) );
 
-
-    // add to favorites button
-    butAddtoFavorites->setWhatsThis ( "<b>" + tr ( "Add to Favorites Button" ) + ":</b> " +
-        tr ( "Click this button to add the currently connected server to the Favorites list"
-        "of the Connect window.  This button is disabled when not connected to a server." ) );
-
-    butAddtoFavorites->setAccessibleName (
-        tr ( "Add to Favorites button" ) );
-
     // reverberation level
     QString strAudReverb = "<b>" + tr ( "Reverb effect" ) + ":</b> " +
                            tr ( "Reverb can be applied to one local mono audio channel or to both "
@@ -348,12 +339,20 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     pEditMenu->addAction ( tr ( "Auto-Adjust all &Faders" ), this, SLOT ( OnAutoAdjustAllFaderLevels() ), QKeySequence ( Qt::CTRL + Qt::Key_F ) );
 
+    // Add to Favorites "button" -----------------------------------------------
+    paFAVAction = new QAction ( tr ( "Add to &Favorites" ) );
+    QObject::connect ( paFAVAction, SIGNAL( triggered() ), &ConnectDlg, SLOT( OnAddtoFavorites() ) );
+    paFAVAction->setEnabled ( false );
+
     // Main menu bar -----------------------------------------------------------
     QMenuBar* pMenu = new QMenuBar ( this );
 
     pMenu->addMenu ( pFileMenu );
     pMenu->addMenu ( pViewMenu );
     pMenu->addMenu ( pEditMenu );
+    pMenu->addMenu ( "|" );
+    pMenu->addAction ( paFAVAction );
+    pMenu->addMenu ( "|" );
     pMenu->addMenu ( new CHelpMenu ( true, this ) );
 
     // Now tell the layout about the menu
@@ -397,9 +396,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // Connections -------------------------------------------------------------
     // push buttons
     QObject::connect ( butConnect, &QPushButton::clicked, this, &CClientDlg::OnConnectDisconBut );
-
-    QObject::connect ( butAddtoFavorites, &QPushButton::clicked,
-        &ConnectDlg, &CConnectDlg::OnAddtoFavorites );
 
     // check boxes
     QObject::connect ( chbSettings, &QCheckBox::stateChanged, this, &CClientDlg::OnSettingsStateChanged );
@@ -509,12 +505,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                        this,
                        &CClientDlg::OnCreateCLServerListReqConnClientsListMes );
 
-<<<<<<< HEAD
-    QObject::connect ( &ConnectDlg, &CConnectDlg::accepted, this, &CClientDlg::OnConnectDlgAccepted );
-=======
     // disable Add to Favorites button by default
-    butAddtoFavorites->setEnabled(false);
->>>>>>> 2eaf6151 (Favorites functionality)
+    paFAVAction->setEnabled( false );
 
     // Initializations which have to be done after the signals are connected ---
     // start timer for status bar
@@ -713,14 +705,10 @@ void CClientDlg::OnConnectDisconBut()
     if ( pClient->IsRunning() )
     {
         Disconnect();
-<<<<<<< HEAD
-        SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
-=======
         SetMixerBoardDeco( RS_UNDEFINED, pClient->GetGUIDesign() );
 
         // disable Add to Favorites button
-        butAddtoFavorites->setEnabled(false);
->>>>>>> 2eaf6151 (Favorites functionality)
+        paFAVAction->setEnabled( false );
     }
     else
     {
@@ -1191,7 +1179,7 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
         MainMixerBoard->SetServerName ( strMixerBoardLabel );
 
         // enable Add to Favorites button
-        butAddtoFavorites->setEnabled(true);
+        paFAVAction->setEnabled( true );
 
         // start timer for level meter bar and ping time measurement
         TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -339,10 +339,17 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     pEditMenu->addAction ( tr ( "Auto-Adjust all &Faders" ), this, SLOT ( OnAutoAdjustAllFaderLevels() ), QKeySequence ( Qt::CTRL + Qt::Key_F ) );
 
-    // Add to Favorites "button" -----------------------------------------------
-    paFAVAction = new QAction ( tr ( "Add to &Favorites" ) );
+    // Favorites menu  --------------------------------------------------------------
+    paFAVAction = new QAction ( tr ( "&Add to Favorites" ) );
     QObject::connect ( paFAVAction, SIGNAL ( triggered() ), &ConnectDlg, SLOT ( OnAddtoFavorites() ) );
     paFAVAction->setEnabled ( false );
+    paFAVAction->setShortcut ( Qt::CTRL + Qt::Key_A );
+
+    QMenu* pFavoritesMenu = new QMenu ( tr ( "Fav&orites" ), this );
+
+    pFavoritesMenu->addAction ( paFAVAction );
+
+    pFavoritesMenu->addAction ( tr ( "Sho&w Favorites..." ), this, SLOT ( OnOpenFavoritesConnectionDialog() ), QKeySequence ( Qt::CTRL + Qt::Key_W ) );
 
     // Main menu bar -----------------------------------------------------------
     QMenuBar* pMenu = new QMenuBar ( this );
@@ -350,9 +357,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pMenu->addMenu ( pFileMenu );
     pMenu->addMenu ( pViewMenu );
     pMenu->addMenu ( pEditMenu );
-    pMenu->addMenu ( "|" );
-    pMenu->addAction ( paFAVAction );
-    pMenu->addMenu ( "|" );
+    pMenu->addMenu ( pFavoritesMenu );
     pMenu->addMenu ( new CHelpMenu ( true, this ) );
 
     // Now tell the layout about the menu
@@ -911,6 +916,14 @@ void CClientDlg::SetMyWindowTitle ( const int iNumClients )
     }
 #    endif
 #endif
+}
+
+void CClientDlg::ShowFavoritesConnectionDialog()
+{
+    // set to Favorites Tab
+    pSettings->bFavoriteWasShownConnect = true;
+    // show connect dialog
+    ShowConnectionSetupDialog();
 }
 
 void CClientDlg::ShowConnectionSetupDialog()

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -96,6 +96,15 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     butConnect->setAccessibleName ( tr ( "Connect and disconnect toggle button" ) );
 
+
+    // add to favorites button
+    butAddtoFavorites->setWhatsThis ( "<b>" + tr ( "Add to Favorites Button" ) + ":</b> " +
+        tr ( "Click this button to add the currently connected server to the Favorites list"
+        "of the Connect window.  This button is disabled when not connected to a server." ) );
+
+    butAddtoFavorites->setAccessibleName (
+        tr ( "Add to Favorites button" ) );
+
     // reverberation level
     QString strAudReverb = "<b>" + tr ( "Reverb effect" ) + ":</b> " +
                            tr ( "Reverb can be applied to one local mono audio channel or to both "
@@ -389,6 +398,9 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // push buttons
     QObject::connect ( butConnect, &QPushButton::clicked, this, &CClientDlg::OnConnectDisconBut );
 
+    QObject::connect ( butAddtoFavorites, &QPushButton::clicked,
+        &ConnectDlg, &CConnectDlg::OnAddtoFavorites );
+
     // check boxes
     QObject::connect ( chbSettings, &QCheckBox::stateChanged, this, &CClientDlg::OnSettingsStateChanged );
 
@@ -497,7 +509,12 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                        this,
                        &CClientDlg::OnCreateCLServerListReqConnClientsListMes );
 
+<<<<<<< HEAD
     QObject::connect ( &ConnectDlg, &CConnectDlg::accepted, this, &CClientDlg::OnConnectDlgAccepted );
+=======
+    // disable Add to Favorites button by default
+    butAddtoFavorites->setEnabled(false);
+>>>>>>> 2eaf6151 (Favorites functionality)
 
     // Initializations which have to be done after the signals are connected ---
     // start timer for status bar
@@ -696,7 +713,14 @@ void CClientDlg::OnConnectDisconBut()
     if ( pClient->IsRunning() )
     {
         Disconnect();
+<<<<<<< HEAD
         SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
+=======
+        SetMixerBoardDeco( RS_UNDEFINED, pClient->GetGUIDesign() );
+
+        // disable Add to Favorites button
+        butAddtoFavorites->setEnabled(false);
+>>>>>>> 2eaf6151 (Favorites functionality)
     }
     else
     {
@@ -1165,6 +1189,9 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
 
         // set server name in audio mixer group box title
         MainMixerBoard->SetServerName ( strMixerBoardLabel );
+
+        // enable Add to Favorites button
+        butAddtoFavorites->setEnabled(true);
 
         // start timer for level meter bar and ping time measurement
         TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -505,6 +505,9 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                        this,
                        &CClientDlg::OnCreateCLServerListReqConnClientsListMes );
 
+    QObject::connect ( &ConnectDlg, &CConnectDlg::accepted,
+        this, &CClientDlg::OnConnectDlgAccepted );
+
     // disable Add to Favorites button by default
     paFAVAction->setEnabled( false );
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -349,7 +349,10 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     pFavoritesMenu->addAction ( paFAVAction );
 
-    pFavoritesMenu->addAction ( tr ( "Sho&w Favorites..." ), this, SLOT ( OnOpenFavoritesConnectionDialog() ), QKeySequence ( Qt::CTRL + Qt::Key_W ) );
+    pFavoritesMenu->addAction ( tr ( "Sho&w Favorites..." ),
+                                this,
+                                SLOT ( OnOpenFavoritesConnectionDialog() ),
+                                QKeySequence ( Qt::CTRL + Qt::Key_W ) );
 
     // Main menu bar -----------------------------------------------------------
     QMenuBar* pMenu = new QMenuBar ( this );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -341,7 +341,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     // Add to Favorites "button" -----------------------------------------------
     paFAVAction = new QAction ( tr ( "Add to &Favorites" ) );
-    QObject::connect ( paFAVAction, SIGNAL( triggered() ), &ConnectDlg, SLOT( OnAddtoFavorites() ) );
+    QObject::connect ( paFAVAction, SIGNAL ( triggered() ), &ConnectDlg, SLOT ( OnAddtoFavorites() ) );
     paFAVAction->setEnabled ( false );
 
     // Main menu bar -----------------------------------------------------------
@@ -505,11 +505,10 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                        this,
                        &CClientDlg::OnCreateCLServerListReqConnClientsListMes );
 
-    QObject::connect ( &ConnectDlg, &CConnectDlg::accepted,
-        this, &CClientDlg::OnConnectDlgAccepted );
+    QObject::connect ( &ConnectDlg, &CConnectDlg::accepted, this, &CClientDlg::OnConnectDlgAccepted );
 
     // disable Add to Favorites button by default
-    paFAVAction->setEnabled( false );
+    paFAVAction->setEnabled ( false );
 
     // Initializations which have to be done after the signals are connected ---
     // start timer for status bar
@@ -708,10 +707,10 @@ void CClientDlg::OnConnectDisconBut()
     if ( pClient->IsRunning() )
     {
         Disconnect();
-        SetMixerBoardDeco( RS_UNDEFINED, pClient->GetGUIDesign() );
+        SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
 
         // disable Add to Favorites button
-        paFAVAction->setEnabled( false );
+        paFAVAction->setEnabled ( false );
     }
     else
     {
@@ -1182,7 +1181,7 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
         MainMixerBoard->SetServerName ( strMixerBoardLabel );
 
         // enable Add to Favorites button
-        paFAVAction->setEnabled( true );
+        paFAVAction->setEnabled ( true );
 
         // start timer for level meter bar and ping time measurement
         TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -84,42 +84,40 @@ public:
                  QWidget*         parent = nullptr );
 
 protected:
-    void               SetGUIDesign ( const EGUIDesign eNewDesign );
-    void               SetMyWindowTitle ( const int iNumClients );
-    void               ShowConnectionSetupDialog();
-    void               ShowMusicianProfileDialog();
-    void               ShowGeneralSettings( int );
-    void               ShowChatWindow ( const bool bForceRaise = true );
-    void               ShowAnalyzerConsole();
-    void               UpdateAudioFaderSlider();
-    void               UpdateRevSelection();
-    void               Connect ( const QString& strSelectedAddress,
-                                 const QString& strMixerBoardLabel );
-    void               Disconnect();
-    void               ManageDragNDrop ( QDropEvent* Event,
-                                         const bool  bCheckAccept );
+    void SetGUIDesign ( const EGUIDesign eNewDesign );
+    void SetMyWindowTitle ( const int iNumClients );
+    void ShowConnectionSetupDialog();
+    void ShowMusicianProfileDialog();
+    void ShowGeneralSettings ( int );
+    void ShowChatWindow ( const bool bForceRaise = true );
+    void ShowAnalyzerConsole();
+    void UpdateAudioFaderSlider();
+    void UpdateRevSelection();
+    void Connect ( const QString& strSelectedAddress, const QString& strMixerBoardLabel );
+    void Disconnect();
+    void ManageDragNDrop ( QDropEvent* Event, const bool bCheckAccept );
 
-    CClient*           pClient;
-    CClientSettings*   pSettings;
-    QAction *          paFAVAction;
+    CClient*         pClient;
+    CClientSettings* pSettings;
+    QAction*         paFAVAction;
 
-    bool               bConnected;
-    bool               bConnectDlgWasShown;
-    bool               bMIDICtrlUsed;
-    bool               bDetectFeedback;
-    ERecorderState     eLastRecorderState;
-    EGUIDesign         eLastDesign;
-    QTimer             TimerSigMet;
-    QTimer             TimerBuffersLED;
-    QTimer             TimerStatus;
-    QTimer             TimerPing;
-    QTimer             TimerCheckAudioDeviceOk;
-    QTimer             TimerDetectFeedback;
+    bool           bConnected;
+    bool           bConnectDlgWasShown;
+    bool           bMIDICtrlUsed;
+    bool           bDetectFeedback;
+    ERecorderState eLastRecorderState;
+    EGUIDesign     eLastDesign;
+    QTimer         TimerSigMet;
+    QTimer         TimerBuffersLED;
+    QTimer         TimerStatus;
+    QTimer         TimerPing;
+    QTimer         TimerCheckAudioDeviceOk;
+    QTimer         TimerDetectFeedback;
 
-    virtual void       closeEvent     ( QCloseEvent*     Event );
-    virtual void       dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }
-    virtual void       dropEvent      ( QDropEvent*      Event ) { ManageDragNDrop ( Event, false ); }
-    void               UpdateDisplay();
+    virtual void closeEvent ( QCloseEvent* Event );
+    virtual void dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }
+    virtual void dropEvent ( QDropEvent* Event ) { ManageDragNDrop ( Event, false ); }
+    void         UpdateDisplay();
 
     CClientSettingsDlg ClientSettingsDlg;
     CChatDlg           ChatDlg;

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -87,8 +87,7 @@ protected:
     void SetGUIDesign ( const EGUIDesign eNewDesign );
     void SetMyWindowTitle ( const int iNumClients );
     void ShowConnectionSetupDialog();
-    void ShowMusicianProfileDialog();
-    void ShowGeneralSettings ( int );
+    void ShowGeneralSettings ( int iTab );
     void ShowChatWindow ( const bool bForceRaise = true );
     void ShowAnalyzerConsole();
     void UpdateAudioFaderSlider();

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -84,38 +84,40 @@ public:
                  QWidget*         parent = nullptr );
 
 protected:
-    void SetGUIDesign ( const EGUIDesign eNewDesign );
-    void SetMyWindowTitle ( const int iNumClients );
-    void ShowConnectionSetupDialog();
-    void ShowGeneralSettings ( int iTab );
-    void ShowChatWindow ( const bool bForceRaise = true );
-    void ShowAnalyzerConsole();
-    void UpdateAudioFaderSlider();
-    void UpdateRevSelection();
-    void Connect ( const QString& strSelectedAddress, const QString& strMixerBoardLabel );
-    void Disconnect();
-    void ManageDragNDrop ( QDropEvent* Event, const bool bCheckAccept );
+    void               SetGUIDesign ( const EGUIDesign eNewDesign );
+    void               SetMyWindowTitle ( const int iNumClients );
+    void               ShowConnectionSetupDialog();
+    void               ShowMusicianProfileDialog();
+    void               ShowGeneralSettings();
+    void               ShowChatWindow ( const bool bForceRaise = true );
+    void               ShowAnalyzerConsole();
+    void               UpdateAudioFaderSlider();
+    void               UpdateRevSelection();
+    void               Connect ( const QString& strSelectedAddress,
+                                 const QString& strMixerBoardLabel );
+    void               Disconnect();
+    void               ManageDragNDrop ( QDropEvent* Event,
+                                         const bool  bCheckAccept );
 
-    CClient*         pClient;
-    CClientSettings* pSettings;
+    CClient*           pClient;
+    CClientSettings*   pSettings;
+    QAction *          paFAVAction;
 
-    bool           bConnected;
-    bool           bConnectDlgWasShown;
-    bool           bMIDICtrlUsed;
-    bool           bDetectFeedback;
-    ERecorderState eLastRecorderState;
-    EGUIDesign     eLastDesign;
-    QTimer         TimerSigMet;
-    QTimer         TimerBuffersLED;
-    QTimer         TimerStatus;
-    QTimer         TimerPing;
-    QTimer         TimerCheckAudioDeviceOk;
-    QTimer         TimerDetectFeedback;
+    bool               bConnected;
+    bool               bConnectDlgWasShown;
+    bool               bMIDICtrlUsed;
+    ERecorderState     eLastRecorderState;
+    EGUIDesign         eLastDesign;
+    QTimer             TimerSigMet;
+    QTimer             TimerBuffersLED;
+    QTimer             TimerStatus;
+    QTimer             TimerPing;
+    QTimer             TimerCheckAudioDeviceOk;
 
-    virtual void closeEvent ( QCloseEvent* Event );
-    virtual void dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }
-    virtual void dropEvent ( QDropEvent* Event ) { ManageDragNDrop ( Event, false ); }
-    void         UpdateDisplay();
+    virtual void       closeEvent     ( QCloseEvent*     Event );
+    virtual void       dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }
+    virtual void       dropEvent      ( QDropEvent*      Event ) { ManageDragNDrop ( Event, false ); }
+    void               UpdateDisplay();
 
     CClientSettingsDlg ClientSettingsDlg;
     CChatDlg           ChatDlg;

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -87,6 +87,7 @@ protected:
     void SetGUIDesign ( const EGUIDesign eNewDesign );
     void SetMyWindowTitle ( const int iNumClients );
     void ShowConnectionSetupDialog();
+    void ShowFavoritesConnectionDialog();
     void ShowGeneralSettings ( int iTab );
     void ShowChatWindow ( const bool bForceRaise = true );
     void ShowAnalyzerConsole();
@@ -151,6 +152,7 @@ public slots:
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }
+    void OnOpenFavoritesConnectionDialog() { ShowFavoritesConnectionDialog(); }
     void OnOpenUserProfileSettings();
     void OnOpenAudioNetSettings();
     void OnOpenAdvancedSettings();

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -88,7 +88,7 @@ protected:
     void               SetMyWindowTitle ( const int iNumClients );
     void               ShowConnectionSetupDialog();
     void               ShowMusicianProfileDialog();
-    void               ShowGeneralSettings();
+    void               ShowGeneralSettings( int );
     void               ShowChatWindow ( const bool bForceRaise = true );
     void               ShowAnalyzerConsole();
     void               UpdateAudioFaderSlider();
@@ -106,6 +106,7 @@ protected:
     bool               bConnected;
     bool               bConnectDlgWasShown;
     bool               bMIDICtrlUsed;
+    bool               bDetectFeedback;
     ERecorderState     eLastRecorderState;
     EGUIDesign         eLastDesign;
     QTimer             TimerSigMet;
@@ -113,6 +114,7 @@ protected:
     QTimer             TimerStatus;
     QTimer             TimerPing;
     QTimer             TimerCheckAudioDeviceOk;
+    QTimer             TimerDetectFeedback;
 
     virtual void       closeEvent     ( QCloseEvent*     Event );
     virtual void       dragEnterEvent ( QDragEnterEvent* Event ) { ManageDragNDrop ( Event, true ); }

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -583,7 +583,10 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>butConnect</tabstop>
   <tabstop>chbLocalMute</tabstop>
+  <tabstop>chbSettings</tabstop>
+  <tabstop>chbChat</tabstop>
   <tabstop>sldAudioReverb</tabstop>
   <tabstop>rbtReverbSelL</tabstop>
   <tabstop>rbtReverbSelR</tabstop>

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -478,16 +478,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QPushButton" name="butAddtoFavorites">
-            <property name="styleSheet">
-             <string notr="true"/>
-            </property>
-            <property name="text">
-             <string>Add to Favorites</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
         <item>

--- a/src/clientdlgbase.ui
+++ b/src/clientdlgbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
-    <height>490</height>
+    <width>462</width>
+    <height>546</height>
    </rect>
   </property>
   <property name="acceptDrops">
@@ -53,7 +53,7 @@
      <property name="frameShadow">
       <enum>QFrame::Plain</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
@@ -73,7 +73,7 @@
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>20</width>
-                  <height>10</height>
+                  <height>5</height>
                  </size>
                 </property>
                </spacer>
@@ -105,7 +105,7 @@
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>10</width>
-                  <height>10</height>
+                  <height>5</height>
                  </size>
                 </property>
                </spacer>
@@ -211,6 +211,9 @@
                <spacer>
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::MinimumExpanding</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -475,6 +478,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QPushButton" name="butAddtoFavorites">
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
+            <property name="text">
+             <string>Add to Favorites</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>
@@ -485,65 +498,72 @@
          </widget>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout">
+         <layout class="QVBoxLayout">
           <item>
-           <widget class="QLabel" name="lblGlobalInfoLabel">
-            <property name="text">
-             <string>MUTED (Other people won't hear you)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="margin">
-             <number>6</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_2">
-            <property name="sizeConstraint">
-             <enum>QLayout::SetMinimumSize</enum>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>9</number>
+           <layout class="QVBoxLayout">
+            <property name="spacing">
+             <number>3</number>
             </property>
             <item>
-             <widget class="QLabel" name="lblConnectToServer">
+             <widget class="QLabel" name="lblGlobalInfoLabel">
+              <property name="text">
+               <string>MUTED (Other people won't hear you)</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="margin">
+               <number>6</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <property name="sizeConstraint">
+               <enum>QLayout::SetMinimumSize</enum>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>9</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="lblConnectToServer">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Set up your audio, connect to a server and start jamming!</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblUpdateCheck">
               <property name="text">
-               <string>Set up your audio, connect to a server and start jamming!</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <string>Update check</string>
               </property>
              </widget>
             </item>
            </layout>
-          </item>
-          <item>
-           <widget class="CAudioMixerBoard" name="MainMixerBoard" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="lblUpdateCheck">
-            <property name="text">
-             <string>Update check</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </item>
@@ -573,10 +593,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>butConnect</tabstop>
   <tabstop>chbLocalMute</tabstop>
-  <tabstop>chbSettings</tabstop>
-  <tabstop>chbChat</tabstop>
   <tabstop>sldAudioReverb</tabstop>
   <tabstop>rbtReverbSelL</tabstop>
   <tabstop>rbtReverbSelR</tabstop>

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -34,9 +34,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
 #if defined( Q_OS_IOS )
     // IOS needs menu to close
-    QMenuBar* pMenu  = new QMenuBar ( this );
-    QAction*  action = pMenu->addAction ( tr ( "&Close" ) );
     QMenuBar* pMenu = new QMenuBar ( this );
+    QAction*  action = pMenu->addAction ( tr ( "&Close" ) );
     connect ( action, SIGNAL ( triggered() ), this, SLOT ( close() ) );
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -36,8 +36,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     // IOS needs menu to close
     QMenuBar* pMenu  = new QMenuBar ( this );
     QAction*  action = pMenu->addAction ( tr ( "&Close" ) );
+    QMenuBar* pMenu = new QMenuBar ( this );
     connect ( action, SIGNAL ( triggered() ), this, SLOT ( close() ) );
-
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );
 #endif

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -34,7 +34,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
 #if defined( Q_OS_IOS )
     // IOS needs menu to close
-    QMenuBar* pMenu = new QMenuBar ( this );
+    QMenuBar* pMenu  = new QMenuBar ( this );
     QAction*  action = pMenu->addAction ( tr ( "&Close" ) );
     connect ( action, SIGNAL ( triggered() ), this, SLOT ( close() ) );
     // Now tell the layout about the menu

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -37,6 +37,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     QMenuBar* pMenu  = new QMenuBar ( this );
     QAction*  action = pMenu->addAction ( tr ( "&Close" ) );
     connect ( action, SIGNAL ( triggered() ), this, SLOT ( close() ) );
+
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );
 #endif

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -25,45 +25,43 @@
 #include "connectdlg.h"
 
 /* Implementation *************************************************************/
-CConnectDlg::CConnectDlg ( CClientSettings* pNSetP,
-                           const bool       bNewShowCompleteRegList,
-                           QWidget*         parent )
-    : CBaseDlg                   ( parent, Qt::Dialog ),
-      pSettings                  ( pNSetP ),
-      strSelectedAddress         ( "" ),
-      strSelectedServerName      ( "" ),
-      strSelectedMaxUsers        ( "" ),
-      strSelectedDirectory       ( "" ),
-      bShowCompleteRegList       ( bNewShowCompleteRegList ),
-      bServerListReceived        ( false ),
-      bReducedServerListReceived ( false ),
-      bServerListItemWasChosen   ( false ),
-      bListFilterWasActive       ( false ),
-      bShowAllMusicians          ( true )
+CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteRegList, QWidget* parent ) :
+    CBaseDlg ( parent, Qt::Dialog ),
+    pSettings ( pNSetP ),
+    strSelectedAddress ( "" ),
+    strSelectedServerName ( "" ),
+    strSelectedMaxUsers ( "" ),
+    strSelectedDirectory ( "" ),
+    bShowCompleteRegList ( bNewShowCompleteRegList ),
+    bServerListReceived ( false ),
+    bReducedServerListReceived ( false ),
+    bServerListItemWasChosen ( false ),
+    bListFilterWasActive ( false ),
+    bShowAllMusicians ( true )
 {
     setupUi ( this );
 
     // Add help text to controls -----------------------------------------------
     // server list
-    lvwServers->setWhatsThis ( "<b>" + tr ( "Server List" ) + ":</b> " + tr (
-        "The Servers tab of the Connection Setup window shows a list of available servers. "
-        "Server operators can optionally list their servers by music genre. "
-        "Use the List dropdown to select a genre, click on the server you want "
-        "to join and press the Connect button to connect to it. Alternatively, "
-        "double click on on the server name. Permanent servers (those that have "
-        "been listed for longer than 48 hours) are shown in bold." ) );
+    lvwServers->setWhatsThis ( "<b>" + tr ( "Server List" ) + ":</b> " +
+                               tr ( "The Servers tab of the Connection Setup window shows a list of available servers. "
+                                    "Server operators can optionally list their servers by music genre. "
+                                    "Use the List dropdown to select a genre, click on the server you want "
+                                    "to join and press the Connect button to connect to it. Alternatively, "
+                                    "double click on on the server name. Permanent servers (those that have "
+                                    "been listed for longer than 48 hours) are shown in bold." ) );
 
     lvwServers->setAccessibleName ( tr ( "Server list view" ) );
 
     // favorites list
-    lvwFavorites->setWhatsThis ( "<b>" + tr ( "Favorites List" ) + ":</b> " + tr (
-        "The Favorites tab of the Connection Setup window shows a list servers you have chosen "
-        "as your Favorites. "
-        "Once you have connected to a server using the Servers tab you can include it in this "
-        "Favorites list by clicking the Add to Favorites button on the main window. "
-        "This works for all servers either public or private. The last used server is shown in the"
-        "top line and is selected by default.  To use that last used server again simply open "
-        "the Connect window to Favorites and click Connect. " ) );
+    lvwFavorites->setWhatsThis ( "<b>" + tr ( "Favorites List" ) + ":</b> " +
+                                 tr ( "The Favorites tab of the Connection Setup window shows a list servers you have chosen "
+                                      "as your Favorites. "
+                                      "Once you have connected to a server using the Servers tab you can include it in this "
+                                      "Favorites list by clicking the Add to Favorites button on the main window. "
+                                      "This works for all servers either public or private. The last used server is shown in the"
+                                      "top line and is selected by default.  To use that last used server again simply open "
+                                      "the Connect window to Favorites and click Connect. " ) );
 
     lvwFavorites->setAccessibleName ( tr ( "Favorites list view" ) );
 
@@ -187,12 +185,10 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP,
     // list view
     QObject::connect ( lvwServers, &QTreeWidget::itemDoubleClicked, this, &CConnectDlg::OnServerListItemDoubleClicked );
 
-    QObject::connect ( lvwFavorites, &QTreeWidget::itemDoubleClicked,
-        this, &CConnectDlg::OnServerListItemDoubleClicked );
+    QObject::connect ( lvwFavorites, &QTreeWidget::itemDoubleClicked, this, &CConnectDlg::OnServerListItemDoubleClicked );
 
     // tab view
-    QObject::connect ( tabConnect, &QTabWidget::currentChanged,
-        this, &CConnectDlg::OnTabChange );
+    QObject::connect ( tabConnect, &QTabWidget::currentChanged, this, &CConnectDlg::OnTabChange );
 
     // to get default return key behaviour working
     QObject::connect ( lvwServers, &QTreeWidget::activated, this, &CConnectDlg::OnConnectClicked );
@@ -211,15 +207,12 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP,
     // check boxes
     QObject::connect ( chbExpandAll, &QCheckBox::stateChanged, this, &CConnectDlg::OnExpandAllStateChanged );
 
-    QObject::connect ( chbExpandAllFAV, &QCheckBox::stateChanged,
-        this, &CConnectDlg::OnExpandAllStateChanged );
+    QObject::connect ( chbExpandAllFAV, &QCheckBox::stateChanged, this, &CConnectDlg::OnExpandAllStateChanged );
 
     // radio buttons
-    QObject::connect ( rbFavSort1, &QRadioButton::clicked,
-        this, &CConnectDlg::OnSortLastUsed );
+    QObject::connect ( rbFavSort1, &QRadioButton::clicked, this, &CConnectDlg::OnSortLastUsed );
 
-    QObject::connect ( rbFavSort2, &QRadioButton::clicked,
-        this, &CConnectDlg::OnSortDirectory );
+    QObject::connect ( rbFavSort2, &QRadioButton::clicked, this, &CConnectDlg::OnSortDirectory );
 
     // buttons
     QObject::connect ( butCancel, &QPushButton::clicked, this, &CConnectDlg::close );
@@ -237,7 +230,7 @@ void CConnectDlg::showEvent ( QShowEvent* )
     // load stored IP addresses in combo box
     cbxServerAddr->clear();
     cbxServerAddr->clearEditText();
-    bServerListItemWasChosen   = false;
+    bServerListItemWasChosen = false;
 
     for ( int iLEIdx = 0; iLEIdx < MAX_NUM_SERVER_ADDR_ITEMS; iLEIdx++ )
     {
@@ -247,15 +240,15 @@ void CConnectDlg::showEvent ( QShowEvent* )
         }
     }
 
-    tabConnect->setCurrentIndex( pSettings->bFavoriteWasShownConnect );
+    tabConnect->setCurrentIndex ( pSettings->bFavoriteWasShownConnect );
 
     if ( pSettings->iFavSort == FAVSORT_LASTUSED )
     {
-        rbFavSort1->setChecked( true );
+        rbFavSort1->setChecked ( true );
     }
     else
     {
-        rbFavSort2->setChecked( true );
+        rbFavSort2->setChecked ( true );
     }
 
     if ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
@@ -339,44 +332,42 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
     }
     else
     {
-        UpdateFAVIPs ( InetAddr, vecServerInfo, bIsReducedServerList );
+        UpdateFAVIPs ( vecServerInfo, bIsReducedServerList );
     }
 }
 
-void CConnectDlg::UpdateFAVIPs( const CHostAddress&         InetAddr,
-                                 const CVector<CServerInfo>& vecServerInfo,
-                                 const bool                  bIsReducedServerList )
+void CConnectDlg::UpdateFAVIPs ( const CVector<CServerInfo>& vecServerInfo, const bool bIsReducedServerList )
 {
 
     if ( bServerListReceived || bIsReducedServerList )
     {
         return;
     }
-    const int iServerInfoLen = vecServerInfo.Size();
-    const int iServerListLen = lvwFavorites->topLevelItemCount();
-    int qtyThisDirectory = 0;
+    const int iServerInfoLen   = vecServerInfo.Size();
+    const int iServerListLen   = lvwFavorites->topLevelItemCount();
+    int       qtyThisDirectory = 0;
 
     // to shorten search, find quantity of servers from this directory
     for ( int iJdx = 0; iJdx < iServerListLen; iJdx++ )
     {
-        if( lvwFavorites->topLevelItem ( iJdx )->data ( 3, Qt::UserRole ) == ecsSelectedDirectECS )
+        if ( lvwFavorites->topLevelItem ( iJdx )->data ( 3, Qt::UserRole ) == ecsSelectedDirectECS )
         {
-           qtyThisDirectory++;
+            qtyThisDirectory++;
         }
     }
 
-    for ( int iIdx = 0; qtyThisDirectory && (iIdx < iServerInfoLen); iIdx++ )
+    for ( int iIdx = 0; qtyThisDirectory && ( iIdx < iServerInfoLen ); iIdx++ )
     {
         for ( int iJdx = 0; iJdx < iServerListLen; iJdx++ )
         {
             // if right directory server and identical name strings
             if ( ( lvwFavorites->topLevelItem ( iJdx )->data ( 3, Qt::UserRole ) == ecsSelectedDirectECS ) &&
-                 ( !lvwFavorites->topLevelItem ( iJdx )->text ( 0 ).compare( vecServerInfo[iIdx].strName ) ) )
+                 ( !lvwFavorites->topLevelItem ( iJdx )->text ( 0 ).compare ( vecServerInfo[iIdx].strName ) ) )
             {
                 qtyThisDirectory--;
                 // if IP addresses are not the same, update in Favorites using value from server
                 if ( lvwFavorites->topLevelItem ( iJdx )->data ( 0, Qt::UserRole ).toString() != vecServerInfo[iIdx].HostAddr.toString() &&
-                    vecServerInfo[iIdx].HostAddr.toString() != "0.0.0.0:0" )  // special case, don't update directory servers
+                     vecServerInfo[iIdx].HostAddr.toString() != "0.0.0.0:0" ) // special case, don't update directory servers
                 {
                     lvwFavorites->topLevelItem ( iJdx )->setData ( 0, Qt::UserRole, vecServerInfo[iIdx].HostAddr.toString() );
                     pSettings->vstrFAVAddress[iJdx] = vecServerInfo[iIdx].HostAddr.toString();
@@ -392,9 +383,7 @@ void CConnectDlg::UpdateFAVIPs( const CHostAddress&         InetAddr,
     }
 }
 
-void CConnectDlg::FillServerTab( const CHostAddress&         InetAddr,
-                                 const CVector<CServerInfo>& vecServerInfo,
-                                 const bool                  bIsReducedServerList )
+void CConnectDlg::FillServerTab ( const CHostAddress& InetAddr, const CVector<CServerInfo>& vecServerInfo, const bool bIsReducedServerList )
 {
     // If the normal list was received, we do not accept any further list
     // updates (to avoid the reduced list overwrites the normal list (#657)). Also,
@@ -558,7 +547,7 @@ void CConnectDlg::FillServerTab( const CHostAddress&         InetAddr,
 void CConnectDlg::SetConnClientsList ( const CHostAddress& InetAddr, const CVector<CChannelInfo>& vecChanInfo )
 {
     // point pList to correct tab list
-    QTreeWidget * pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
+    QTreeWidget* pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
 
     // find the server with the correct address
     QTreeWidgetItem* pCurListViewItem = FindListViewItem ( InetAddr );
@@ -631,7 +620,7 @@ void CConnectDlg::SetConnClientsList ( const CHostAddress& InetAddr, const CVect
         }
 
         // the clients list may have changed, update the filter selection
-        if( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS )
+        if ( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS )
         {
             UpdateListFilter();
         }
@@ -782,11 +771,12 @@ void CConnectDlg::UpdateListFilter()
 void CConnectDlg::OnConnectClicked()
 {
     // to eliminate 2 executions on double click
-    if( bServerListItemWasChosen == true ) return;
+    if ( bServerListItemWasChosen == true )
+        return;
     bServerListItemWasChosen = true;
 
     CHostAddress CurHostAddress;
-    strSelectedMaxUsers = "";
+    strSelectedMaxUsers  = "";
     strSelectedDirectory = "";
 
     // get the IP address to be used according to the following definitions:
@@ -794,15 +784,15 @@ void CConnectDlg::OnConnectClicked()
     // - if the list has no focus, use the current combo box text
 
     // point pList to correct tab list
-    QTreeWidget * pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
+    QTreeWidget* pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
 
     QList<QTreeWidgetItem*> CurSelListItemList = pList->selectedItems();
 
     // if from Servers combobox, process and return
-    if( ( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS ) && ( CurSelListItemList.count() == 0 ) )
+    if ( ( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS ) && ( CurSelListItemList.count() == 0 ) )
     {
         NetworkUtil::ParseNetworkAddress ( cbxServerAddr->currentText(), CurHostAddress );
-        strSelectedAddress = CurHostAddress.toString();
+        strSelectedAddress    = CurHostAddress.toString();
         strSelectedServerName = cbxServerAddr->currentText();
         done ( QDialog::Accepted );
         return;
@@ -812,18 +802,18 @@ void CConnectDlg::OnConnectClicked()
 
     // get host address from selected list view item as a string
     NetworkUtil::ParseNetworkAddress ( pCurSelTopListItem->data ( 0, Qt::UserRole ).toString(), CurHostAddress );
-    strSelectedAddress = CurHostAddress.toString();
+    strSelectedAddress    = CurHostAddress.toString();
     strSelectedServerName = pCurSelTopListItem->text ( 0 );
 
     // get MaxUsers from selected list view item as a string
     strSelectedMaxUsers = pCurSelTopListItem->text ( 5 );
 
-    if( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
+    if ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
     {
         // FAV List, get Directory from list
         strSelectedDirectory = pCurSelTopListItem->text ( 3 );
 
-        if( pSettings->iFavSort == FAVSORT_DIRECTORY )
+        if ( pSettings->iFavSort == FAVSORT_DIRECTORY )
         {
             pSettings->iFavDirLastSelected = pList->indexOfTopLevelItem ( pCurSelTopListItem );
         }
@@ -837,7 +827,7 @@ void CConnectDlg::OnConnectClicked()
     else
     {
         // Server list, Directory is in combobox
-        if( pSettings->eCentralServerAddressType == AT_CUSTOM )
+        if ( pSettings->eCentralServerAddressType == AT_CUSTOM )
         {
             // if Custom, get server name from Settings
             strSelectedDirectory = "Custom: " + pSettings->vstrCentralServerAddress[0];
@@ -858,51 +848,51 @@ void CConnectDlg::OnTimerPing()
     CHostAddress ServerAddress;
 
     // point pList to correct table list
-    QTreeWidget * pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
+    QTreeWidget* pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
 
     int iServerListLen = pList->topLevelItemCount();
 
     // if Favorites, check if servers aren't responding, send server request if so to open ports
-    if( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
+    if ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
     {
         // iWasSent, bitfield to remember which directorys have been queried
         int iWasSent = 0;
 
         // pList->topLevelItem ( iIdx )->data ( 1 ) stores sequencer
-        //  val == 0, first timeout -> skip, check if no directory (privat server), set val to 4 to do no request
+        //  val == 0, first timeout -> skip, check if no directory (private server), set val to 4 to do no request
         //  val == 1, check if no ping arrived, send Server List Query to corresponding Directory if the case.
         //  val == 2, ping requested, but not seen
         //  val == 3, ping seen, set in SetPingTimeAndNumClientsResult
         //  val == 4, do nothing (privat server)
         for ( int iIdx = 0; iIdx < iServerListLen; iIdx++ )
         {
-            int iSequence = pList->topLevelItem ( iIdx )->data ( 1 , Qt::UserRole ).toInt();
+            int iSequence = pList->topLevelItem ( iIdx )->data ( 1, Qt::UserRole ).toInt();
             // skip first time
             if ( iSequence == 0 )
             {
-                if ( pList->topLevelItem ( iIdx )->text ( 3 ).isEmpty() )  // no directory server
+                if ( pList->topLevelItem ( iIdx )->text ( 3 ).isEmpty() ) // no directory server
                 {
-                    pList->topLevelItem ( iIdx )->setData ( 1 , Qt::UserRole, 4 );  // do no request
+                    pList->topLevelItem ( iIdx )->setData ( 1, Qt::UserRole, 4 ); // do no request
                     pList->topLevelItem ( iIdx )->setText ( 3, tr ( "Private Server" ) );
                 }
-                pList->topLevelItem ( iIdx )->setData ( 1 , Qt::UserRole, 1 );  // set to second time
+                pList->topLevelItem ( iIdx )->setData ( 1, Qt::UserRole, 1 ); // set to second time
             }
             else
-            // no ping seen
-            if ( iSequence == 1 )
+                // no ping seen
+                if ( iSequence == 1 )
             {
                 // if no ping response, request server list from corresponding Directory
                 ecsSelectedDirectECS = static_cast<ECSAddType> ( pList->topLevelItem ( iIdx )->data ( 3, Qt::UserRole ).toInt() );
 
                 // if this directory not previously queried
-                if ( ( iWasSent & ( 1<<( (int)ecsSelectedDirectECS ) ) ) == 0 )
+                if ( ( iWasSent & ( 1 << ( (int) ecsSelectedDirectECS ) ) ) == 0 )
                 {
-                    iWasSent |= 1<<( (int)ecsSelectedDirectECS );
+                    iWasSent |= 1 << ( (int) ecsSelectedDirectECS );
                     // set sequencer to query sent
-                    pList->topLevelItem ( iIdx )->setData ( 1 , Qt::UserRole, 2 );
-                    if ( NetworkUtil().ParseNetworkAddress ( NetworkUtil::GetCentralServerAddress ( ecsSelectedDirectECS,
-                                                                                                    pSettings->vstrCentralServerAddress[0] ),
-                                                                                                    ServerAddress ) )
+                    pList->topLevelItem ( iIdx )->setData ( 1, Qt::UserRole, 2 );
+                    if ( NetworkUtil().ParseNetworkAddress (
+                             NetworkUtil::GetCentralServerAddress ( ecsSelectedDirectECS, pSettings->vstrCentralServerAddress[0] ),
+                             ServerAddress ) )
                     {
                         // send the request for the server list
                         emit ReqServerListQuery ( ServerAddress );
@@ -911,13 +901,12 @@ void CConnectDlg::OnTimerPing()
                 }
             }
             else
-            // query sent, but no ping seen
-            if ( iSequence == 2 )
+                // query sent, but no ping seen
+                if ( iSequence == 2 )
             {
                 // was sent, but no ping seen, display offline
-                pList->topLevelItem ( iIdx )->setText ( 1 , "  offline" );
+                pList->topLevelItem ( iIdx )->setText ( 1, "  offline" );
             }
-
         }
     }
 
@@ -928,15 +917,10 @@ void CConnectDlg::OnTimerPing()
     {
         // try to parse host address string which is stored as user data
         // in the server list item GUI control element
-        if ( NetworkUtil().ParseNetworkAddress (
-                pList->topLevelItem ( iIdx )->
-                data ( 0, Qt::UserRole ).toString(),
-                ServerAddress ) )
+        if ( NetworkUtil().ParseNetworkAddress ( pList->topLevelItem ( iIdx )->data ( 0, Qt::UserRole ).toString(), ServerAddress ) )
         {
             // if address is valid, send ping message using a new thread
-            QtConcurrent::run ( this,
-                                &CConnectDlg::EmitCLServerListPingMes,
-                                ServerAddress );
+            QtConcurrent::run ( this, &CConnectDlg::EmitCLServerListPingMes, ServerAddress );
         }
     }
 }
@@ -958,7 +942,7 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
     QTreeWidgetItem* pCurListViewItem;
 
     // point pList to correct tab list
-    QTreeWidget * pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
+    QTreeWidget* pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
 
     pCurListViewItem = FindListViewItem ( InetAddr );
 
@@ -969,7 +953,6 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
         bool       bDoSorting   = false;
         // retain that a ping has been received from this server
         pCurListViewItem->setData ( 1, Qt::UserRole, 3 );
-
 
         // update minimum ping time column (invisible, used for sorting) if
         // the new value is smaller than the old value
@@ -1055,7 +1038,7 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
             pCurListViewItem->setHidden ( false );
         }
 
-        if( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS )
+        if ( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS )
         {
             // Update sorting. Note that the sorting must be the last action for the
             // current item since the topLevelItem(iIdx) is then no longer valid.
@@ -1063,7 +1046,7 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
             // could lead to connecting an incorrect server) the sorting is disabled
             // as long as the mouse is over the list (but it is not disabled for the
             // initial timer of about 2s, see TimerInitialSort) (#293).
-            if ( bDoSorting && !bShowCompleteRegList && (TimerInitialSort.isActive() || !pList->underMouse()) ) // do not sort if "show all servers"
+            if ( bDoSorting && !bShowCompleteRegList && ( TimerInitialSort.isActive() || !pList->underMouse() ) ) // do not sort if "show all servers"
             {
                 pList->sortByColumn ( 4, Qt::AscendingOrder );
             }
@@ -1088,7 +1071,7 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
         pList->setRootIsDecorated ( false );
     }
 
-    if( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS )
+    if ( pSettings->bFavoriteWasShownConnect == CONTAB_SERVERS )
     {
         // we may have changed the Hidden state for some items, if a filter was active, we now
         // have to update it to void lines appear which do not satisfy the filter criteria
@@ -1099,7 +1082,7 @@ void CConnectDlg::SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
 QTreeWidgetItem* CConnectDlg::FindListViewItem ( const CHostAddress& InetAddr )
 {
     // point pList to correct tab list
-    QTreeWidget * pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
+    QTreeWidget* pList = ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES ) ? lvwFavorites : lvwServers;
 
     const int iServerListLen = pList->topLevelItemCount();
 
@@ -1107,9 +1090,7 @@ QTreeWidgetItem* CConnectDlg::FindListViewItem ( const CHostAddress& InetAddr )
     {
         // compare the received address with the user data string of the
         // host address by a string compare
-        if ( !pList->topLevelItem ( iIdx )->
-                data ( 0, Qt::UserRole ).toString().
-                compare ( InetAddr.toString() ) )
+        if ( !pList->topLevelItem ( iIdx )->data ( 0, Qt::UserRole ).toString().compare ( InetAddr.toString() ) )
         {
             return pList->topLevelItem ( iIdx );
         }
@@ -1196,7 +1177,6 @@ void CConnectDlg::FillFavoritesTab()
         CurServerNameFont.setBold ( true );
         pNewListViewItem->setFont ( 0, CurServerNameFont );
 
-
         // the ping time shall be shown in bold font
         QFont CurPingTimeFont = pNewListViewItem->font ( 1 );
         CurPingTimeFont.setBold ( true );
@@ -1213,7 +1193,7 @@ void CConnectDlg::FillFavoritesTab()
         pNewListViewItem->setText ( 4, "99999999" );
 
         pNewListViewItem->setText ( 5, pSettings->vstrFAVMaxUsers[iIdx] );
-        strTmp = QChar ( 'a'+iIdx );
+        strTmp = QChar ( 'a' + iIdx );
         pNewListViewItem->setText ( 6, strTmp );
         if ( bShowAllMusicians )
         {
@@ -1222,7 +1202,7 @@ void CConnectDlg::FillFavoritesTab()
     }
 
     // list finished, now select top row
-    lvwFavorites->setCurrentItem ( lvwFavorites->topLevelItem( 0 ) );
+    lvwFavorites->setCurrentItem ( lvwFavorites->topLevelItem ( 0 ) );
 
     // start the ping timer since the favorites list is filled
     OnTimerPing();
@@ -1232,12 +1212,12 @@ void CConnectDlg::FillFavoritesTab()
 void CConnectDlg::OnAddtoFavorites()
 {
     CHostAddress CurHostAddress;
-    int iIdx, dupIdx;
+    int          iIdx, dupIdx;
 
     // Look for duplicate
-    for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS-1; iIdx++ )
+    for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS - 1; iIdx++ )
     {
-        if( strSelectedAddress == pSettings->vstrFAVAddress[iIdx] )
+        if ( strSelectedAddress == pSettings->vstrFAVAddress[iIdx] )
         {
             break;
         }
@@ -1245,28 +1225,28 @@ void CConnectDlg::OnAddtoFavorites()
     dupIdx = iIdx;
 
     // duplicate found
-    if( dupIdx < MAX_NUM_FAVORITE_ADDR_ITEMS-1 )
+    if ( dupIdx < MAX_NUM_FAVORITE_ADDR_ITEMS - 1 )
     {
         // push down to remove duplicate
         for ( iIdx = dupIdx; iIdx > 0; iIdx-- )
         {
-            pSettings->vstrFAVAddress[iIdx]   = pSettings->vstrFAVAddress[iIdx-1];
-            pSettings->vstrFAVName[iIdx]      = pSettings->vstrFAVName[iIdx-1];
-            pSettings->vstrFAVDirectory[iIdx] = pSettings->vstrFAVDirectory[iIdx-1];
-            pSettings->vecsFAVDirectECS[iIdx] = pSettings->vecsFAVDirectECS[iIdx-1];
-            pSettings->vstrFAVMaxUsers[iIdx]  = pSettings->vstrFAVMaxUsers[iIdx-1];
+            pSettings->vstrFAVAddress[iIdx]   = pSettings->vstrFAVAddress[iIdx - 1];
+            pSettings->vstrFAVName[iIdx]      = pSettings->vstrFAVName[iIdx - 1];
+            pSettings->vstrFAVDirectory[iIdx] = pSettings->vstrFAVDirectory[iIdx - 1];
+            pSettings->vecsFAVDirectECS[iIdx] = pSettings->vecsFAVDirectECS[iIdx - 1];
+            pSettings->vstrFAVMaxUsers[iIdx]  = pSettings->vstrFAVMaxUsers[iIdx - 1];
         }
     }
     else
     {
         // no duplicate, push all down to free top line
-        for ( iIdx = MAX_NUM_FAVORITE_ADDR_ITEMS-1; iIdx > 0; iIdx-- )
+        for ( iIdx = MAX_NUM_FAVORITE_ADDR_ITEMS - 1; iIdx > 0; iIdx-- )
         {
-            pSettings->vstrFAVAddress[iIdx]   = pSettings->vstrFAVAddress[iIdx-1];
-            pSettings->vstrFAVName[iIdx]      = pSettings->vstrFAVName[iIdx-1];
-            pSettings->vstrFAVDirectory[iIdx] = pSettings->vstrFAVDirectory[iIdx-1];
-            pSettings->vecsFAVDirectECS[iIdx] = pSettings->vecsFAVDirectECS[iIdx-1];
-            pSettings->vstrFAVMaxUsers[iIdx]  = pSettings->vstrFAVMaxUsers[iIdx-1];
+            pSettings->vstrFAVAddress[iIdx]   = pSettings->vstrFAVAddress[iIdx - 1];
+            pSettings->vstrFAVName[iIdx]      = pSettings->vstrFAVName[iIdx - 1];
+            pSettings->vstrFAVDirectory[iIdx] = pSettings->vstrFAVDirectory[iIdx - 1];
+            pSettings->vecsFAVDirectECS[iIdx] = pSettings->vecsFAVDirectECS[iIdx - 1];
+            pSettings->vstrFAVMaxUsers[iIdx]  = pSettings->vstrFAVMaxUsers[iIdx - 1];
         }
     }
 
@@ -1280,19 +1260,19 @@ void CConnectDlg::OnAddtoFavorites()
 
 void CConnectDlg::ThisFAVtoTop()
 {
-    int iIdx = 0, dupIdx = 0;
-    QString strName, strMax, strDirectory;
+    int        iIdx = 0, dupIdx = 0;
+    QString    strName, strMax, strDirectory;
     ECSAddType ecsSave;
 
     // Look for selected server
     for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS; iIdx++ )
     {
-        if( strSelectedAddress == pSettings->vstrFAVAddress[iIdx] )
+        if ( strSelectedAddress == pSettings->vstrFAVAddress[iIdx] )
         {
             break;
         }
     }
-    dupIdx = iIdx;
+    dupIdx       = iIdx;
     strName      = pSettings->vstrFAVName[dupIdx];
     strMax       = pSettings->vstrFAVMaxUsers[dupIdx];
     strDirectory = pSettings->vstrFAVDirectory[dupIdx];
@@ -1301,11 +1281,11 @@ void CConnectDlg::ThisFAVtoTop()
     // push down to free first line
     for ( iIdx = dupIdx; iIdx > 0; iIdx-- )
     {
-        pSettings->vstrFAVAddress[iIdx]   = pSettings->vstrFAVAddress[iIdx-1];
-        pSettings->vstrFAVName[iIdx]      = pSettings->vstrFAVName[iIdx-1];
-        pSettings->vstrFAVDirectory[iIdx] = pSettings->vstrFAVDirectory[iIdx-1];
-        pSettings->vecsFAVDirectECS[iIdx] = pSettings->vecsFAVDirectECS[iIdx-1];
-        pSettings->vstrFAVMaxUsers[iIdx]  = pSettings->vstrFAVMaxUsers[iIdx-1];
+        pSettings->vstrFAVAddress[iIdx]   = pSettings->vstrFAVAddress[iIdx - 1];
+        pSettings->vstrFAVName[iIdx]      = pSettings->vstrFAVName[iIdx - 1];
+        pSettings->vstrFAVDirectory[iIdx] = pSettings->vstrFAVDirectory[iIdx - 1];
+        pSettings->vecsFAVDirectECS[iIdx] = pSettings->vecsFAVDirectECS[iIdx - 1];
+        pSettings->vstrFAVMaxUsers[iIdx]  = pSettings->vstrFAVMaxUsers[iIdx - 1];
     }
     // move to top
     pSettings->vstrFAVAddress[0]   = strSelectedAddress;
@@ -1315,13 +1295,12 @@ void CConnectDlg::ThisFAVtoTop()
     pSettings->vecsFAVDirectECS[0] = ecsSave;
 }
 
-
 void CConnectDlg::OnTabChange()
 {
     TimerPing.stop();
     pSettings->bFavoriteWasShownConnect = tabConnect->currentIndex();
 
-    if( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
+    if ( pSettings->bFavoriteWasShownConnect == CONTAB_FAVORITES )
     {
         // load stored favorites
         FillFavoritesTab();
@@ -1339,7 +1318,7 @@ void CConnectDlg::OnSortLastUsed()
     lvwFavorites->sortItems ( 6, Qt::AscendingOrder );
     pSettings->iFavSort = FAVSORT_LASTUSED;
     // select top row
-    lvwFavorites->setCurrentItem ( lvwFavorites->topLevelItem( 0 ) );
+    lvwFavorites->setCurrentItem ( lvwFavorites->topLevelItem ( 0 ) );
 }
 
 void CConnectDlg::OnSortDirectory()
@@ -1360,6 +1339,6 @@ void CConnectDlg::SortFavorites()
     else
     {
         // sort by Directory Server
-       OnSortDirectory();
+        OnSortDirectory();
     }
 }

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -53,25 +53,18 @@ public:
     void ThisFAVtoTop();
     void OnTabChange();
     void FillFavoritesTab();
-    void SetFAVPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
-                                          const int           iPingTime,
-                                          const int           iNumClients );
+    void SetFAVPingTimeAndNumClientsResult ( const CHostAddress& InetAddr, const int iPingTime, const int iNumClients );
 
     void SetShowAllMusicians ( const bool bState ) { ShowAllMusicians ( bState ); }
     bool GetShowAllMusicians() { return bShowAllMusicians; }
 
     void SetServerList ( const CHostAddress& InetAddr, const CVector<CServerInfo>& vecServerInfo, const bool bIsReducedServerList = false );
 
-    void FillServerTab ( const CHostAddress&         InetAddr,
-                                      const CVector<CServerInfo>& vecServerInfo,
-                                      const bool                  bIsReducedServerList );
+    void FillServerTab ( const CHostAddress& InetAddr, const CVector<CServerInfo>& vecServerInfo, const bool bIsReducedServerList );
 
-    void UpdateFAVIPs( const CHostAddress&         InetAddr,
-                                     const CVector<CServerInfo>& vecServerInfo,
-                                     const bool                  bIsReducedServerList );
+    void UpdateFAVIPs ( const CVector<CServerInfo>& vecServerInfo, const bool bIsReducedServerList );
 
-    void SetConnClientsList ( const CHostAddress&          InetAddr,
-                              const CVector<CChannelInfo>& vecChanInfo );
+    void SetConnClientsList ( const CHostAddress& InetAddr, const CVector<CChannelInfo>& vecChanInfo );
 
     void SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr, const int iPingTime, const int iNumClients );
 
@@ -95,21 +88,21 @@ protected:
 
     CClientSettings* pSettings;
 
-    QTimer           TimerPing;
-    QTimer           TimerReRequestServList;
-    QTimer           TimerInitialSort;
-    CHostAddress     CentralServerAddress;
-    QString          strSelectedAddress;
-    QString          strSelectedServerName;
-    QString          strSelectedMaxUsers;
-    QString          strSelectedDirectory;
-    ECSAddType       ecsSelectedDirectECS;
-    bool             bShowCompleteRegList;
-    bool             bServerListReceived;
-    bool             bReducedServerListReceived;
-    bool             bServerListItemWasChosen;
-    bool             bListFilterWasActive;
-    bool             bShowAllMusicians;
+    QTimer       TimerPing;
+    QTimer       TimerReRequestServList;
+    QTimer       TimerInitialSort;
+    CHostAddress CentralServerAddress;
+    QString      strSelectedAddress;
+    QString      strSelectedServerName;
+    QString      strSelectedMaxUsers;
+    QString      strSelectedDirectory;
+    ECSAddType   ecsSelectedDirectECS;
+    bool         bShowCompleteRegList;
+    bool         bServerListReceived;
+    bool         bReducedServerListReceived;
+    bool         bServerListItemWasChosen;
+    bool         bListFilterWasActive;
+    bool         bShowAllMusicians;
 
 public slots:
     void OnAddtoFavorites();

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -66,6 +66,10 @@ public:
                                       const CVector<CServerInfo>& vecServerInfo,
                                       const bool                  bIsReducedServerList );
 
+    void UpdateFAVIPs( const CHostAddress&         InetAddr,
+                                     const CVector<CServerInfo>& vecServerInfo,
+                                     const bool                  bIsReducedServerList );
+
     void SetConnClientsList ( const CHostAddress&          InetAddr,
                               const CVector<CChannelInfo>& vecChanInfo );
 
@@ -98,6 +102,7 @@ protected:
     QString          strSelectedServerName;
     QString          strSelectedMaxUsers;
     QString          strSelectedDirectory;
+    ECSAddType       ecsSelectedDirectECS;
     bool             bShowCompleteRegList;
     bool             bServerListReceived;
     bool             bReducedServerListReceived;

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -50,12 +50,25 @@ class CConnectDlg : public CBaseDlg, private Ui_CConnectDlgBase
 public:
     CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteRegList, QWidget* parent = nullptr );
 
+    void OnAddtoFavorites();
+    void ThisFAVtoTop();
+    void OnTabChange();
+    void FillFavoritesTab();
+    void SetFAVPingTimeAndNumClientsResult ( const CHostAddress& InetAddr,
+                                          const int           iPingTime,
+                                          const int           iNumClients );
+
     void SetShowAllMusicians ( const bool bState ) { ShowAllMusicians ( bState ); }
     bool GetShowAllMusicians() { return bShowAllMusicians; }
 
     void SetServerList ( const CHostAddress& InetAddr, const CVector<CServerInfo>& vecServerInfo, const bool bIsReducedServerList = false );
 
-    void SetConnClientsList ( const CHostAddress& InetAddr, const CVector<CChannelInfo>& vecChanInfo );
+    void FillServerTab ( const CHostAddress&         InetAddr,
+                                      const CVector<CServerInfo>& vecServerInfo,
+                                      const bool                  bIsReducedServerList );
+
+    void SetConnClientsList ( const CHostAddress&          InetAddr,
+                              const CVector<CChannelInfo>& vecChanInfo );
 
     void SetPingTimeAndNumClientsResult ( const CHostAddress& InetAddr, const int iPingTime, const int iNumClients );
 
@@ -67,6 +80,7 @@ protected:
     virtual void showEvent ( QShowEvent* );
     virtual void hideEvent ( QHideEvent* );
 
+    QTreeWidgetItem* FindFAVListViewItem ( const CHostAddress& InetAddr );
     QTreeWidgetItem* FindListViewItem ( const CHostAddress& InetAddr );
     QTreeWidgetItem* GetParentListViewItem ( QTreeWidgetItem* pItem );
     void             DeleteAllListViewItemChilds ( QTreeWidgetItem* pItem );
@@ -77,18 +91,20 @@ protected:
 
     CClientSettings* pSettings;
 
-    QTimer       TimerPing;
-    QTimer       TimerReRequestServList;
-    QTimer       TimerInitialSort;
-    CHostAddress CentralServerAddress;
-    QString      strSelectedAddress;
-    QString      strSelectedServerName;
-    bool         bShowCompleteRegList;
-    bool         bServerListReceived;
-    bool         bReducedServerListReceived;
-    bool         bServerListItemWasChosen;
-    bool         bListFilterWasActive;
-    bool         bShowAllMusicians;
+    QTimer           TimerPing;
+    QTimer           TimerReRequestServList;
+    QTimer           TimerInitialSort;
+    CHostAddress     CentralServerAddress;
+    QString          strSelectedAddress;
+    QString          strSelectedServerName;
+    QString          strSelectedMaxUsers;
+    QString          strSelectedDirectory;
+    bool             bShowCompleteRegList;
+    bool             bServerListReceived;
+    bool             bReducedServerListReceived;
+    bool             bServerListItemWasChosen;
+    bool             bListFilterWasActive;
+    bool             bShowAllMusicians;
 
 public slots:
     void OnServerListItemDoubleClicked ( QTreeWidgetItem* Item, int );
@@ -104,6 +120,7 @@ public slots:
 signals:
     void ReqServerListQuery ( CHostAddress InetAddr );
     void CreateCLServerListPingMes ( CHostAddress InetAddr );
+    void CreateCLServerFAVListPingMes ( CHostAddress InetAddr );
     void CreateCLServerListReqVerAndOSMes ( CHostAddress InetAddr );
     void CreateCLServerListReqConnClientsListMes ( CHostAddress InetAddr );
 };

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -50,7 +50,6 @@ class CConnectDlg : public CBaseDlg, private Ui_CConnectDlgBase
 public:
     CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteRegList, QWidget* parent = nullptr );
 
-    void OnAddtoFavorites();
     void ThisFAVtoTop();
     void OnTabChange();
     void FillFavoritesTab();
@@ -107,6 +106,7 @@ protected:
     bool             bShowAllMusicians;
 
 public slots:
+    void OnAddtoFavorites();
     void OnServerListItemDoubleClicked ( QTreeWidgetItem* Item, int );
     void OnServerAddrEditTextChanged ( const QString& );
     void OnCentServAddrTypeChanged ( int iTypeIdx );

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -91,6 +91,7 @@ protected:
     void             ShowAllMusicians ( const bool bState );
     void             RequestServerList();
     void             EmitCLServerListPingMes ( const CHostAddress& CurServerAddress );
+    void             SortFavorites();
 
     CClientSettings* pSettings;
 
@@ -121,6 +122,8 @@ public slots:
     void OnConnectClicked();
     void OnTimerPing();
     void OnTimerReRequestServList();
+    void OnSortLastUsed();
+    void OnSortDirectory();
 
 signals:
     void ReqServerListQuery ( CHostAddress InetAddr );

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -203,7 +203,7 @@
            <property name="sizeHint" stdset="0">
             <size>
              <width>17</width>
-             <height>23</height>
+             <height>26</height>
             </size>
            </property>
           </spacer>

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -132,14 +132,32 @@
       <attribute name="title">
        <string>Favorites</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
+           <item>
+            <widget class="QLabel" name="lblFavSort">
+             <property name="text">
+              <string>Sort by: </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="rbFavSort1">
+             <property name="text">
+              <string>Last used</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="rbFavSort2">
+             <property name="text">
+              <string>Directory</string>
+             </property>
+            </widget>
+           </item>
            <item>
             <spacer name="horizontalSpacer">
              <property name="orientation">

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>521</width>
-    <height>493</height>
+    <width>550</width>
+    <height>505</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,91 +23,196 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="bottomMargin">
-      <number>0</number>
+    <widget class="QTabWidget" name="tabConnect">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <item>
-      <widget class="QLabel" name="lblList">
-       <property name="text">
-        <string>List</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cbxCentServAddrType"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="lblFilter">
-       <property name="text">
-        <string>Filter</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="edtFilter"/>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="chbExpandAll">
-       <property name="text">
-        <string>Show All Musicians</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTreeWidget" name="lvwServers">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="tabKeyNavigation">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string>Server Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Ping Time</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Musicians</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Location</string>
-      </property>
-     </column>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Directories</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="lblList">
+           <property name="text">
+            <string>List</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cbxCentServAddrType">
+           <property name="minimumSize">
+            <size>
+             <width>140</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblFilter">
+           <property name="text">
+            <string>Filter</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtFilter"/>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="chbExpandAll">
+           <property name="text">
+            <string>Show All Musicians</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="lvwServers">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="tabKeyNavigation">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Server Name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Ping Time</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Musicians</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Location</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel" name="lblServerAddr">
+           <property name="text">
+            <string>Server Address</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cbxServerAddr">
+           <property name="editable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Favorites</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="chbExpandAllFAV">
+             <property name="text">
+              <string>Show All Musicians</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QTreeWidget" name="lvwFavorites">
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="tabKeyNavigation">
+            <bool>true</bool>
+           </property>
+           <column>
+            <property name="text">
+             <string>Server Name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Ping Time</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Musicians</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Directory</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>17</width>
+             <height>23</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QLabel" name="lblServerAddr">
-       <property name="text">
-        <string>Server Address</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cbxServerAddr">
-       <property name="editable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout">

--- a/src/global.h
+++ b/src/global.h
@@ -181,10 +181,10 @@ LED bar:      lbr
 #define MAX_NUM_IN_OUT_CHANNELS 64
 
 // maximum number of elements in the server address combo box
-#define MAX_NUM_SERVER_ADDR_ITEMS        12
+#define MAX_NUM_SERVER_ADDR_ITEMS 12
 
 // maximum number of elements in the favorite address list
-#define MAX_NUM_FAVORITE_ADDR_ITEMS        16
+#define MAX_NUM_FAVORITE_ADDR_ITEMS 16
 
 // maximum number of fader settings to be stored (together with the fader tags)
 #define MAX_NUM_STORED_FADER_SETTINGS 250

--- a/src/global.h
+++ b/src/global.h
@@ -180,8 +180,11 @@ LED bar:      lbr
 // of channels by the audio device)
 #define MAX_NUM_IN_OUT_CHANNELS 64
 
-// maximum number of elemts in the server address combo box
-#define MAX_NUM_SERVER_ADDR_ITEMS 12
+// maximum number of elements in the server address combo box
+#define MAX_NUM_SERVER_ADDR_ITEMS        12
+
+// maximum number of elements in the favorite address list
+#define MAX_NUM_FAVORITE_ADDR_ITEMS        16
 
 // maximum number of fader settings to be stored (together with the fader tags)
 #define MAX_NUM_STORED_FADER_SETTINGS 250

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -538,7 +538,7 @@ int main ( int argc, char** argv )
     QCoreApplication* pApp = new QCoreApplication ( argc, argv );
 #else
 #    if defined( Q_OS_IOS )
-    bUseGUI        = true;
+    bUseGUI = true;
 
     // bUseMultithreading = true;
     QApplication* pApp = new QApplication ( argc, argv );

--- a/src/server.h
+++ b/src/server.h
@@ -103,7 +103,7 @@ public:
 protected:
     virtual void run();
 
-    bool     bRun;
+    bool bRun;
 
 #    if defined( __APPLE__ ) || defined( __MACOSX )
     uint64_t Delay;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -243,6 +243,20 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         bFavoriteWasShownConnect = bValue;
     }
 
+    // Favorites Sort type
+    if ( GetNumericIniSet ( IniXMLDocument, "client", "favsort",
+         0, 1, iValue ) )
+    {
+        iFavSort = static_cast<EFavSort>(iValue);
+    }
+
+    // Favorites Sort type
+    if ( GetNumericIniSet ( IniXMLDocument, "client", "favlastselected",
+         0, MAX_NUM_FAVORITE_ADDR_ITEMS, iValue ) )
+    {
+        iFavDirLastSelected = iValue;
+    }
+
     // FAVORITE addresses
     QString strT;
     QStringList listT;
@@ -583,6 +597,14 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // visibility state of favorites tab
     SetFlagIniSet ( IniXMLDocument, "client", "favshown",
         bFavoriteWasShownConnect );
+
+    // Favorites Sort type
+    SetNumericIniSet ( IniXMLDocument, "client", "favsort",
+        static_cast<int>(iFavSort) );
+
+    // Favorites Last Selected for Dir Sort
+    SetNumericIniSet ( IniXMLDocument, "client", "favlastselected",
+        iFavDirLastSelected );
 
     // Favorite info
     QString strT;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -252,11 +252,12 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
             GetIniSetting ( IniXMLDocument, "client",
                             QString ( "favname%1" ).arg ( iIdx ), "" );
         listT = strT.split(QLatin1Char(','));
-        if( (!listT[0].isEmpty()) && listT.size() == 4 ) {
+        if( (!listT[0].isEmpty()) && listT.size() == 5 ) {
             vstrFAVAddress[iIdx]   = listT[0];
             vstrFAVMaxUsers[iIdx]  = listT[1];
             vstrFAVDirectory[iIdx] = listT[2];
             vstrFAVName[iIdx]      = FromBase64ToString ( listT[3] );
+            vecsFAVDirectECS[iIdx] = static_cast<ECSAddType>(listT[4].toInt());
         }
     }
 
@@ -587,8 +588,13 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     QString strT;
     for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS; iIdx++ )
     {
-        strT = vstrFAVAddress[iIdx] + "," + vstrFAVMaxUsers[iIdx] + "," +
-               vstrFAVDirectory[iIdx] + "," + ToBase64 ( vstrFAVName[iIdx] );
+        strT = "";
+        if( !vstrFAVAddress[iIdx].isEmpty() )
+        {
+            strT = vstrFAVAddress[iIdx] + "," + vstrFAVMaxUsers[iIdx] + "," +
+               vstrFAVDirectory[iIdx] + "," + ToBase64 ( vstrFAVName[iIdx] ) +
+               "," + QString::number( static_cast<int>(vecsFAVDirectECS[iIdx]) );
+        }
         PutIniSetting ( IniXMLDocument, "client",
                         QString ( "favname%1" ).arg ( iIdx ),
                         strT );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -244,34 +244,31 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     }
 
     // Favorites Sort type
-    if ( GetNumericIniSet ( IniXMLDocument, "client", "favsort",
-         0, 1, iValue ) )
+    if ( GetNumericIniSet ( IniXMLDocument, "client", "favsort", 0, 1, iValue ) )
     {
-        iFavSort = static_cast<EFavSort>(iValue);
+        iFavSort = static_cast<EFavSort> ( iValue );
     }
 
     // Favorites Sort type
-    if ( GetNumericIniSet ( IniXMLDocument, "client", "favlastselected",
-         0, MAX_NUM_FAVORITE_ADDR_ITEMS, iValue ) )
+    if ( GetNumericIniSet ( IniXMLDocument, "client", "favlastselected", 0, MAX_NUM_FAVORITE_ADDR_ITEMS, iValue ) )
     {
         iFavDirLastSelected = iValue;
     }
 
     // FAVORITE addresses
-    QString strT;
+    QString     strT;
     QStringList listT;
     for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS; iIdx++ )
     {
-        strT =
-            GetIniSetting ( IniXMLDocument, "client",
-                            QString ( "favname%1" ).arg ( iIdx ), "" );
-        listT = strT.split(QLatin1Char(','));
-        if( (!listT[0].isEmpty()) && listT.size() == 5 ) {
+        strT  = GetIniSetting ( IniXMLDocument, "client", QString ( "favname%1" ).arg ( iIdx ), "" );
+        listT = strT.split ( QLatin1Char ( ',' ) );
+        if ( ( !listT[0].isEmpty() ) && listT.size() == 5 )
+        {
             vstrFAVAddress[iIdx]   = listT[0];
             vstrFAVMaxUsers[iIdx]  = listT[1];
             vstrFAVDirectory[iIdx] = listT[2];
             vstrFAVName[iIdx]      = FromBase64ToString ( listT[3] );
-            vecsFAVDirectECS[iIdx] = static_cast<ECSAddType>(listT[4].toInt());
+            vecsFAVDirectECS[iIdx] = static_cast<ECSAddType> ( listT[4].toInt() );
         }
     }
 
@@ -595,31 +592,25 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     }
 
     // visibility state of favorites tab
-    SetFlagIniSet ( IniXMLDocument, "client", "favshown",
-        bFavoriteWasShownConnect );
+    SetFlagIniSet ( IniXMLDocument, "client", "favshown", bFavoriteWasShownConnect );
 
     // Favorites Sort type
-    SetNumericIniSet ( IniXMLDocument, "client", "favsort",
-        static_cast<int>(iFavSort) );
+    SetNumericIniSet ( IniXMLDocument, "client", "favsort", static_cast<int> ( iFavSort ) );
 
     // Favorites Last Selected for Dir Sort
-    SetNumericIniSet ( IniXMLDocument, "client", "favlastselected",
-        iFavDirLastSelected );
+    SetNumericIniSet ( IniXMLDocument, "client", "favlastselected", iFavDirLastSelected );
 
     // Favorite info
     QString strT;
     for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS; iIdx++ )
     {
         strT = "";
-        if( !vstrFAVAddress[iIdx].isEmpty() )
+        if ( !vstrFAVAddress[iIdx].isEmpty() )
         {
-            strT = vstrFAVAddress[iIdx] + "," + vstrFAVMaxUsers[iIdx] + "," +
-               vstrFAVDirectory[iIdx] + "," + ToBase64 ( vstrFAVName[iIdx] ) +
-               "," + QString::number( static_cast<int>(vecsFAVDirectECS[iIdx]) );
+            strT = vstrFAVAddress[iIdx] + "," + vstrFAVMaxUsers[iIdx] + "," + vstrFAVDirectory[iIdx] + "," + ToBase64 ( vstrFAVName[iIdx] ) + "," +
+                   QString::number ( static_cast<int> ( vecsFAVDirectECS[iIdx] ) );
         }
-        PutIniSetting ( IniXMLDocument, "client",
-                        QString ( "favname%1" ).arg ( iIdx ),
-                        strT );
+        PutIniSetting ( IniXMLDocument, "client", QString ( "favname%1" ).arg ( iIdx ), strT );
     }
 
     // new client level

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -237,6 +237,29 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         vstrIPAddress[iIdx] = GetIniSetting ( IniXMLDocument, "client", QString ( "ipaddress%1" ).arg ( iIdx ), "" );
     }
 
+    // Favorites shown ?
+    if ( GetFlagIniSet ( IniXMLDocument, "client", "favshown", bValue ) )
+    {
+        bFavoriteWasShownConnect = bValue;
+    }
+
+    // FAVORITE addresses
+    QString strT;
+    QStringList listT;
+    for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS; iIdx++ )
+    {
+        strT =
+            GetIniSetting ( IniXMLDocument, "client",
+                            QString ( "favname%1" ).arg ( iIdx ), "" );
+        listT = strT.split(QLatin1Char(','));
+        if( (!listT[0].isEmpty()) && listT.size() == 4 ) {
+            vstrFAVAddress[iIdx]   = listT[0];
+            vstrFAVMaxUsers[iIdx]  = listT[1];
+            vstrFAVDirectory[iIdx] = listT[2];
+            vstrFAVName[iIdx]      = FromBase64ToString ( listT[3] );
+        }
+    }
+
     // new client level
     if ( GetNumericIniSet ( IniXMLDocument, "client", "newclientlevel", 0, 100, iValue ) )
     {
@@ -554,6 +577,21 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
         PutIniSetting ( IniXMLDocument, "client", QString ( "ipaddress%1" ).arg ( iIdx ), vstrIPAddress[iIdx] );
+    }
+
+    // visibility state of favorites tab
+    SetFlagIniSet ( IniXMLDocument, "client", "favshown",
+        bFavoriteWasShownConnect );
+
+    // Favorite info
+    QString strT;
+    for ( iIdx = 0; iIdx < MAX_NUM_FAVORITE_ADDR_ITEMS; iIdx++ )
+    {
+        strT = vstrFAVAddress[iIdx] + "," + vstrFAVMaxUsers[iIdx] + "," +
+               vstrFAVDirectory[iIdx] + "," + ToBase64 ( vstrFAVName[iIdx] );
+        PutIniSetting ( IniXMLDocument, "client",
+                        QString ( "favname%1" ).arg ( iIdx ),
+                        strT );
     }
 
     // new client level

--- a/src/settings.h
+++ b/src/settings.h
@@ -123,7 +123,9 @@ public:
         vstrFAVMaxUsers ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
         vstrFAVDirectory ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
         vecsFAVDirectECS ( MAX_NUM_FAVORITE_ADDR_ITEMS, AT_DEFAULT ),
+        iNewClientFaderLevel ( 100 ),
         iInputBoost ( 1 ),
+        iSettingsTab ( SETTING_TAB_AUDIONET ),
         bConnectDlgShowAllMusicians ( true ),
         eChannelSortType ( ST_NO_SORT ),
         iNumMixerPanelRows ( 1 ),
@@ -131,6 +133,7 @@ public:
         iFavDirLastSelected ( 0 ),
         vstrCentralServerAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
         eCentralServerAddressType ( AT_DEFAULT ),
+        bEnableFeedbackDetection ( true ),
         vecWindowPosSettings(), // empty array
         vecWindowPosChat(),     // empty array
         vecWindowPosConnect(),  // empty array

--- a/src/settings.h
+++ b/src/settings.h
@@ -127,6 +127,8 @@ public:
         bConnectDlgShowAllMusicians ( true ),
         eChannelSortType            ( ST_NO_SORT ),
         iNumMixerPanelRows          ( 1 ),
+        iFavSort                    ( FAVSORT_LASTUSED ),
+        iFavDirLastSelected         ( 0 ),
         vstrCentralServerAddress    ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
         eCentralServerAddressType   ( AT_DEFAULT ),
         vecWindowPosSettings        ( ), // empty array
@@ -161,6 +163,8 @@ public:
     bool             bConnectDlgShowAllMusicians;
     EChSortType      eChannelSortType;
     int              iNumMixerPanelRows;
+    EFavSort         iFavSort;
+    int              iFavDirLastSelected;
     CVector<QString> vstrCentralServerAddress;
     ECSAddType       eCentralServerAddressType;
     bool             bEnableFeedbackDetection;

--- a/src/settings.h
+++ b/src/settings.h
@@ -110,33 +110,34 @@ class CClientSettings : public CSettings
 {
 public:
     CClientSettings ( CClient* pNCliP, const QString& sNFiName ) :
-        CSettings(),
-        vecStoredFaderTags ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
-        vecStoredFaderLevels ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
-        vecStoredPanValues ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_PAN_MAX / 2 ),
-        vecStoredFaderIsSolo ( MAX_NUM_STORED_FADER_SETTINGS, false ),
-        vecStoredFaderIsMute ( MAX_NUM_STORED_FADER_SETTINGS, false ),
-        vecStoredFaderGroupID ( MAX_NUM_STORED_FADER_SETTINGS, INVALID_INDEX ),
-        vstrIPAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
-        iNewClientFaderLevel ( 100 ),
-        iInputBoost ( 1 ),
-        iSettingsTab ( SETTING_TAB_AUDIONET ),
+        CSettings                   ( ),
+        vecStoredFaderTags          ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
+        vecStoredFaderLevels        ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
+        vecStoredPanValues          ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_PAN_MAX / 2 ),
+        vecStoredFaderIsSolo        ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+        vecStoredFaderIsMute        ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+        vecStoredFaderGroupID       ( MAX_NUM_STORED_FADER_SETTINGS, INVALID_INDEX ),
+        vstrIPAddress               ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
+        vstrFAVName                 ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vstrFAVAddress              ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vstrFAVMaxUsers             ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vstrFAVDirectory            ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        iNewClientFaderLevel        ( 100 ),
+        iInputBoost                 ( 1 ),
         bConnectDlgShowAllMusicians ( true ),
-        eChannelSortType ( ST_NO_SORT ),
-        iNumMixerPanelRows ( 1 ),
-        vstrCentralServerAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
-        eCentralServerAddressType ( AT_DEFAULT ),
-        bEnableFeedbackDetection ( true ),
-        vecWindowPosSettings(), // empty array
-        vecWindowPosChat(),     // empty array
-        vecWindowPosConnect(),  // empty array
-        bWindowWasShownSettings ( false ),
-        bWindowWasShownChat ( false ),
-        bWindowWasShownConnect ( false ),
-        pClient ( pNCliP )
-    {
-        SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME );
-    }
+        eChannelSortType            ( ST_NO_SORT ),
+        iNumMixerPanelRows          ( 1 ),
+        vstrCentralServerAddress    ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
+        eCentralServerAddressType   ( AT_DEFAULT ),
+        vecWindowPosSettings        ( ), // empty array
+        vecWindowPosChat            ( ), // empty array
+        vecWindowPosConnect         ( ), // empty array
+        bWindowWasShownSettings     ( false ),
+        bWindowWasShownChat         ( false ),
+        bWindowWasShownConnect      ( false ),
+        bFavoriteWasShownConnect    ( false ),
+        pClient                     ( pNCliP )
+        { SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME ); }
 
     void LoadFaderSettings ( const QString& strCurFileName );
     void SaveFaderSettings ( const QString& strCurFileName );
@@ -149,6 +150,10 @@ public:
     CVector<int>     vecStoredFaderIsMute;
     CVector<int>     vecStoredFaderGroupID;
     CVector<QString> vstrIPAddress;
+    CVector<QString> vstrFAVName;
+    CVector<QString> vstrFAVAddress;
+    CVector<QString> vstrFAVMaxUsers;
+    CVector<QString> vstrFAVDirectory;
     int              iNewClientFaderLevel;
     int              iInputBoost;
     int              iSettingsTab;
@@ -166,6 +171,7 @@ public:
     bool       bWindowWasShownSettings;
     bool       bWindowWasShownChat;
     bool       bWindowWasShownConnect;
+    bool       bFavoriteWasShownConnect;
 
 protected:
     // No CommandLineOptions used when reading Client inifile

--- a/src/settings.h
+++ b/src/settings.h
@@ -122,7 +122,7 @@ public:
         vstrFAVAddress              ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
         vstrFAVMaxUsers             ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
         vstrFAVDirectory            ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
-        iNewClientFaderLevel        ( 100 ),
+        vecsFAVDirectECS            ( MAX_NUM_FAVORITE_ADDR_ITEMS, AT_DEFAULT ),
         iInputBoost                 ( 1 ),
         bConnectDlgShowAllMusicians ( true ),
         eChannelSortType            ( ST_NO_SORT ),
@@ -154,6 +154,7 @@ public:
     CVector<QString> vstrFAVAddress;
     CVector<QString> vstrFAVMaxUsers;
     CVector<QString> vstrFAVDirectory;
+    CVector<ECSAddType> vecsFAVDirectECS;
     int              iNewClientFaderLevel;
     int              iInputBoost;
     int              iSettingsTab;

--- a/src/settings.h
+++ b/src/settings.h
@@ -110,64 +110,66 @@ class CClientSettings : public CSettings
 {
 public:
     CClientSettings ( CClient* pNCliP, const QString& sNFiName ) :
-        CSettings                   ( ),
-        vecStoredFaderTags          ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
-        vecStoredFaderLevels        ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
-        vecStoredPanValues          ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_PAN_MAX / 2 ),
-        vecStoredFaderIsSolo        ( MAX_NUM_STORED_FADER_SETTINGS, false ),
-        vecStoredFaderIsMute        ( MAX_NUM_STORED_FADER_SETTINGS, false ),
-        vecStoredFaderGroupID       ( MAX_NUM_STORED_FADER_SETTINGS, INVALID_INDEX ),
-        vstrIPAddress               ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
-        vstrFAVName                 ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
-        vstrFAVAddress              ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
-        vstrFAVMaxUsers             ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
-        vstrFAVDirectory            ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
-        vecsFAVDirectECS            ( MAX_NUM_FAVORITE_ADDR_ITEMS, AT_DEFAULT ),
-        iInputBoost                 ( 1 ),
+        CSettings(),
+        vecStoredFaderTags ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
+        vecStoredFaderLevels ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
+        vecStoredPanValues ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_PAN_MAX / 2 ),
+        vecStoredFaderIsSolo ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+        vecStoredFaderIsMute ( MAX_NUM_STORED_FADER_SETTINGS, false ),
+        vecStoredFaderGroupID ( MAX_NUM_STORED_FADER_SETTINGS, INVALID_INDEX ),
+        vstrIPAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
+        vstrFAVName ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vstrFAVAddress ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vstrFAVMaxUsers ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vstrFAVDirectory ( MAX_NUM_FAVORITE_ADDR_ITEMS, "" ),
+        vecsFAVDirectECS ( MAX_NUM_FAVORITE_ADDR_ITEMS, AT_DEFAULT ),
+        iInputBoost ( 1 ),
         bConnectDlgShowAllMusicians ( true ),
-        eChannelSortType            ( ST_NO_SORT ),
-        iNumMixerPanelRows          ( 1 ),
-        iFavSort                    ( FAVSORT_LASTUSED ),
-        iFavDirLastSelected         ( 0 ),
-        vstrCentralServerAddress    ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
-        eCentralServerAddressType   ( AT_DEFAULT ),
-        vecWindowPosSettings        ( ), // empty array
-        vecWindowPosChat            ( ), // empty array
-        vecWindowPosConnect         ( ), // empty array
-        bWindowWasShownSettings     ( false ),
-        bWindowWasShownChat         ( false ),
-        bWindowWasShownConnect      ( false ),
-        bFavoriteWasShownConnect    ( false ),
-        pClient                     ( pNCliP )
-        { SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME ); }
+        eChannelSortType ( ST_NO_SORT ),
+        iNumMixerPanelRows ( 1 ),
+        iFavSort ( FAVSORT_LASTUSED ),
+        iFavDirLastSelected ( 0 ),
+        vstrCentralServerAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
+        eCentralServerAddressType ( AT_DEFAULT ),
+        vecWindowPosSettings(), // empty array
+        vecWindowPosChat(),     // empty array
+        vecWindowPosConnect(),  // empty array
+        bWindowWasShownSettings ( false ),
+        bWindowWasShownChat ( false ),
+        bWindowWasShownConnect ( false ),
+        bFavoriteWasShownConnect ( false ),
+        pClient ( pNCliP )
+    {
+        SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME );
+    }
 
     void LoadFaderSettings ( const QString& strCurFileName );
     void SaveFaderSettings ( const QString& strCurFileName );
 
     // general settings
-    CVector<QString> vecStoredFaderTags;
-    CVector<int>     vecStoredFaderLevels;
-    CVector<int>     vecStoredPanValues;
-    CVector<int>     vecStoredFaderIsSolo;
-    CVector<int>     vecStoredFaderIsMute;
-    CVector<int>     vecStoredFaderGroupID;
-    CVector<QString> vstrIPAddress;
-    CVector<QString> vstrFAVName;
-    CVector<QString> vstrFAVAddress;
-    CVector<QString> vstrFAVMaxUsers;
-    CVector<QString> vstrFAVDirectory;
+    CVector<QString>    vecStoredFaderTags;
+    CVector<int>        vecStoredFaderLevels;
+    CVector<int>        vecStoredPanValues;
+    CVector<int>        vecStoredFaderIsSolo;
+    CVector<int>        vecStoredFaderIsMute;
+    CVector<int>        vecStoredFaderGroupID;
+    CVector<QString>    vstrIPAddress;
+    CVector<QString>    vstrFAVName;
+    CVector<QString>    vstrFAVAddress;
+    CVector<QString>    vstrFAVMaxUsers;
+    CVector<QString>    vstrFAVDirectory;
     CVector<ECSAddType> vecsFAVDirectECS;
-    int              iNewClientFaderLevel;
-    int              iInputBoost;
-    int              iSettingsTab;
-    bool             bConnectDlgShowAllMusicians;
-    EChSortType      eChannelSortType;
-    int              iNumMixerPanelRows;
-    EFavSort         iFavSort;
-    int              iFavDirLastSelected;
-    CVector<QString> vstrCentralServerAddress;
-    ECSAddType       eCentralServerAddressType;
-    bool             bEnableFeedbackDetection;
+    int                 iNewClientFaderLevel;
+    int                 iInputBoost;
+    int                 iSettingsTab;
+    bool                bConnectDlgShowAllMusicians;
+    EChSortType         eChannelSortType;
+    int                 iNumMixerPanelRows;
+    EFavSort            iFavSort;
+    int                 iFavDirLastSelected;
+    CVector<QString>    vstrCentralServerAddress;
+    ECSAddType          eCentralServerAddressType;
+    bool                bEnableFeedbackDetection;
 
     // window position/state settings
     QByteArray vecWindowPosSettings;

--- a/src/util.h
+++ b/src/util.h
@@ -445,6 +445,15 @@ signals:
 /******************************************************************************\
 * Other Classes/Enums                                                          *
 \******************************************************************************/
+// Connect Dialog Tabs -------------------------------------------------
+enum EConnectTab
+{
+    // used for settings -> enum values should be fixed
+    CONTAB_SERVERS = 0,
+    CONTAB_FAVORITES = 1
+};
+
+
 // Audio channel configuration -------------------------------------------------
 enum EAudChanConf
 {

--- a/src/util.h
+++ b/src/util.h
@@ -449,13 +449,13 @@ signals:
 enum EConnectTab
 {
     // used for settings -> enum values should be fixed
-    CONTAB_SERVERS = 0,
+    CONTAB_SERVERS   = 0,
     CONTAB_FAVORITES = 1
 };
 enum EFavSort
 {
     // used for settings -> enum values should be fixed
-    FAVSORT_LASTUSED = 0,
+    FAVSORT_LASTUSED  = 0,
     FAVSORT_DIRECTORY = 1
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -452,7 +452,12 @@ enum EConnectTab
     CONTAB_SERVERS = 0,
     CONTAB_FAVORITES = 1
 };
-
+enum EFavSort
+{
+    // used for settings -> enum values should be fixed
+    FAVSORT_LASTUSED = 0,
+    FAVSORT_DIRECTORY = 1
+};
 
 // Audio channel configuration -------------------------------------------------
 enum EAudChanConf


### PR DESCRIPTION
PR Favorites

This PR implements a Favorite functionality as a tab in the Connect window.
The idea being able to use favorites even when directories are down, the server names, IP, max users and genre are saved.

The favorites list now has 16 members, the most recently used is at the top, the others pushed down.  Not used servers will fall off the end of the list.
To add a server to the list, connect to the server using the connect window Directory tab (unchanged behaviour) and then click the Add to Favorites button on the clientdlg.  This way any server can be added, be it private or public, using IP address or URL.  Of course if the connection does not use the services of a directory there is no max users and no genre.  Adding a server that is already on the list again does no harm.  The Add to Favorites button is disabled when not connected to a server.

The last used server in the favorites list is automagically selected when the list is built so that if you use only one server all you need to do is click on connect. 

The changes are almost all in connectdlg.  Settings adds the saving of the new values.  Clientdlg has the new Add to Favorites button.

There is a problem with this code that I have not been able to solve. Certain servers sometimes do not respond to the ping requests.  It is usually the same servers not responding and very strangely if you go to the Directory tab and directory of the server, wait a bit, and then go back to the Favorites the server responds.  When the server is not responding it is also not possible to connect to it from the favorites tab, from the servers tab, however, works.
I need help finding this, for the moment I have no idea what is happening.

![FAV01](https://user-images.githubusercontent.com/64357360/115780828-e61efd80-a3b9-11eb-8309-cf66c897a907.JPG)

Here we see one server that is not responding, frosch
![FAV03](https://user-images.githubusercontent.com/64357360/115780852-f040fc00-a3b9-11eb-953b-c200d0afcb38.JPG)
