### PR TITLE
Feature connectionlist

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -400,6 +400,7 @@ FORMS_GUI = src/clientdlgbase.ui \
 HEADERS += src/buffer.h \
     src/channel.h \
     src/client.h \
+    src/connectionlistdlg.h \
     src/global.h \
     src/protocol.h \
     src/recorder/jamcontroller.h \
@@ -502,6 +503,7 @@ HEADERS_OPUS_X86 = libs/opus/celt/x86/celt_lpc_sse.h \
 SOURCES += src/buffer.cpp \
     src/channel.cpp \
     src/client.cpp \
+    src/connectionlistdlg.cpp \
     src/main.cpp \
     src/protocol.cpp \
     src/recorder/jamcontroller.cpp \
@@ -1130,3 +1132,6 @@ contains(CONFIG, "disable_version_check") {
 }
 
 ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
+
+FORMS += \
+    src/connectionlistdlg.ui

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -44,7 +44,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     ChatDlg ( parent ),
     ConnectDlg ( pNSetP, bNewShowComplRegConnList, parent ),
     AnalyzerConsole ( pNCliP, parent ),
-    CtrlDlg( parent )
+    ConnectionListDlg( parent )
 {
     setupUi ( this );
 
@@ -502,7 +502,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                        &CClientDlg::OnCreateCLServerListReqConnClientsListMes );
 
     QObject::connect ( &ConnectDlg, &CConnectDlg::accepted, this, &CClientDlg::OnConnectDlgAccepted );
-    QObject::connect ( &CtrlDlg, &ConnectionListDlg::CtrlDlgUpdated, this, &CClientDlg::OnCtrlDlgUpdated );
+    QObject::connect ( &ConnectionListDlg, &CConnectionListDlg::CtrlDlgUpdated, this, &CClientDlg::OnCtrlDlgUpdated );
 
     // Initializations which have to be done after the signals are connected ---
     // start timer for status bar
@@ -556,7 +556,7 @@ void CClientDlg::closeEvent ( QCloseEvent* Event )
     ClientSettingsDlg.close();
     ChatDlg.close();
     ConnectDlg.close();
-    CtrlDlg.close();
+    ConnectionListDlg.close();
     AnalyzerConsole.close();
 
     // if connected, terminate connection
@@ -637,10 +637,10 @@ void CClientDlg::UpdateRevSelection()
 void CClientDlg::OnCtrlDlgUpdated()
 {
         // get the address from the CtrlDlg dialog
-        QString strSelectedAddress = CtrlDlg.getSelectedAddress();
+        QString strSelectedAddress = ConnectionListDlg.getSelectedAddress();
 
         // get name to be set in audio mixer group box title
-        QString strMixerBoardLabel = CtrlDlg.getSelectedName();
+        QString strMixerBoardLabel = ConnectionListDlg.getSelectedName();
 
         // first check if we are already connected, if this is the case we have to
         // disconnect the old server first
@@ -749,10 +749,10 @@ void CClientDlg::OnConnectionList()
      if ( !strFileName.isEmpty() )
      {
          // first update the settings struct and then update the mixer panel
-         CtrlDlg.LoadConnectionList(strFileName);
-         CtrlDlg.show();
-         CtrlDlg.raise();
-         CtrlDlg.activateWindow();
+         ConnectionListDlg.LoadConnectionList(strFileName);
+         ConnectionListDlg.show();
+         ConnectionListDlg.raise();
+         ConnectionListDlg.activateWindow();
      }
 }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -502,7 +502,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                        &CClientDlg::OnCreateCLServerListReqConnClientsListMes );
 
     QObject::connect ( &ConnectDlg, &CConnectDlg::accepted, this, &CClientDlg::OnConnectDlgAccepted );
-    QObject::connect ( &ConnectionListDlg, &CConnectionListDlg::CtrlDlgUpdated, this, &CClientDlg::OnCtrlDlgUpdated );
+    QObject::connect ( &ConnectionListDlg, &CConnectionListDlg::ConnectionListDlgUpdated, this, &CClientDlg::OnConnectionListDlgUpdated );
 
     // Initializations which have to be done after the signals are connected ---
     // start timer for status bar
@@ -634,9 +634,9 @@ void CClientDlg::UpdateRevSelection()
     MainMixerBoard->SetDisplayPans ( pClient->GetAudioChannels() != CC_MONO );
 }
 
