### PR TITLE
Add Apple AppStore license note

### DIFF
--- a/APPLEAPPSTORE.LICENSE.WAIVER
+++ b/APPLEAPPSTORE.LICENSE.WAIVER
@@ -1,0 +1,19 @@
+The inclusion of Jamulus in the App Store is the only practical way of allowing its use on Apple mobile devices. Although Apple will assert the GPL as the "Custom EULA” for Jamulus, their T&Cs impose some extra conditions. This act of addition when distributing the software is not allowed under the GPL.
+
+However, Apple's terms apply to those who obtain Jamulus from the App Store. It does not affect the copyright holders' assertion of the GPL, or otherwise affect the Jamulus project:
+
+https://www.apple.com/legal/internet-services/itunes/us/terms.html
+
+Moreover, there are no provisions in the Apple terms and conditions that we identify as being unacceptable to the copyright holders, or to the Jamulus project overall. Anyone using App Store services would already be accepting Apple’s terms for their use of any service they are obtaining. This includes being unable to re-distribute the software.
+
+The copyright holders do not want a legal conflict to prevent the distribution of Jamulus on the Apple App Store. Therefore, and in consideration of the above points, we the copyright holders in Jamulus hereby waive any objections to the fact that Apple would be violating the GPL in making Jamulus available on the App Store.
+
+Apple reserves the right to change its terms. If at any time they do that in a way that we find unacceptable, we will remove Jamulus from the App Store.
+
+This waiver applies solely to the specific case of obtaining Jamulus from the Apple App Store. All other distribution methods must fully comply with the terms of the GPL.
+
+Dissent
+
+Any Jamulus contributor who does not wish their code to be published via the App Store must ensure their code is not so published. This can be achieved for example by removing their code from the Jamulus source, or by using technical measures (e.g. #ifdef) to ensure the code in question will not be compiled and included for App Store releases.
+
+[ends]


### PR DESCRIPTION
See also: https://github.com/nextcloud/ios/blob/master/COPYING.iOS
#1856 

Jamulus is licensed under the GPL. Currently there is ongoing work on getting Jamulus on the app store. However, there might be incompatibilities between the Apple TOS and the GPL. 

This text should be modified and added to the main repo to ensure that we will not sue anyone (especially, but not only @emlynmac) who publishes the code. 

I'd be more than happy if any contributor who doesn't want his code to be published on the app store remove his code. 

Tagging
@jamulussoftware/maindevelopers here.
