### PR TITLE
Do not reset fMuteOutStreamGain when reinit sound parameters

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -927,7 +927,7 @@ void CClient::Init()
     vecZeros.Init ( iStereoBlockSizeSam, 0 );
     vecsStereoSndCrdMuteStream.Init ( iStereoBlockSizeSam );
 
-    fMuteOutStreamGain = 1.0f;
+    //fMuteOutStreamGain = 1.0f;
 
     opus_custom_encoder_ctl ( CurOpusEncoder,
                               OPUS_SET_BITRATE ( CalcBitRateBitsPerSecFromCodedBytes ( iCeltNumCodedBytes, iOPUSFrameSizeSamples ) ) );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -927,8 +927,6 @@ void CClient::Init()
     vecZeros.Init ( iStereoBlockSizeSam, 0 );
     vecsStereoSndCrdMuteStream.Init ( iStereoBlockSizeSam );
 
-    // fMuteOutStreamGain = 1.0f;
-
     opus_custom_encoder_ctl ( CurOpusEncoder,
                               OPUS_SET_BITRATE ( CalcBitRateBitsPerSecFromCodedBytes ( iCeltNumCodedBytes, iOPUSFrameSizeSamples ) ) );
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -927,7 +927,7 @@ void CClient::Init()
     vecZeros.Init ( iStereoBlockSizeSam, 0 );
     vecsStereoSndCrdMuteStream.Init ( iStereoBlockSizeSam );
 
-    //fMuteOutStreamGain = 1.0f;
+    // fMuteOutStreamGain = 1.0f;
 
     opus_custom_encoder_ctl ( CurOpusEncoder,
                               OPUS_SET_BITRATE ( CalcBitRateBitsPerSecFromCodedBytes ( iCeltNumCodedBytes, iOPUSFrameSizeSamples ) ) );


### PR DESCRIPTION
See discussion #909.

Expected behaviour, as described here https://github.com/jamulussoftware/jamulus/issues/909#issuecomment-769383616

```
MUTE MYSELF = false and MUTE = false. I DO hear myself returned from the server.
MUTE MYSELF = false and MUTE = true. I DO NOT hear myself returned from the server.
MUTE MYSELF = true and MUTE = false. I DO NOT hear myself returned from the server. I DO hear myself locally.
MUTE MYSELF = true and MUTE = true. I DO NOT hear myself returned from the server. I DO NOT hear myself locally. In other words, I hear nothing.
```

However, when MUTE MYSELF = true and MUTE = true, change any sound parameter (buffer size, channels, quality, etc.), you will hear yourself locally, meaning expected behaviour is no longer respected. 

This is because of line 930: `fMuteOutStreamGain = 1.0f;` in `CClient::Init()`, called by every parameter change. 

This line is actually not necessary, because CClient::CClient() already does it. 