### PR TITLE
Settings: Remember last used tab & move mixer rows setting to "My Profile"

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -243,16 +243,19 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QMenu* pViewMenu = new QMenu ( tr ( "&View" ), this );
 
     pViewMenu->addAction ( tr ( "&Connection Setup..." ), this,
-        SLOT ( OnOpenConnectionSetupDialog() ) );
+        SLOT ( OnOpenConnectionSetupDialog() ), QKeySequence ( Qt::CTRL + Qt::Key_C ) );
 
     pViewMenu->addAction ( tr ( "My &Profile..." ), this,
-        SLOT ( OnOpenMusicianProfileDialog() ) );
+        SLOT ( OnOpenUserProfileSettings() ), QKeySequence ( Qt::CTRL + Qt::Key_P ) );
 
     pViewMenu->addAction ( tr ( "C&hat..." ), this,
-        SLOT ( OnOpenChatDialog() ) );
+        SLOT ( OnOpenChatDialog() ), QKeySequence ( Qt::CTRL + Qt::Key_H ) );
 
-    pViewMenu->addAction ( tr ( "&Settings..." ), this,
-        SLOT ( OnOpenGeneralSettings() ) );
+    pViewMenu->addAction ( tr ( "Audio/Network &Settings..." ), this,
+        SLOT ( OnOpenAudioNetSettings() ), QKeySequence ( Qt::CTRL + Qt::Key_S ) );
+
+    pViewMenu->addAction ( tr ( "A&dvanced Settings..." ), this,
+        SLOT ( OnOpenAdvancedSettings() ), QKeySequence ( Qt::CTRL + Qt::Key_D ) );
 
     // optionally show analyzer console entry
     if ( bShowAnalyzerConsole )
@@ -862,12 +865,17 @@ void CClientDlg::OnNumClientsChanged ( int iNewNumClients )
     SetMyWindowTitle ( iNewNumClients );
 }
 
-void CClientDlg::OnOpenGeneralSettings()
+void CClientDlg::OnOpenAudioNetSettings()
 {
     ShowGeneralSettings ( SETTING_TAB_AUDIONET );
 }
 
-void CClientDlg::OnOpenMusicianProfileDialog()
+void CClientDlg::OnOpenAdvancedSettings()
+{
+    ShowGeneralSettings ( SETTING_TAB_ADVANCED );
+}
+
+void CClientDlg::OnOpenUserProfileSettings()
 {
     ShowGeneralSettings ( SETTING_TAB_USER );
 }

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -245,11 +245,11 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pViewMenu->addAction ( tr ( "&Connection Setup..." ), this,
         SLOT ( OnOpenConnectionSetupDialog() ), QKeySequence ( Qt::CTRL + Qt::Key_C ) );
 
-    pViewMenu->addAction ( tr ( "My &Profile..." ), this,
-        SLOT ( OnOpenUserProfileSettings() ), QKeySequence ( Qt::CTRL + Qt::Key_P ) );
-
     pViewMenu->addAction ( tr ( "C&hat..." ), this,
         SLOT ( OnOpenChatDialog() ), QKeySequence ( Qt::CTRL + Qt::Key_H ) );
+
+    pViewMenu->addAction ( tr ( "My &Profile..." ), this,
+        SLOT ( OnOpenUserProfileSettings() ), QKeySequence ( Qt::CTRL + Qt::Key_P ) );
 
     pViewMenu->addAction ( tr ( "Audio/Network &Settings..." ), this,
         SLOT ( OnOpenAudioNetSettings() ), QKeySequence ( Qt::CTRL + Qt::Key_S ) );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -864,12 +864,12 @@ void CClientDlg::OnNumClientsChanged ( int iNewNumClients )
 
 void CClientDlg::OnOpenGeneralSettings()
 {
-    ShowGeneralSettings( SETTING_TAB_AUDIONET );
+    ShowGeneralSettings ( SETTING_TAB_AUDIONET );
 }
 
 void CClientDlg::OnOpenMusicianProfileDialog()
 {
-    ShowGeneralSettings( SETTING_TAB_USER );
+    ShowGeneralSettings ( SETTING_TAB_USER );
 }
 
 void CClientDlg::SetMyWindowTitle ( const int iNumClients )

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -343,7 +343,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     if ( pSettings->bWindowWasShownSettings )
     {
-        ShowGeneralSettings();
+        ShowGeneralSettings( pSettings->iSettingsTab );
     }
 
     // chat window
