### PR TITLE
Own fader to first position

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1070,9 +1070,15 @@ void CAudioMixerBoard::ChangeFaderOrder ( const EChSortType eChSortType )
     // create a pair list of lower strings and fader ID for each channel
     QList<QPair<QString, int>> PairList;
     int                        iNumVisibleFaders = 0;
+    int                        iMyFader          = -1;
 
     for ( int i = 0; i < MAX_NUM_CHANNELS; i++ )
     {
+        if ( vecpChanFader[i]->GetIsMyOwnFader() )
+        {
+            iMyFader = i;
+        }
+
         if ( eChSortType == ST_BY_NAME )
         {
             PairList << QPair<QString, int> ( vecpChanFader[i]->GetReceivedName().toLower(), i );
@@ -1116,6 +1122,19 @@ void CAudioMixerBoard::ChangeFaderOrder ( const EChSortType eChSortType )
 
     // sort the channels according to the first of the pair
     std::stable_sort ( PairList.begin(), PairList.end() );
+
+    // move my fader to first position
+    if ( pSettings->bOwnFaderFirst )
+    {
+        for ( int i = 0; i < MAX_NUM_CHANNELS; i++ )
+        {
+            if ( iMyFader == PairList[i].second )
+            {
+                PairList.move ( i, 0 );
+                break;
+            }
+        }
+    }
 
     // we want to distribute iNumVisibleFaders across the first row, then the next, etc
     // up to iNumMixerPanelRows.  So row wants to start at 0 until we get to some number,

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -84,6 +84,7 @@ public:
     int    GetRunningNewClientCnt() { return iRunningNewClientCnt; }
     void   SetChannelLevel ( const uint16_t iLevel );
     void   SetIsMyOwnFader() { bIsMyOwnFader = true; }
+    bool   GetIsMyOwnFader() { return bIsMyOwnFader; }
     void   UpdateSoloState ( const bool bNewOtherSoloState );
 
 protected:

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -308,6 +308,12 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // View menu  --------------------------------------------------------------
     QMenu* pViewMenu = new QMenu ( tr ( "&View" ), this );
 
+    // own fader first option: works from server version 3.5.5 which supports sending client ID back to client
+    QAction* OwnFaderFirstAction =
+        pViewMenu->addAction ( tr ( "O&wn Fader First" ), this, SLOT ( OnOwnFaderFirst() ), QKeySequence ( Qt::CTRL + Qt::Key_W ) );
+
+    pViewMenu->addSeparator();
+
     QAction* NoSortAction =
         pViewMenu->addAction ( tr ( "N&o User Sorting" ), this, SLOT ( OnNoSortChannels() ), QKeySequence ( Qt::CTRL + Qt::Key_O ) );
 
@@ -324,6 +330,9 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     QAction* ByCityAction =
         pViewMenu->addAction ( tr ( "Sort Users by &City" ), this, SLOT ( OnSortChannelsByCity() ), QKeySequence ( Qt::CTRL + Qt::Key_T ) );
+
+    OwnFaderFirstAction->setCheckable ( true );
+    OwnFaderFirstAction->setChecked ( pSettings->bOwnFaderFirst );
 
     // the sorting menu entries shall be checkable and exclusive
     QActionGroup* SortActionGroup = new QActionGroup ( this );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -159,6 +159,11 @@ public slots:
     void OnOpenAdvancedSettings();
     void OnOpenChatDialog() { ShowChatWindow(); }
     void OnOpenAnalyzerConsole() { ShowAnalyzerConsole(); }
+    void OnOwnFaderFirst()
+    {
+        pSettings->bOwnFaderFirst = !pSettings->bOwnFaderFirst;
+        MainMixerBoard->SetFaderSorting ( pSettings->eChannelSortType );
+    }
     void OnNoSortChannels() { MainMixerBoard->SetFaderSorting ( ST_NO_SORT ); }
     void OnSortChannelsByName() { MainMixerBoard->SetFaderSorting ( ST_BY_NAME ); }
     void OnSortChannelsByInstrument() { MainMixerBoard->SetFaderSorting ( ST_BY_INSTRUMENT ); }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -270,6 +270,12 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         eChannelSortType = static_cast<EChSortType> ( iValue );
     }
 
+    // own fader first sorting
+    if ( GetFlagIniSet ( IniXMLDocument, "client", "ownfaderfirst", bValue ) )
+    {
+        bOwnFaderFirst = bValue;
+    }
+
     // number of mixer panel rows
     if ( GetNumericIniSet ( IniXMLDocument, "client", "numrowsmixpan", 1, 8, iValue ) )
     {
@@ -623,6 +629,9 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
 
     // fader channel sorting
     SetNumericIniSet ( IniXMLDocument, "client", "channelsort", static_cast<int> ( eChannelSortType ) );
+
+    // own fader first sorting
+    SetFlagIniSet ( IniXMLDocument, "client", "ownfaderfirst", bOwnFaderFirst );
 
     // number of mixer panel rows
     SetNumericIniSet ( IniXMLDocument, "client", "numrowsmixpan", iNumMixerPanelRows );

--- a/src/settings.h
+++ b/src/settings.h
@@ -133,6 +133,7 @@ public:
         bWindowWasShownSettings ( false ),
         bWindowWasShownChat ( false ),
         bWindowWasShownConnect ( false ),
+        bOwnFaderFirst ( false ),
         pClient ( pNCliP )
     {
         SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME );
@@ -167,6 +168,7 @@ public:
     bool       bWindowWasShownSettings;
     bool       bWindowWasShownChat;
     bool       bWindowWasShownConnect;
+    bool       bOwnFaderFirst;
 
 protected:
     // No CommandLineOptions used when reading Client inifile


### PR DESCRIPTION
This pull request set own fader always to 1st position, regardless of the sorting setting.
See discussion #1646

In case we want to have the choice to set or unset the option, then UI changes must be involved.