### PR TITLE
Add action to select Xcode 11.7 for Qt5 compatibility on Mac

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -134,6 +134,9 @@ jobs:
 
     runs-on:                        ${{ matrix.config.building_on_os }}
     steps:
+
+      # For Qt5 on Mac, we need to ensure SDK 10.15 is used, and not SDK 11.x
+      # This is done by selecting Xcode 11.7 instead of the latest default of 12.x
       - name:                       Select Xcode version for Mac
         if:                         ${{ matrix.config.target_os == 'macos' }}
         uses:                       maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -134,6 +134,12 @@ jobs:
 
     runs-on:                        ${{ matrix.config.building_on_os }}
     steps:
+      - name:                       Select Xcode version for Mac
+        if:                         ${{ matrix.config.target_os == 'macos' }}
+        uses:                       maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '11.7'
+
       # Checkout code
       - name:                       Checkout code
         uses:                       actions/checkout@v2


### PR DESCRIPTION
When testing a build for Mac with Qt 5.15.2, the following warning was received:
```
Project WARNING: Qt has only been tested with version 10.15 of the platform SDK, you're using 11.1.
Project WARNING: This is an unsupported configuration. You may experience build issues, and by using
Project WARNING: the 11.1 SDK you are opting in to new features that Qt has not been prepared for.
Project WARNING: Please downgrade the SDK you use to build your app to version 10.15, or configure
Project WARNING: with CONFIG+=sdk_no_version_check when running qmake to silence this warning.
```
This is because the default macOS build environment on Github is now using Xcode 12, which by default uses the 11.1 SDK.

Although Qt 5.9.9 does not give this warning, it seems likely that is because it just doesn't check, and it would seem reasonable to conclude that any potential incompatibility between Qt 5.15.2 and the 11.1 SDK would be even more the case with Qt 5.9.9.

This PR uses the action from https://github.com/marketplace/actions/setup-xcode-version to explicitly request Xcode 11.7, which by default uses the 10.15 SDK.