### PR TITLE
Add menu item for About Qt

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -573,6 +573,8 @@ CLicenceDlg::CLicenceDlg ( QWidget* parent ) : CBaseDlg ( parent )
 // Help menu -------------------------------------------------------------------
 CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&Help" ), parent )
 {
+    QAction* pAction;
+
     // standard help menu consists of about and what's this help
     if ( bIsClient )
     {
@@ -586,8 +588,10 @@ CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&
     addSeparator();
     addAction ( tr ( "What's &This" ), this, SLOT ( OnHelpWhatsThis() ), QKeySequence ( Qt::SHIFT + Qt::Key_F1 ) );
     addSeparator();
-    addAction ( tr ( "&About Jamulus..." ), this, SLOT ( OnHelpAbout() ) );
-    addAction ( tr ( "About &Qt..." ), this, SLOT ( OnHelpAboutQt() ) );
+    pAction = addAction ( tr ( "&About Jamulus..." ), this, SLOT ( OnHelpAbout() ) );
+    pAction->setMenuRole(QAction::AboutRole);
+    pAction = addAction ( tr ( "About &Qt..." ), this, SLOT ( OnHelpAboutQt() ) );
+    pAction->setMenuRole(QAction::AboutQtRole);
 }
 
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -586,7 +586,8 @@ CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&
     addSeparator();
     addAction ( tr ( "What's &This" ), this, SLOT ( OnHelpWhatsThis() ), QKeySequence ( Qt::SHIFT + Qt::Key_F1 ) );
     addSeparator();
-    addAction ( tr ( "&About..." ), this, SLOT ( OnHelpAbout() ) );
+    addAction ( tr ( "&About Jamulus..." ), this, SLOT ( OnHelpAbout() ) );
+    addAction ( tr ( "About &Qt..." ), this, SLOT ( OnHelpAboutQt() ) );
 }
 
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -589,9 +589,9 @@ CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&
     addAction ( tr ( "What's &This" ), this, SLOT ( OnHelpWhatsThis() ), QKeySequence ( Qt::SHIFT + Qt::Key_F1 ) );
     addSeparator();
     pAction = addAction ( tr ( "&About Jamulus..." ), this, SLOT ( OnHelpAbout() ) );
-    pAction->setMenuRole(QAction::AboutRole);
+    pAction->setMenuRole(QAction::AboutRole);   // required for Mac
     pAction = addAction ( tr ( "About &Qt..." ), this, SLOT ( OnHelpAboutQt() ) );
-    pAction->setMenuRole(QAction::AboutQtRole);
+    pAction->setMenuRole(QAction::AboutQtRole); // required for Mac
 }
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,7 @@
 #include <QHostAddress>
 #include <QHostInfo>
 #ifndef HEADLESS
+# include <QMessageBox>
 # include <QMenu>
 # include <QWhatsThis>
 # include <QTextBrowser>
@@ -437,6 +438,7 @@ protected:
 public slots:
     void OnHelpWhatsThis()        { QWhatsThis::enterWhatsThisMode(); }
     void OnHelpAbout()            { AboutDlg.exec(); }
+    void OnHelpAboutQt()          { QMessageBox::aboutQt(this, QString("About Qt")); }
     void OnHelpClientGetStarted() { QDesktopServices::openUrl ( QUrl ( CLIENT_GETTING_STARTED_URL ) ); }
     void OnHelpServerGetStarted() { QDesktopServices::openUrl ( QUrl ( SERVER_GETTING_STARTED_URL ) ); }
     void OnHelpSoftwareMan()      { QDesktopServices::openUrl ( QUrl ( SOFTWARE_MANUAL_URL ) ); }


### PR DESCRIPTION
This is using a built-in feature of Qt and was inspired by the same function in MuseScore. In addition to the existing About Jamulus box, it provides another menu item for "About Qt", which could be useful when diagnosing issues:
![image](https://user-images.githubusercontent.com/3224952/118354704-560d4780-b564-11eb-9ae2-83f71f9c6d7c.png)
That displays a message box built in to Qt, which gives information about the Qt version being used and its licensing:
![image](https://user-images.githubusercontent.com/3224952/118354734-7210e900-b564-11eb-9da4-138e7e51af7b.png)
The extra tweaks to the translation files can easily be done while preparing the RC version.