### PR TITLE
Server: Permit simple HTML in chat messages again

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -415,6 +415,8 @@ protected:
 
     CSignalHandler*            pSignalHandler;
 
+    QList<QRegExp>             qlPermittedChatTagPatterns;
+
 signals:
     void Started();
     void Stopped();


### PR DESCRIPTION
PR #939 disabled HTML usage in chat messages by escaping all user input at the server side for security reasons.

There is demand to keep basic text formatting working for sharing lyrics/chords in a sane way.

This PR re-enables certain safe tags again to enable such use cases.

This works by keeping the existing message escaping, but converting selected safe HTML tags back into their parsable form.

To avoid worsening security again, this PR deliberately
- does not permit CSS or any color changes which could enable user
  impersonation,
- does not accept any attributes in HTML tags,
- does not accept invalid HTML (e.g. start tags without end tags),
- does not accept nested HTML tags (except for `<br>`s within `<pre>...</pre>`).
- does not handle uppercase tags or XML-style

References: https://github.com/jamulussoftware/jamulus/discussions/1021 https://github.com/jamulussoftware/jamulus/discussions/1524

This PR seems to work, but I'm marking it as draft because the topic hasn't been discussed fully yet.

Freel free to post feedback on the code here. Feedback regarding the best approach should rather be posted to the [discussion thread](https://github.com/jamulussoftware/jamulus/discussions/1021).

cc @atsampson 