### PR TITLE
Improve directory server handling in GUI mode.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -856,6 +856,9 @@ int main ( int argc, char** argv )
                 // only start application without using the GUI
                 qInfo() << qUtf8Printable( GetVersionAndNameStr ( false ) );
 
+                // enable server list if a directory server is defined
+                Server.SetServerListEnabled ( !strCentralServer.isEmpty() );
+
                 // update serverlist
                 Server.UpdateServerList();
 

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -571,11 +571,6 @@ void CServerDlg::OnLocationCountryActivated ( int iCntryListItem )
 
 void CServerDlg::OnCentServAddrTypeActivated ( int iTypeIdx )
 {
-    // if server was registered, unregister first
-    if ( pServer->GetServerListEnabled() )
-    {
-        pServer->UnregisterSlaveServer();
-    }
 
     // apply new setting to the server and update it
     pServer->SetCentralServerAddressType ( static_cast<ECSAddType> ( iTypeIdx ) );

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -202,7 +202,7 @@ void CServerListManager::SetCentralServerAddressType ( const ECSAddType eNCSAT )
 
     QMutexLocker locker ( &Mutex );
 
-    // no update the server type
+    // now update the server type
     eCentralServerAddressType = eNCSAT;
 
     // per definition: If we are in server mode and the directory server address

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -168,12 +168,14 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
 void CServerListManager::SetCentralServerAddress ( const QString sNCentServAddr )
 {
     // if the address has not actually changed, do nothing
-    if ( sNCentServAddr == strCentralServerAddress ) {
+    if ( sNCentServAddr == strCentralServerAddress )
+    {
         return;
     }
 
     // if we are registered to a custom directory server, unregister before updating the name
-    if ( eCentralServerAddressType == AT_CUSTOM && GetSvrRegStatus() == SRS_REGISTERED ) {
+    if ( eCentralServerAddressType == AT_CUSTOM && GetSvrRegStatus() == SRS_REGISTERED )
+    {
         SlaveServerUnregister();
     }
 
@@ -196,7 +198,8 @@ void CServerListManager::SetCentralServerAddress ( const QString sNCentServAddr 
 void CServerListManager::SetCentralServerAddressType ( const ECSAddType eNCSAT )
 {
     // if the type is changing, unregister before updating
-    if ( eNCSAT != eCentralServerAddressType && GetSvrRegStatus() == SRS_REGISTERED ) {
+    if ( eNCSAT != eCentralServerAddressType && GetSvrRegStatus() == SRS_REGISTERED )
+    {
         SlaveServerUnregister();
     }
 

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -146,7 +146,7 @@ public:
     void SetCentralServerAddress ( const QString sNCentServAddr );
     QString GetCentralServerAddress() { return strCentralServerAddress; }
 
-    void SetCentralServerAddressType ( const ECSAddType eNCSAT ) { eCentralServerAddressType = eNCSAT; }
+    void SetCentralServerAddressType ( const ECSAddType eNCSAT );
     ECSAddType GetCentralServerAddressType() { return eCentralServerAddressType; }
 
     bool GetIsCentralServer() const { return bIsCentralServer; }


### PR DESCRIPTION
Server was wrongly registering with a directory server every time the custom directory server field lost focus, even if the "Make public" checkbox was not enabled.

Fixes #1624