-void CClientDlg::OnCtrlDlgUpdated()
+void CClientDlg::OnConnectionListDlgUpdated()
 {
-        // get the address from the CtrlDlg dialog
+        // get the address from the ConnectionListDlg dialog
         QString strSelectedAddress = ConnectionListDlg.getSelectedAddress();
 
         // get name to be set in audio mixer group box title

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -247,9 +247,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // File menu  --------------------------------------------------------------
     QMenu* pFileMenu = new QMenu ( tr ( "&File" ), this );
 
-    pFileMenu->addAction ( tr ( "Load &Connection list..." ), this,
-    +         SLOT ( OnConnectionList() ) );
-
     pFileMenu->addAction ( tr ( "&Load Mixer Channels Setup..." ), this, SLOT ( OnLoadChannelSetup() ) );
 
     pFileMenu->addAction ( tr ( "&Save Mixer Channels Setup..." ), this, SLOT ( OnSaveChannelSetup() ) );
@@ -349,6 +346,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pMenu->addMenu ( pFileMenu );
     pMenu->addMenu ( pViewMenu );
     pMenu->addMenu ( pEditMenu );
+    pMenu->addMenu ( ConnectionListDlg.setupMenu(this) );
     pMenu->addMenu ( new CHelpMenu ( true, this ) );
 
     // Now tell the layout about the menu
@@ -738,22 +736,6 @@ void CClientDlg::OnClearAllStoredSoloMuteSettings()
     pSettings->vecStoredFaderIsSolo.Reset ( false );
     pSettings->vecStoredFaderIsMute.Reset ( false );
     MainMixerBoard->LoadAllFaderSettings();
-}
-void CClientDlg::OnConnectionList()
-{
-     QString strFileName = QFileDialog::getOpenFileName ( this,
-                                                          tr ( "Favourites file" ),
-                                                          "",
-                                                          QString ( "*.jcl" ));
-
-     if ( !strFileName.isEmpty() )
-     {
-         // first update the settings struct and then update the mixer panel
-         ConnectionListDlg.LoadConnectionList(strFileName);
-         ConnectionListDlg.show();
-         ConnectionListDlg.raise();
-         ConnectionListDlg.activateWindow();
-     }
 }
 
 void CClientDlg::OnLoadChannelSetup()
@@ -1204,10 +1186,10 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
 
         // change connect button text to "disconnect"
         butConnect->setText ( tr ( "D&isconnect" ) );
-
+        butConnect->repaint();
         // set server name in audio mixer group box title
         MainMixerBoard->SetServerName ( strMixerBoardLabel );
-
+        ConnectionListDlg.setCurrentServer(strMixerBoardLabel, strSelectedAddress);
         // start timer for level meter bar and ping time measurement
         TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );
         TimerBuffersLED.start ( BUFFER_LED_UPDATE_TIME_MS );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -149,7 +149,6 @@ public slots:
 
     void OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType, QString strVersion );
 
-    void OnConnectionList();
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -122,7 +122,7 @@ protected:
     CChatDlg           ChatDlg;
     CConnectDlg        ConnectDlg;
     CAnalyzerConsole   AnalyzerConsole;
-    ConnectionListDlg         CtrlDlg;
+    CConnectionListDlg  ConnectionListDlg;
 
 public slots:
     void OnConnectDisconBut();

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -225,7 +225,7 @@ public slots:
 
     void OnConnectDlgAccepted();
     void OnDisconnected() { Disconnect(); }
-    void OnCtrlDlgUpdated();
+    void OnConnectionListDlgUpdated();
     void OnGUIDesignChanged();
     void OnRecorderStateReceived ( ERecorderState eRecorderState );
     void SetMixerBoardDeco ( const ERecorderState newRecorderState, const EGUIDesign eNewDesign );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -49,6 +49,7 @@
 #include "clientsettingsdlg.h"
 #include "chatdlg.h"
 #include "connectdlg.h"
+#include "connectionlistdlg.h"
 #include "analyzerconsole.h"
 #include "ui_clientdlgbase.h"
 #if defined( __APPLE__ ) || defined( __MACOSX )
@@ -121,6 +122,7 @@ protected:
     CChatDlg           ChatDlg;
     CConnectDlg        ConnectDlg;
     CAnalyzerConsole   AnalyzerConsole;
+    ConnectionListDlg         CtrlDlg;
 
 public slots:
     void OnConnectDisconBut();
@@ -147,6 +149,7 @@ public slots:
 
     void OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType, QString strVersion );
 
+    void OnConnectionList();
     void OnLoadChannelSetup();
     void OnSaveChannelSetup();
     void OnOpenConnectionSetupDialog() { ShowConnectionSetupDialog(); }
