### PR TITLE
Fix X/Y distribution on mixer board

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1071,6 +1071,11 @@ void CAudioMixerBoard::ChangeFaderOrder ( const EChSortType eChSortType )
     // sort the channels according to the first of the pair
     std::stable_sort ( PairList.begin(), PairList.end() );
 
+    // we want to distribute iNumVisibleFaders across the first row, then the next, etc
+    // up to iNumMixerPanelRows.  So row wants to start at 0 until we get to some number,
+    // then increase, where "some number" means we get no more than iNumMixerPanelRows.
+    const int iNumFadersFirstRow = 1 + ( iNumVisibleFaders / iNumMixerPanelRows );
+
     // add channels to the layout in the new order, note that it is not required to remove
     // the widget from the layout first but it is moved to the new position automatically
     int iVisibleFaderCnt = 0;
@@ -1081,11 +1086,11 @@ void CAudioMixerBoard::ChangeFaderOrder ( const EChSortType eChSortType )
 
         if ( vecpChanFader[iCurFaderID]->IsVisible() )
         {
-            // per definition: the fader order is colum-first/row-second (note that
-            // the value in iNumFadersFirstRows defines how many rows we will get)
+            // channels are added row-first, up to iNumFadersFirstRow, then onto
+            // the next row.
             pMainLayout->addWidget ( vecpChanFader[iCurFaderID]->GetMainWidget(),
-                    iVisibleFaderCnt % iNumMixerPanelRows,
-                    iVisibleFaderCnt / iNumMixerPanelRows );
+                    iVisibleFaderCnt / iNumFadersFirstRow,
+                    iVisibleFaderCnt % iNumFadersFirstRow );
 
             iVisibleFaderCnt++;
         }

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1074,7 +1074,7 @@ void CAudioMixerBoard::ChangeFaderOrder ( const EChSortType eChSortType )
     // we want to distribute iNumVisibleFaders across the first row, then the next, etc
     // up to iNumMixerPanelRows.  So row wants to start at 0 until we get to some number,
     // then increase, where "some number" means we get no more than iNumMixerPanelRows.
-    const int iNumFadersFirstRow = 1 + ( iNumVisibleFaders / iNumMixerPanelRows );
+    const int iNumFadersFirstRow = ( iNumVisibleFaders + iNumMixerPanelRows - 1 ) / iNumMixerPanelRows;
 
     // add channels to the layout in the new order, note that it is not required to remove
     // the widget from the layout first but it is moved to the new position automatically


### PR DESCRIPTION
Five clients, one row:
![image](https://user-images.githubusercontent.com/1549463/116005150-9d578680-a5fd-11eb-94c0-d76d3c4c71fd.png)
Two rows:
![image](https://user-images.githubusercontent.com/1549463/116005175-afd1c000-a5fd-11eb-8b0e-e27a5b1e7db7.png)
Three rows (the window would open any taller for me):
![image](https://user-images.githubusercontent.com/1549463/116005194-bf510900-a5fd-11eb-8231-981ff6d06fd1.png)
