### PR TITLE
Mac build: Pin dmgbuild to 1.4.2 as 1.5.0 is broken

### DIFF
--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -44,7 +44,7 @@ build_installer_image()
 {
     # Install dmgbuild (for the current user), this is required to build the installer image
     python -m ensurepip --user --default-pip
-    python -m pip install --user dmgbuild
+    python -m pip install --user dmgbuild==1.4.2
     local dmgbuild_bin="$(python -c 'import site; print(site.USER_BASE)')/bin/dmgbuild"
 
     # Get Jamulus version


### PR DESCRIPTION
We are using `dmgbuild` in the Mac build process. Version 1.5.0 was released [some hours ago](https://pypi.org/project/dmgbuild/1.5.0/#history) and it breaks our build process as seen here:

https://github.com/hoffie/jamulus/runs/2709826916?check_suite_focus=true#step:6:1329 (that branch is a copy of `master`)

This PR pins the version to the version we've been using previously.
Unless `dmgbuild` is updated again on PyPI, this PR will have to be merged for the final Jamulus release as autobuild will fail otherwise. At the same time, it should be save to merge because it restores the state to what was used for rc2.

I have raised an upstream issue as well: https://github.com/al45tair/dmgbuild/issues/40