### PR TITLE
Fix spacing and make title translatable.

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -438,7 +438,7 @@ protected:
 public slots:
     void OnHelpWhatsThis()        { QWhatsThis::enterWhatsThisMode(); }
     void OnHelpAbout()            { AboutDlg.exec(); }
-    void OnHelpAboutQt()          { QMessageBox::aboutQt(this, QString("About Qt")); }
+    void OnHelpAboutQt()          { QMessageBox::aboutQt ( nullptr, QString ( tr ( "About Qt" ) ) ); }
     void OnHelpClientGetStarted() { QDesktopServices::openUrl ( QUrl ( CLIENT_GETTING_STARTED_URL ) ); }
     void OnHelpServerGetStarted() { QDesktopServices::openUrl ( QUrl ( SERVER_GETTING_STARTED_URL ) ); }
     void OnHelpSoftwareMan()      { QDesktopServices::openUrl ( QUrl ( SOFTWARE_MANUAL_URL ) ); }


### PR DESCRIPTION
Also supply `nullptr` as parent widget, instead of help menu. This should centre on screen.