### PR TITLE
Restrict permissions to Autobuild

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -34,6 +34,8 @@ on:
 name:                               Auto-Build
 jobs:
   create_release:
+     permissions: # We need write permissions to create a release
+      contents: write
      name:                          Prepare Auto-Build/Release
      runs-on:                       ubuntu-20.04
      outputs:
@@ -86,6 +88,8 @@ jobs:
 
 
   release_assets:
+    permissions: # we need write permissions to upload assets
+        contents: write
     name:                           Build assets for ${{ matrix.config.config_name }}
     needs:                          create_release
     strategy:


### PR DESCRIPTION
Related to https://github.com/jamulussoftware/jamulus/issues/1737

Although not yet tested, I think we only need content permissions (which is quite a lot unfortunately) for the autobuild CI.