### PR TITLE
Android - close buttons (chat and settings) - #1763 fix

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -66,7 +66,7 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
 #endif
 
 #if defined( ANDROID ) || defined( Q_OS_ANDROID )
-    pEditMenu->addAction ( tr ( "&Close" ), this, SLOT ( close() ), QKeySequence ( Qt::CTRL + Qt::Key_C ) );
+    pEditMenu->addAction ( tr ( "&Close" ), this, SLOT ( close() ), QKeySequence ( Qt::CTRL + Qt::Key_W ) );
 #endif
 
     // Now tell the layout about the menu

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -65,6 +65,10 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
     connect ( action, SIGNAL ( triggered() ), this, SLOT ( close() ) );
 #endif
 
+#if defined( ANDROID ) || defined( Q_OS_ANDROID )
+    pEditMenu->addAction ( tr ( "&Close" ), this, SLOT ( close() ), QKeySequence ( Qt::CTRL + Qt::Key_C ) );
+#endif
+
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -42,6 +42,17 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     layout()->setMenuBar ( pMenu );
 #endif
 
+#if defined( Q_OS_ANDROID ) || defined( ANDROID )
+    // Android too
+    QMenuBar* pMenu      = new QMenuBar ( this );
+    QMenu*    pCloseMenu = new QMenu ( tr ( "Close" ), this );
+    pCloseMenu->addAction ( tr ( "Close" ), this, SLOT ( close() ) );
+    pMenu->addMenu ( pCloseMenu );
+
+    // Now tell the layout about the menu
+    layout()->setMenuBar ( pMenu );
+#endif
+
     // Add help text to controls -----------------------------------------------
     // local audio input fader
     QString strAudFader = "<b>" + tr ( "Local Audio Input Fader" ) + ":</b> " +

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -45,8 +45,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 #if defined( Q_OS_ANDROID ) || defined( ANDROID )
     // Android too
     QMenuBar* pMenu      = new QMenuBar ( this );
-    QMenu*    pCloseMenu = new QMenu ( tr ( "Close" ), this );
-    pCloseMenu->addAction ( tr ( "Close" ), this, SLOT ( close() ) );
+    QMenu*    pCloseMenu = new QMenu ( tr ( "&Close" ), this );
+    pCloseMenu->addAction ( tr ( "&Close" ), this, SLOT ( close() ) );
     pMenu->addMenu ( pCloseMenu );
 
     // Now tell the layout about the menu


### PR DESCRIPTION
Fix for #1763: add close button for dialogs in Android.