@@ -862,6 +862,16 @@ void CClientDlg::OnNumClientsChanged ( int iNewNumClients )
     SetMyWindowTitle ( iNewNumClients );
 }
 
+void CClientDlg::OnOpenGeneralSettings()
+{
+    ShowGeneralSettings( SETTING_TAB_AUDIONET );
+}
+
+void CClientDlg::OnOpenMusicianProfileDialog()
+{
+    ShowGeneralSettings( SETTING_TAB_USER );
+}
+
 void CClientDlg::SetMyWindowTitle ( const int iNumClients )
 {
     // set the window title (and therefore also the task bar icon text of the OS)
@@ -937,22 +947,10 @@ void CClientDlg::ShowConnectionSetupDialog()
     ConnectDlg.activateWindow();
 }
 
-void CClientDlg::ShowMusicianProfileDialog()
-{
-    // show musician profile dialog
-    emit SendTabChange ( SETTING_TAB_USER );
-    ClientSettingsDlg.show();
-    ClientSettingsDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Settings" ) , pClient->strClientName ) );
-
-    // make sure dialog is upfront and has focus
-    ClientSettingsDlg.raise();
-    ClientSettingsDlg.activateWindow();
-}
-
-void CClientDlg::ShowGeneralSettings()
+void CClientDlg::ShowGeneralSettings( int iTab )
 {
     // open general settings dialog
-    emit SendTabChange ( SETTING_TAB_AUDIONET );
+    emit SendTabChange ( iTab );
     ClientSettingsDlg.show();
     ClientSettingsDlg.setWindowTitle ( MakeClientNameTitle ( tr ( "Settings" ) , pClient->strClientName ) );
 
@@ -991,7 +989,7 @@ void CClientDlg::OnSettingsStateChanged ( int value )
 {
     if ( value == Qt::Checked )
     {
-        ShowGeneralSettings();
+        ShowGeneralSettings( SETTING_TAB_AUDIONET );
     }
     else
     {

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -89,8 +89,7 @@ protected:
     void               SetGUIDesign ( const EGUIDesign eNewDesign );
     void               SetMyWindowTitle ( const int iNumClients );
     void               ShowConnectionSetupDialog();
-    void               ShowMusicianProfileDialog();
-    void               ShowGeneralSettings();
+    void               ShowGeneralSettings( int iTab );
     void               ShowChatWindow ( const bool bForceRaise = true );
     void               ShowAnalyzerConsole();
     void               UpdateAudioFaderSlider();
@@ -168,8 +167,8 @@ public slots:
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }
-    void OnOpenMusicianProfileDialog() { ShowMusicianProfileDialog(); }
-    void OnOpenGeneralSettings() { ShowGeneralSettings(); }
+    void OnOpenMusicianProfileDialog();
+    void OnOpenGeneralSettings();
     void OnOpenChatDialog() { ShowChatWindow(); }
     void OnOpenAnalyzerConsole() { ShowAnalyzerConsole(); }
     void OnNoSortChannels()           { MainMixerBoard->SetFaderSorting ( ST_NO_SORT ); }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -167,8 +167,9 @@ public slots:
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }
-    void OnOpenMusicianProfileDialog();
-    void OnOpenGeneralSettings();
+    void OnOpenUserProfileSettings();
+    void OnOpenAudioNetSettings();
+    void OnOpenAdvancedSettings();
     void OnOpenChatDialog() { ShowChatWindow(); }
     void OnOpenAnalyzerConsole() { ShowAnalyzerConsole(); }
     void OnNoSortChannels()           { MainMixerBoard->SetFaderSorting ( ST_NO_SORT ); }

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -666,7 +666,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
     QObject::connect ( tabSettings, &QTabWidget::currentChanged,
         this, &CClientSettingsDlg::OnTabChanged );
 
-    tabSettings->setCurrentIndex ( pSettings->iSettingsTab ); //pSettings->iSettingsTab
+    tabSettings->setCurrentIndex ( pSettings->iSettingsTab );
 
     // Timers ------------------------------------------------------------------
     // start timer for status bar

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -666,7 +666,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient*         pNCliP,
     QObject::connect ( tabSettings, &QTabWidget::currentChanged,
         this, &CClientSettingsDlg::OnTabChanged );
 
-    tabSettings->setCurrentIndex ( iTabIdx );
+    tabSettings->setCurrentIndex ( pSettings->iSettingsTab ); //pSettings->iSettingsTab
 
     // Timers ------------------------------------------------------------------
     // start timer for status bar
@@ -1108,12 +1108,12 @@ void CClientSettingsDlg::OnMakeTabChange ( int iTab )
 {
     tabSettings->setCurrentIndex ( iTab );
 
-    iTabIdx = iTab;
+    pSettings->iSettingsTab = iTab;
 }
 
 void CClientSettingsDlg::OnTabChanged ( void )
 {
-    iTabIdx = tabSettings->currentIndex();
+    pSettings->iSettingsTab = tabSettings->currentIndex();
 }
 
 void CClientSettingsDlg::UpdateAudioFaderSlider()

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -74,8 +74,6 @@ public:
 
     void UpdateDisplay();
     void UpdateSoundDeviceChannelSelectionFrame();
-    void SetTabIdx( int iIdx ) { iTabIdx = iIdx; }
-    int  iTabIdx;
 
     void SetEnableFeedbackDetection ( bool enable );
 

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -24,13 +24,16 @@
    <item>
     <widget class="QTabWidget" name="tabSettings">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>true</bool>
      </property>
      <widget class="QWidget" name="tab_0_User">
       <attribute name="title">
        <string>My Profile</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_11">
+      <layout class="QVBoxLayout" name="verticalLayout_16">
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_10">
          <item>
@@ -213,6 +216,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <widget class="QLabel" name="lblMixerRows">
+                    <property name="text">
+                     <string>Mixer Rows</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </item>
                 <item>
@@ -227,6 +237,19 @@
                       <width>150</width>
                       <height>0</height>
                      </size>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSpinBox" name="spnMixerRows">
+                    <property name="alignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                    <property name="minimum">
+                     <number>1</number>
+                    </property>
+                    <property name="maximum">
+                     <number>8</number>
                     </property>
                    </widget>
                   </item>
@@ -1091,39 +1114,6 @@
              </item>
              <item>
               <spacer name="verticalSpacer_13">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLabel" name="lblMixerRows">
-               <property name="text">
-                <string>Mixer Rows</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="spnMixerRows">
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>8</number>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacer_14">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
                </property>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -540,7 +540,7 @@ if ( GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) )
 
     // selected Settings Tab
     if ( GetNumericIniSet ( IniXMLDocument, "client", "settingstab",
-         0, 3, iValue ) )
+         0, 2, iValue ) )
     {
         iSettingsTab = iValue;
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -538,6 +538,13 @@ if ( GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) )
         bWindowWasShownConnect = bValue;
     }
 
