### PR TITLE
Mute icon: Fix alignment by not hardcoding font height

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -86,9 +86,10 @@ CChannelFader::CChannelFader ( QWidget* pNW ) :
     pPan->setRange               ( 0, AUD_MIX_PAN_MAX );
     pPan->setValue               ( AUD_MIX_PAN_MAX / 2 );
     pPan->setNotchesVisible      ( true );
-    pInfoLabel->setMinimumHeight ( 15 ); // prevents jitter when muting/unmuting (#811)
-    pPanInfoGrid->addWidget      ( pPanLabel, 0, Qt::AlignLeft );
-    pPanInfoGrid->addWidget      ( pInfoLabel );
+    pInfoLabel->setMinimumHeight ( pPanLabel->height() ); // prevents jitter when muting/unmuting (#811)
+    pInfoLabel->setAlignment     ( Qt::AlignTop );
+    pPanInfoGrid->addWidget      ( pPanLabel, 0, Qt::AlignLeft | Qt::AlignTop );
+    pPanInfoGrid->addWidget      ( pInfoLabel, 0, Qt::AlignHCenter | Qt::AlignTop );
     pPanGrid->addLayout          ( pPanInfoGrid );
     pPanGrid->addWidget          ( pPan, 0, Qt::AlignHCenter );
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -491,6 +491,7 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
         "<p>Ferenc Wágner (<a href=\"https://github.com/wferi\">wferi</a>)</p>"
         "<p>Martin Kaistra (<a href=\"https://github.com/djfun\">djfun</a>)</p>"
         "<p>Burkhard Volkemer (<a href=\"https://github.com/buv\">buv</a>)</p>"
+        "<p>Magnus Groß (<a href=\"https://github.com/vimpostor\">vimpostor</a>)</p>"
         "<br>" + tr ( "For details on the contributions check out the " ) +
         "<a href=\"https://github.com/jamulussoftware/jamulus/graphs/contributors\">" + tr ( "Github Contributors list" ) + "</a>." );
 


### PR DESCRIPTION
Fixes #1312

**Before**: On the Left - Volume Sliders have mismatched height, Mute icon is slightly misaligned
**After**: On the Right - Volume Sliders and Mute icon are placed without weird misalignment
![Screenshot_20210506_003727](https://user-images.githubusercontent.com/21310755/117218515-9867b380-ae03-11eb-8c3f-9cda13b64898.png)

Note that I tried some cleaner ways of fixing this misalignement - that is I tried not setting minimum height at all and using a more clever alignment. None of that worked though and I actually think there is a Qt bug when rendering Unicode symbols regarding the height of layouts.

Anyways, in the end I think this is the best method of solving the problem now.