### PR TITLE
Update Qt on Mac to 5.12.10, for better compatibility with Big Sur

### DIFF
--- a/autobuild/mac/artifacts/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_1_prepare.sh
@@ -8,10 +8,10 @@
 
 echo "Install dependencies..."
 python3 -m pip install aqtinstall
-python3 -m aqt install --outputdir /usr/local/opt/qt 5.9.9 mac desktop
+python3 -m aqt install --outputdir /usr/local/opt/qt 5.12.10 mac desktop
 
 # add the qt binaries to the path
-export -p PATH=/usr/local/opt/qt/5.9.9/clang_64/bin:"${PATH}"
+export -p PATH=/usr/local/opt/qt/5.12.10/clang_64/bin:"${PATH}"
 echo "::set-env name=PATH::${PATH}"
 echo "the path is ${PATH}"
 

--- a/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
@@ -8,10 +8,10 @@
 
 echo "Install dependencies..."
 python3 -m pip install aqtinstall
-python3 -m aqt install --outputdir /usr/local/opt/qt 5.9.9 mac desktop
+python3 -m aqt install --outputdir /usr/local/opt/qt 5.12.10 mac desktop
 
 # add the qt binaries to the path
-export -p PATH=/usr/local/opt/qt/5.9.9/clang_64/bin:"${PATH}"
+export -p PATH=/usr/local/opt/qt/5.12.10/clang_64/bin:"${PATH}"
 echo "::set-env name=PATH::${PATH}"
 echo "the path is ${PATH}"
 


### PR DESCRIPTION
Note that this makes the earliest version of macOS supported by the release builds
to be 10.12 (Sierra), and drops support for Yosemite and El Capitan.