### PR TITLE
Fix Ampersand not being shown correctly

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1102,7 +1102,14 @@ void CAudioMixerBoard::UpdateTitle()
         strTitlePrefix = "[" + tr ( "RECORDING ACTIVE" ) + "] ";
     }
 
-    setTitle ( strTitlePrefix + tr ( "Personal Mix at: " ) + strServerName );
+    // replace & signs with && (See Qt documentation for QLabel)
+    // if strServerName includes an "&" sign, this is interpreted as keyboard shortcut (#1886)
+    // it might be possible to find a more elegant solution here?
+
+    QString strEscServerName = strServerName;
+    strEscServerName.replace ( "&", "&&" );
+
+    setTitle ( strTitlePrefix + tr ( "Personal Mix at: " ) + strEscServerName );
     setAccessibleName ( title() );
 }
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

This is a bug-fix

**Context: Fixes an issue?**

If a server-name contained '&' this was interpreted as keyboard shortcut in the mixer board.
Replacing & by && allows us to show server-names correctly.
Fixes: https://github.com/jamulussoftware/jamulus/issues/1886

**Does this change need documentation? What needs to be documented and how?**
Only an entry in the change log.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
Working implementation. Ready for review

**What is missing until this pull request can be merged?**
Ready for review:
Needes: two approvals (based on tests on macOS and Windows)

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want (switching recording states via GUI server works; &&&, && and & is shown correctly in server names)
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