@@ -222,6 +225,7 @@ public slots:
 
     void OnConnectDlgAccepted();
     void OnDisconnected() { Disconnect(); }
+    void OnCtrlDlgUpdated();
     void OnGUIDesignChanged();
     void OnRecorderStateReceived ( ERecorderState eRecorderState );
     void SetMixerBoardDeco ( const ERecorderState newRecorderState, const EGUIDesign eNewDesign );

--- a/src/connectionlistdlg.cpp
+++ b/src/connectionlistdlg.cpp
@@ -6,20 +6,20 @@
 
 
 
-ConnectionListDlg::ConnectionListDlg(QWidget *parent) :
+CConnectionListDlg::CConnectionListDlg(QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::ConnectionListDlg),
+    ui(new Ui::CConnectionListDlg),
     vecServerInfo(0),
     ulSelectedServer(0)
 {
     ui->setupUi(this);
 }
 
-ConnectionListDlg::~ConnectionListDlg()
+CConnectionListDlg::~CConnectionListDlg()
 {
     delete ui;
 }
-void ConnectionListDlg::LoadConnectionList(QString filename)
+void CConnectionListDlg::LoadConnectionList(QString filename)
 {
     NetworkUtil networkUtil;
 
@@ -55,12 +55,12 @@ void ConnectionListDlg::LoadConnectionList(QString filename)
     ulSelectedServer = 0;
 }
 
-void ConnectionListDlg::on_connectButton_clicked()
+void CConnectionListDlg::on_connectButton_clicked()
 {
     emit CtrlDlgUpdated();
 }
 
-void ConnectionListDlg::on_nextButton_clicked()
+void CConnectionListDlg::on_nextButton_clicked()
 {
     int newRow = ui->listWidget->currentRow()+1;
     if ( newRow == ui->listWidget->count() )
@@ -73,24 +73,24 @@ void ConnectionListDlg::on_nextButton_clicked()
     emit CtrlDlgUpdated();
 }
 
-QString ConnectionListDlg::getSelectedName()
+QString CConnectionListDlg::getSelectedName()
 {
     CServerInfo ci = vecServerInfo[ulSelectedServer];
     return ci.strName;
 }
 
-QString ConnectionListDlg::getSelectedAddress()
+QString CConnectionListDlg::getSelectedAddress()
 {
     CServerInfo ci = vecServerInfo[ulSelectedServer];
     return ci.HostAddr.toString();
 }
 
-void ConnectionListDlg::on_listWidget_currentRowChanged(int currentRow)
+void CConnectionListDlg::on_listWidget_currentRowChanged(int currentRow)
 {
     ulSelectedServer = currentRow;
 }
 
-void ConnectionListDlg::on_listWidget_itemDoubleClicked(QListWidgetItem *item)
+void CConnectionListDlg::on_listWidget_itemDoubleClicked(QListWidgetItem *item)
 {
     emit CtrlDlgUpdated();
 }

--- a/src/connectionlistdlg.cpp
+++ b/src/connectionlistdlg.cpp
@@ -57,7 +57,7 @@ void CConnectionListDlg::LoadConnectionList(QString filename)
 
 void CConnectionListDlg::on_connectButton_clicked()
 {
-    emit CtrlDlgUpdated();
+    emit ConnectionListDlgUpdated();
 }
 
 void CConnectionListDlg::on_nextButton_clicked()
@@ -70,7 +70,7 @@ void CConnectionListDlg::on_nextButton_clicked()
     ulSelectedServer = newRow;
     ui->listWidget->setCurrentRow(newRow);
     ui->listWidget->repaint();
-    emit CtrlDlgUpdated();
+    emit ConnectionListDlgUpdated();
 }
 
 QString CConnectionListDlg::getSelectedName()
@@ -92,6 +92,6 @@ void CConnectionListDlg::on_listWidget_currentRowChanged(int currentRow)
 
 void CConnectionListDlg::on_listWidget_itemDoubleClicked(QListWidgetItem *item)
 {
-    emit CtrlDlgUpdated();
+    emit ConnectionListDlgUpdated();
 }
 

