### PR TITLE
Server: Sync channel list right after connect

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -665,6 +665,9 @@ void CServer::OnNewConnection ( int          iChID,
     // send recording state message on connection
     vecChannels[iChID].CreateRecorderStateMes ( JamController.GetRecorderState() );
 
+    // ensure that all other clients know about the new one
+    CreateAndSendChanListForAllConChannels();
+
     // reset the conversion buffers
     DoubleFrameSizeConvBufIn[iChID].Reset();
     DoubleFrameSizeConvBufOut[iChID].Reset();


### PR DESCRIPTION
Previously, the list of active channels was only distributed to clients when metadata such as names had changed. This allowed for clients to remain in a semi-connected state.

This change ensures that a complete channel list is sent as soon as a new client connects. Therefore, state is properly synced across all clients.

Fixes #1243.

Testing:
The difference can be observed when running client without `Protocol.CreateChanInfoMes`.
On a server without this PR, this client would be invisible to all previously connected clients.
On a server with this this PR, the client will be visible right away.

@softins Can you check how that works in combination with Jamulus Explorer's welcome message scraping? I fear it would cause a channel with an empty name to appear for a very short time. :(
With this approach, I could only think about delaying this synchronization step to avoid this. This would have the downside of not completely fixing this though.
A completely different approach is given in #1243 as Option 2.