### PR TITLE
honour JACK_DEFAULT_SERVER environment variable

### DIFF
--- a/linux/sound.cpp
+++ b/linux/sound.cpp
@@ -29,9 +29,9 @@
 #ifdef WITH_JACK
 void CSound::OpenJack ( const bool bNoAutoJackConnect, const char* jackClientName )
 {
-    jack_status_t JackStatus;
+    jack_status_t  JackStatus;
     jack_options_t options = JackServerName;
-    const char*   serverName;
+    const char*    serverName;
 
     if ( ( serverName = getenv ( "JACK_DEFAULT_SERVER" ) ) == NULL )
     {

--- a/linux/sound.cpp
+++ b/linux/sound.cpp
@@ -30,6 +30,7 @@
 void CSound::OpenJack ( const bool bNoAutoJackConnect, const char* jackClientName )
 {
     jack_status_t JackStatus;
+    jack_options_t options = JackServerName;
     const char*   serverName;
 
     if ( ( serverName = getenv ( "JACK_DEFAULT_SERVER" ) ) == NULL )
@@ -40,7 +41,7 @@ void CSound::OpenJack ( const bool bNoAutoJackConnect, const char* jackClientNam
         QString ( "Connecting to jack \"%1\" instance (use the JACK_DEFAULT_SERVER environment variable to change this)." ).arg ( serverName ) );
 
     // try to become a client of the JACK server
-    pJackClient = jack_client_open ( jackClientName, JackNullOption, &JackStatus );
+    pJackClient = jack_client_open ( jackClientName, options, &JackStatus, serverName );
 
     if ( pJackClient == nullptr )
     {


### PR DESCRIPTION
commit 2a798c626883a2651f56b47da87d9c54e03c228e checks the environment variable but then does nothing with it.

This pull request passes the server name through to the jack client library so it can look for the named jackd instance.