--- a/src/connectionlistdlg.cpp
+++ b/src/connectionlistdlg.cpp
@@ -22,8 +22,9 @@ CConnectionListDlg::~CConnectionListDlg()
 QMenu* CConnectionListDlg::setupMenu(QWidget* pMain)
 {
     QMenu* pBookmarkMenu = new QMenu ( tr ( "&Bookmarks" ), pMain );
-    pBookmarkMenu->addAction ( tr ( "&Add Bookmark..." ), this,
+    pBookmarkMenu->addAction ( tr ( "&Add Bookmark" ), this,
     +         SLOT ( OnAddBookmark() ) );
+    pBookmarkMenu->addSeparator();
     pBookmarkMenu->addAction ( tr ( "&Load Bookmarks..." ), this,
     +         SLOT ( OnLoadBookmarks() ) );
     pBookmarkMenu->addAction ( tr ( "&Save Bookmarks..." ), this,
@@ -94,6 +95,7 @@ void CConnectionListDlg::OnAddBookmark()
                       0,
                       false ) );
     ui->listWidget->addItem(strCurrentServerName);
+    show();
 }
 void CConnectionListDlg::OnLoadBookmarks()
 {

--- a/src/connectionlistdlg.cpp
+++ b/src/connectionlistdlg.cpp
@@ -1,0 +1,97 @@
+#include "connectionlistdlg.h"
+#include "ui_connectionlistdlg.h"
+#include <QFile>
+#include <QMessageBox>
+#include <QDebug>
+
+
+
+ConnectionListDlg::ConnectionListDlg(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ConnectionListDlg),
+    vecServerInfo(0),
+    ulSelectedServer(0)
+{
+    ui->setupUi(this);
+}
+
+ConnectionListDlg::~ConnectionListDlg()
+{
+    delete ui;
+}
+void ConnectionListDlg::LoadConnectionList(QString filename)
+{
+    NetworkUtil networkUtil;
+
+    ui->listWidget->clear();
+    vecServerInfo.clear();
+
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(this,"Error!",file.errorString());
+        return ;
+    }
+    while (!file.atEnd()) {
+        QByteArray line = file.readLine();
+        QList<QByteArray> items = line.split(',');
+        if (items.size() == 2)
+        {
+        ui->listWidget->addItem(items[0]);
+        CHostAddress address;
+        networkUtil.ParseNetworkAddress(items[1],address);
+        // add server information to vector
+        vecServerInfo.Add (
+            CServerInfo ( address,
+                          address,
+                          items[0],
+                          QLocale::AnyCountry,
+                          "AnyCity",
+                          0,
+                          false ) );
+        } //end if
+    } //end while
+    file.close();
+    ui->listWidget->setCurrentRow(0);
+    ulSelectedServer = 0;
+}
+
+void ConnectionListDlg::on_connectButton_clicked()
+{
+    emit CtrlDlgUpdated();
+}
+
+void ConnectionListDlg::on_nextButton_clicked()
+{
+    int newRow = ui->listWidget->currentRow()+1;
+    if ( newRow == ui->listWidget->count() )
+    {
+        newRow = 0;
+    }
+    ulSelectedServer = newRow;
+    ui->listWidget->setCurrentRow(newRow);
+    ui->listWidget->repaint();
+    emit CtrlDlgUpdated();
+}
+
+QString ConnectionListDlg::getSelectedName()
+{
+    CServerInfo ci = vecServerInfo[ulSelectedServer];
+    return ci.strName;
+}
+
+QString ConnectionListDlg::getSelectedAddress()
+{
+    CServerInfo ci = vecServerInfo[ulSelectedServer];
+    return ci.HostAddr.toString();
+}
+
+void ConnectionListDlg::on_listWidget_currentRowChanged(int currentRow)
+{
+    ulSelectedServer = currentRow;
+}
+
+void ConnectionListDlg::on_listWidget_itemDoubleClicked(QListWidgetItem *item)
+{
+    emit CtrlDlgUpdated();
+}
+

--- a/src/connectionlistdlg.h
+++ b/src/connectionlistdlg.h
@@ -27,7 +27,7 @@ private slots:
     void on_listWidget_itemDoubleClicked(QListWidgetItem *item);
 
 signals:
-    void CtrlDlgUpdated() ;
+    void ConnectionListDlgUpdated() ;
 
 private:
     Ui::CConnectionListDlg *ui;

--- a/src/connectionlistdlg.h
+++ b/src/connectionlistdlg.h
@@ -1,21 +1,21 @@
-#ifndef CTRLDIALOG_H
-#define CTRLDIALOG_H
+
+#pragma once
 
 #include <QDialog>
 #include <util.h>
 #include <QListWidgetItem>
 
 namespace Ui {
-class ConnectionListDlg;
+class CConnectionListDlg;
 }
 
-class ConnectionListDlg : public QDialog
+class CConnectionListDlg : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit ConnectionListDlg(QWidget *parent = nullptr);
-    ~ConnectionListDlg();
+    explicit CConnectionListDlg(QWidget *parent = nullptr);
+    ~CConnectionListDlg();
     QString getSelectedName();
     QString getSelectedAddress();
     void LoadConnectionList(QString filename);