+    // selected Settings Tab
+    if ( GetNumericIniSet ( IniXMLDocument, "client", "settingstab",
+         0, 3, iValue ) )
+    {
+        iSettingsTab = iValue;
+    }
+
     // fader settings
     ReadFaderSettingsFromXML ( IniXMLDocument );
 }
@@ -760,6 +767,10 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // visibility state of the connect window
     SetFlagIniSet ( IniXMLDocument, "client", "winviscon",
         bWindowWasShownConnect );
+
+    // Settings Tab
+    SetNumericIniSet ( IniXMLDocument, "client", "settingstab",
+        iSettingsTab );
 
     // fader settings
     WriteFaderSettingsToXML ( IniXMLDocument );

--- a/src/settings.h
+++ b/src/settings.h
@@ -146,6 +146,7 @@ public:
         vstrIPAddress               ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
         iNewClientFaderLevel        ( 100 ),
         iInputBoost                 ( 1 ),
+        iSettingsTab                ( SETTING_TAB_AUDIONET ),
         bConnectDlgShowAllMusicians ( true ),
         eChannelSortType            ( ST_NO_SORT ),
         iNumMixerPanelRows          ( 1 ),
@@ -174,6 +175,7 @@ public:
     CVector<QString> vstrIPAddress;
     int              iNewClientFaderLevel;
     int              iInputBoost;
+    int              iSettingsTab;
     bool             bConnectDlgShowAllMusicians;
     EChSortType      eChannelSortType;
     int              iNumMixerPanelRows;


### PR DESCRIPTION
If Settings window shown at program start, last tab is shown.
last state saved in ini file.
Some redundant code concerning tab change removed.