### PR TITLE
Jamulus.pro: Run clang-format on build

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,3 +1,7 @@
-# exclude third party code from clang-format checks
+# Exclude third party code from clang-format checks.
+#
+# This file is used by the clang-format-lint-action on Github.
+# When updating this list, remember to update Jamulus.pro's CLANG_SOURCES
+# as well.
 ./libs
 ./windows/nsProcess

--- a/.github/workflows/coding-style-check.yml
+++ b/.github/workflows/coding-style-check.yml
@@ -17,4 +17,6 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@2a28e3a8d9553f244243f7e1ff94f6685dff87be
       with:
         clangFormatVersion: 10
+        # When updating the extension list, remember to update
+        # Jamulus.pro's CLANG_SOURCES as well.
         extensions: 'cpp,h'

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1169,3 +1169,10 @@ contains(CONFIG, "disable_version_check") {
 
 ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
 
+# Enable formatting all code via `make clang_format`.
+# Note: When extending the list of file extensions or when changing the excludes,
+# be sure to update .github/workflows/coding-style-check.yml and .clang-format-ignore as well.
+CLANG_SOURCES = $$files(*.cpp, true) $$files(*.h, true)
+CLANG_SOURCES ~= s!^\(libs/|moc_|ui_|windows/nsProcess/|src/res/qrc_resources\.cpp\)\S*$!!g
+clang_format.commands = 'clang-format -i $$CLANG_SOURCES'
+QMAKE_EXTRA_TARGETS += clang_format


### PR DESCRIPTION
This ensures that clang-format is run on all source files before building (#1702).

If clang-format is not available, a warning is output and the build continues.

clang-format is also invoked on non-release builds only as that is what PRs will usually be based on.

@passing @pljones Would that be a useful integration? Can someone test on Windows how it would behave there (does it work when clang-format is available, does it continue properly if it isn't)?.

Just seeing a disadvantage right now: `$$SOURCE` does not include the platform-specific directories for the non-current platform (i.e. I'm on Linux and it won't contain `mac/`, etc.). :(
I guess we could do something `find`-based, but that would be hard to get right and nice in a cross-platform way, I think?