@@ -30,9 +30,7 @@ signals:
     void CtrlDlgUpdated() ;
 
 private:
-    Ui::ConnectionListDlg *ui;
+    Ui::CConnectionListDlg *ui;
     CVector<CServerInfo> vecServerInfo ;
     unsigned long ulSelectedServer;
 };
-
-#endif // CTRLDIALOG_H

--- a/src/connectionlistdlg.h
+++ b/src/connectionlistdlg.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <util.h>
 #include <QListWidgetItem>
+#include <QDebug>
 
 namespace Ui {
 class CConnectionListDlg;
@@ -18,14 +19,22 @@ public:
     ~CConnectionListDlg();
     QString getSelectedName();
     QString getSelectedAddress();
-    void LoadConnectionList(QString filename);
-
+    QMenu* setupMenu(QWidget* pMain);
+    inline void setCurrentServer(const QString& name, const QString& address)
+    { strCurrentServerName = name; strCurrentServerAddress = address; }
+private:
+    void LoadConnectionList(const QString& filename);
+    void SaveConnectionList(const QString& filename);
 private slots:
     void on_connectButton_clicked();
     void on_nextButton_clicked();
     void on_listWidget_currentRowChanged(int currentRow);
     void on_listWidget_itemDoubleClicked(QListWidgetItem *item);
 
+public slots:
+    void OnAddBookmark();
+    void OnLoadBookmarks();
+    void OnSaveBookmarks();
 signals:
     void ConnectionListDlgUpdated() ;
 
@@ -33,4 +42,6 @@ private:
     Ui::CConnectionListDlg *ui;
     CVector<CServerInfo> vecServerInfo ;
     unsigned long ulSelectedServer;
+    QString strCurrentServerName;
+    QString strCurrentServerAddress;
 };

--- a/src/connectionlistdlg.h
+++ b/src/connectionlistdlg.h
@@ -1,0 +1,38 @@
+#ifndef CTRLDIALOG_H
+#define CTRLDIALOG_H
+
+#include <QDialog>
+#include <util.h>
+#include <QListWidgetItem>
+
+namespace Ui {
+class ConnectionListDlg;
+}
+
+class ConnectionListDlg : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ConnectionListDlg(QWidget *parent = nullptr);
+    ~ConnectionListDlg();
+    QString getSelectedName();
+    QString getSelectedAddress();
+    void LoadConnectionList(QString filename);
+
+private slots:
+    void on_connectButton_clicked();
+    void on_nextButton_clicked();
+    void on_listWidget_currentRowChanged(int currentRow);
+    void on_listWidget_itemDoubleClicked(QListWidgetItem *item);
+
+signals:
+    void CtrlDlgUpdated() ;
+
+private:
+    Ui::ConnectionListDlg *ui;
+    CVector<CServerInfo> vecServerInfo ;
+    unsigned long ulSelectedServer;
+};
+
+#endif // CTRLDIALOG_H

--- a/src/connectionlistdlg.ui
+++ b/src/connectionlistdlg.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ConnectionListDlg</class>
- <widget class="QDialog" name="ConnectionListDlg">
+ <class>CConnectionListDlg</class>
+ <widget class="QDialog" name="CConnectionListDlg">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/connectionlistdlg.ui
+++ b/src/connectionlistdlg.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConnectionListDlg</class>
+ <widget class="QDialog" name="ConnectionListDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Connection List</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="1">
+    <widget class="QPushButton" name="nextButton">
+     <property name="text">
+      <string>Connect Next</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="connectButton">
+     <property name="text">
+      <string>Connect Selected</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QListWidget" name="listWidget"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION

![Screen Shot 2021-05-20 at 17 42 20](https://user-images.githubusercontent.com/41147387/119017381-db449200-b992-11eb-82f9-c59963ab9936.png)
The need:
- During WorldJam performances performers need to change servers multiple times. Using the currently available method this is not convenient.
- Sound engineers and other organisers need to move around a lot too.
- Most of these transitions are pre-defined and lists can be generated to provide a convenient path through the process.

The POC:
- This change adds a Menu item to the application where the user can select to load a server list *.jcl (Jamulus connection list)
- Format: "name,host:port"
- This list is provided in a new dialog box that allows to connect to the selected server via double click or using the relevant button. Also provides a connect to next button that takes the next server in the list and connects to that.
All previous connect/disconnect functionality stays un-affected.
