### PR TITLE
Change last instance of Central Server to Directory Server

### DIFF
--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -1070,7 +1070,7 @@
              <item>
               <widget class="QLabel" name="lblCentralServerAddress">
                <property name="text">
-                <string>Custom Central Server Address:</string>
+                <string>Custom Directory Server Address:</string>
                </property>
               </widget>
              </item>

--- a/src/serverdlgbase.ui
+++ b/src/serverdlgbase.ui
@@ -79,7 +79,7 @@
          <item>
           <widget class="QLabel" name="label">
            <property name="text">
-            <string>Genre</string>
+            <string>List</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
The item in clientsettingsdlgbase.ui had been missed (reported on Facebook).

Also took the opportunity to change Genre to List in the server dialog,
for consistency with the client connect dialog.

Updated translation files, and marked the Custom Directory Server Address
item as unfinished, so it won't get forgotten.