### PR TITLE
CJamRecorder: Add currentSession pointer initialization and improve locking

### DIFF
--- a/src/recorder/jamrecorder.cpp
+++ b/src/recorder/jamrecorder.cpp
@@ -401,7 +401,7 @@ void CJamRecorder::Start()
 
     {
         // needs to be after OnEnd() as that also locks
-        QMutexLocker mutexLocker(&ChIdMutex);
+        QMutexLocker mutexLocker ( &ChIdMutex );
         try
         {
             currentSession = new CJamSession ( recordBaseDir );
@@ -428,7 +428,7 @@ void CJamRecorder::Start()
  */
 void CJamRecorder::OnEnd()
 {
-    QMutexLocker mutexLocker(&ChIdMutex);
+    QMutexLocker mutexLocker ( &ChIdMutex );
     if ( isRecording )
     {
         isRecording = false;
@@ -567,7 +567,7 @@ void CJamRecorder::SessionDirToReaper ( QString& strSessionDirName, int serverFr
  */
 void CJamRecorder::OnDisconnected ( int iChID )
 {
-    QMutexLocker mutexLocker(&ChIdMutex);
+    QMutexLocker mutexLocker ( &ChIdMutex );
     if ( !isRecording )
     {
         qWarning() << "CJamRecorder::OnDisconnected: channel" << iChID << "disconnected but not recording";
@@ -611,7 +611,7 @@ void CJamRecorder::OnFrame ( const int              iChID,
 
     // needs to be after Start() as that also locks
     {
-        QMutexLocker mutexLocker(&ChIdMutex);
+        QMutexLocker mutexLocker ( &ChIdMutex );
         currentSession->Frame ( iChID, name, address, numAudioChannels, data, iServerFrameSizeSamples );
     }
 }

--- a/src/recorder/jamrecorder.cpp
+++ b/src/recorder/jamrecorder.cpp
@@ -399,9 +399,9 @@ void CJamRecorder::Start()
 
     QString error;
 
-    // needs to be after OnEnd() as that also locks
-    ChIdMutex.lock();
     {
+        // needs to be after OnEnd() as that also locks
+        QMutexLocker mutexLocker(&ChIdMutex);
         try
         {
             currentSession = new CJamSession ( recordBaseDir );
@@ -413,7 +413,6 @@ void CJamRecorder::Start()
             error          = err.GetErrorText();
         }
     }
-    ChIdMutex.unlock();
 
     if ( !currentSession )
     {
@@ -429,21 +428,18 @@ void CJamRecorder::Start()
  */
 void CJamRecorder::OnEnd()
 {
-    ChIdMutex.lock(); // iChId used in currentSession->End()
+    QMutexLocker mutexLocker(&ChIdMutex);
+    if ( isRecording )
     {
-        if ( isRecording )
-        {
-            isRecording = false;
-            currentSession->End();
+        isRecording = false;
+        currentSession->End();
 
-            ReaperProjectFromCurrentSession();
-            AudacityLofFromCurrentSession();
+        ReaperProjectFromCurrentSession();
+        AudacityLofFromCurrentSession();
 
-            delete currentSession;
-            currentSession = nullptr;
-        }
+        delete currentSession;
+        currentSession = nullptr;
     }
-    ChIdMutex.unlock();
 }
 
 /**
@@ -571,21 +567,18 @@ void CJamRecorder::SessionDirToReaper ( QString& strSessionDirName, int serverFr
  */
 void CJamRecorder::OnDisconnected ( int iChID )
 {
-    ChIdMutex.lock();
+    QMutexLocker mutexLocker(&ChIdMutex);
+    if ( !isRecording )
     {
-        if ( !isRecording )
-        {
-            qWarning() << "CJamRecorder::OnDisconnected: channel" << iChID << "disconnected but not recording";
-        }
-        if ( currentSession == nullptr )
-        {
-            qWarning() << "CJamRecorder::OnDisconnected: channel" << iChID << "disconnected but no currentSession";
-            return;
-        }
-
-        currentSession->DisconnectClient ( iChID );
+        qWarning() << "CJamRecorder::OnDisconnected: channel" << iChID << "disconnected but not recording";
     }
-    ChIdMutex.unlock();
+    if ( currentSession == nullptr )
+    {
+        qWarning() << "CJamRecorder::OnDisconnected: channel" << iChID << "disconnected but no currentSession";
+        return;
+    }
+
+    currentSession->DisconnectClient ( iChID );
 }
 
 /**
@@ -617,9 +610,8 @@ void CJamRecorder::OnFrame ( const int              iChID,
     }
 
     // needs to be after Start() as that also locks
-    ChIdMutex.lock();
     {
+        QMutexLocker mutexLocker(&ChIdMutex);
         currentSession->Frame ( iChID, name, address, numAudioChannels, data, iServerFrameSizeSamples );
     }
-    ChIdMutex.unlock();
 }

--- a/src/recorder/jamrecorder.h
+++ b/src/recorder/jamrecorder.h
@@ -158,7 +158,7 @@ public:
         recordBaseDir ( strRecordingBaseDir ),
         iServerFrameSizeSamples ( iServerFrameSizeSamples ),
         isRecording ( false ),
-        currentSession( nullptr )
+        currentSession ( nullptr )
     {}
 
     /**

--- a/src/recorder/jamrecorder.h
+++ b/src/recorder/jamrecorder.h
@@ -157,7 +157,8 @@ public:
     CJamRecorder ( const QString strRecordingBaseDir, const int iServerFrameSizeSamples ) :
         recordBaseDir ( strRecordingBaseDir ),
         iServerFrameSizeSamples ( iServerFrameSizeSamples ),
-        isRecording ( false )
+        isRecording ( false ),
+        currentSession( nullptr )
     {}
 
     /**


### PR DESCRIPTION
- Added initialization of currentSession pointer in CJamRecorder constructor
- Changed locking code in CJamRecorder to use QMutexLock, to prevent leaving mutex locked if method exits with exception or nested return statement.

Server code tested on Windows and Ubuntu 20.04.