### PR TITLE
Re-order and refactor help for client/server validation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,8 @@ int main ( int argc, char** argv )
     QString        strArgument;
     double         rDbleArgument;
     QList<QString> CommandLineOptions;
+    QList<QString> ServerOnlyOptions;
+    QList<QString> ClientOnlyOptions;
 
     // initialize all flags and string which might be changed by command line
     // arguments
@@ -105,153 +107,46 @@ int main ( int argc, char** argv )
     }
 #endif
 
+    // When adding new options, follow the same order as --help output
+
     // QT docu: argv()[0] is the program name, argv()[1] is the first
     // argument and argv()[argc()-1] is the last argument.
     // Start with first argument, therefore "i = 1"
     for ( int i = 1; i < argc; i++ )
     {
-        // Server mode flag ----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-s", "--server" ) )
+
+        // Help (usage) flag ---------------------------------------------------
+        if ( ( !strcmp ( argv[i], "--help" ) ) || ( !strcmp ( argv[i], "-h" ) ) || ( !strcmp ( argv[i], "-?" ) ) )
         {
-            bIsClient = false;
-            qInfo() << "- server mode chosen";
-            CommandLineOptions << "--server";
+            const QString strHelp = UsageArguments ( argv );
+            qInfo() << qUtf8Printable ( strHelp );
+            exit ( 0 );
+        }
+
+        // Version number ------------------------------------------------------
+        if ( ( !strcmp ( argv[i], "--version" ) ) || ( !strcmp ( argv[i], "-v" ) ) )
+        {
+            qCritical() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
+            exit ( 1 );
+        }
+
+        // Common options:
+
+        // Initialization file -------------------------------------------------
+        if ( GetStringArgument ( argc, argv, i, "-i", "--inifile", strArgument ) )
+        {
+            strIniFileName = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- initialization file name: %1" ).arg ( strIniFileName ) );
+            CommandLineOptions << "--inifile";
             continue;
         }
 
-        // Use GUI flag --------------------------------------------------------
+        // Disable GUI flag ----------------------------------------------------
         if ( GetFlagArgument ( argv, i, "-n", "--nogui" ) )
         {
             bUseGUI = false;
             qInfo() << "- no GUI mode chosen";
             CommandLineOptions << "--nogui";
-            continue;
-        }
-
-        // Use licence flag ----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-L", "--licence" ) )
-        {
-            // right now only the creative commons licence is supported
-            eLicenceType = LT_CREATIVECOMMONS;
-            qInfo() << "- licence required";
-            CommandLineOptions << "--licence";
-            continue;
-        }
-
-        // Use 64 samples frame size mode --------------------------------------
-        if ( GetFlagArgument ( argv, i, "-F", "--fastupdate" ) )
-        {
-            bUseDoubleSystemFrameSize = false; // 64 samples frame size
-            qInfo() << qUtf8Printable ( QString ( "- using %1 samples frame size mode" ).arg ( SYSTEM_FRAME_SIZE_SAMPLES ) );
-            CommandLineOptions << "--fastupdate";
-            continue;
-        }
-
-        // Use multithreading --------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-T", "--multithreading" ) )
-        {
-            bUseMultithreading = true;
-            qInfo() << "- using multithreading";
-            CommandLineOptions << "--multithreading";
-            continue;
-        }
-
-        // Maximum number of channels ------------------------------------------
-        if ( GetNumericArgument ( argc, argv, i, "-u", "--numchannels", 1, MAX_NUM_CHANNELS, rDbleArgument ) )
-        {
-            iNumServerChannels = static_cast<int> ( rDbleArgument );
-
-            qInfo() << qUtf8Printable ( QString ( "- maximum number of channels: %1" ).arg ( iNumServerChannels ) );
-
-            CommandLineOptions << "--numchannels";
-            continue;
-        }
-
-        // Start minimized -----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-z", "--startminimized" ) )
-        {
-            bStartMinimized = true;
-            qInfo() << "- start minimized enabled";
-            CommandLineOptions << "--startminimized";
-            continue;
-        }
-
-        // Disconnect all clients on quit --------------------------------------
-        if ( GetFlagArgument ( argv, i, "-d", "--discononquit" ) )
-        {
-            bDisconnectAllClientsOnQuit = true;
-            qInfo() << "- disconnect all clients on quit";
-            CommandLineOptions << "--discononquit";
-            continue;
-        }
-
-        // Disabling auto Jack connections -------------------------------------
-        if ( GetFlagArgument ( argv, i, "-j", "--nojackconnect" ) )
-        {
-            bNoAutoJackConnect = true;
-            qInfo() << "- disable auto Jack connections";
-            CommandLineOptions << "--nojackconnect";
-            continue;
-        }
-
-        // Disable translations ------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-t", "--notranslation" ) )
-        {
-            bUseTranslation = false;
-            qInfo() << "- translations disabled";
-            CommandLineOptions << "--notranslation";
-            continue;
-        }
-
-        // Show all registered servers in the server list ----------------------
-        // Undocumented debugging command line argument: Show all registered
-        // servers in the server list regardless if a ping to the server is
-        // possible or not.
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--showallservers", // no short form
-                               "--showallservers" ) )
-        {
-            bShowComplRegConnList = true;
-            qInfo() << "- show all registered servers in server list";
-            CommandLineOptions << "--showallservers";
-            continue;
-        }
-
-        // Show analyzer console -----------------------------------------------
-        // Undocumented debugging command line argument: Show the analyzer
-        // console to debug network buffer properties.
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--showanalyzerconsole", // no short form
-                               "--showanalyzerconsole" ) )
-        {
-            bShowAnalyzerConsole = true;
-            qInfo() << "- show analyzer console";
-            CommandLineOptions << "--showanalyzerconsole";
-            continue;
-        }
-
-        // Controller MIDI channel ---------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--ctrlmidich", // no short form
-                                 "--ctrlmidich",
-                                 strArgument ) )
-        {
-            strMIDISetup = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- MIDI controller settings: %1" ).arg ( strMIDISetup ) );
-            CommandLineOptions << "--ctrlmidich";
-            continue;
-        }
-
-        // Use logging ---------------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-l", "--log", strArgument ) )
-        {
-            strLoggingFileName = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- logging file name: %1" ).arg ( strLoggingFileName ) );
-            CommandLineOptions << "--log";
             continue;
         }
 
@@ -274,56 +169,24 @@ int main ( int argc, char** argv )
             continue;
         }
 
-        // HTML status file ----------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-m", "--htmlstatus", strArgument ) )
+        // Disable translations ------------------------------------------------
+        if ( GetFlagArgument ( argv, i, "-t", "--notranslation" ) )
         {
-            strHTMLStatusFileName = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- HTML status file name: %1" ).arg ( strHTMLStatusFileName ) );
-            CommandLineOptions << "--htmlstatus";
+            bUseTranslation = false;
+            qInfo() << "- translations disabled";
+            CommandLineOptions << "--notranslation";
             continue;
         }
 
-        // Client Name ---------------------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--clientname", // no short form
-                                 "--clientname",
-                                 strArgument ) )
-        {
-            strClientName = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- client name: %1" ).arg ( strClientName ) );
-            CommandLineOptions << "--clientname";
-            continue;
-        }
+        // Server only:
 
-        // Recording directory -------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-R", "--recording", strArgument ) )
+        // Disconnect all clients on quit --------------------------------------
+        if ( GetFlagArgument ( argv, i, "-d", "--discononquit" ) )
         {
-            strRecordingDirName = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- recording directory name: %1" ).arg ( strRecordingDirName ) );
-            CommandLineOptions << "--recording";
-            continue;
-        }
-
-        // Disable recording on startup ----------------------------------------
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--norecord", // no short form
-                               "--norecord" ) )
-        {
-            bDisableRecording = true;
-            qInfo() << "- recording will not take place until enabled";
-            CommandLineOptions << "--norecord";
-            continue;
-        }
-
-        // Enable delay panning on startup -------------------------------------
-        if ( GetFlagArgument ( argv, i, "-P", "--delaypan" ) )
-        {
-            bDelayPan = true;
-            qInfo() << "- starting with delay panning";
-            CommandLineOptions << "--delaypan";
+            bDisconnectAllClientsOnQuit = true;
+            qInfo() << "- disconnect all clients on quit";
+            CommandLineOptions << "--discononquit";
+            ServerOnlyOptions << "--discononquit";
             continue;
         }
 
@@ -333,6 +196,7 @@ int main ( int argc, char** argv )
             strCentralServer = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strCentralServer ) );
             CommandLineOptions << "--directoryserver";
+            ServerOnlyOptions << "--directoryserver";
             continue;
         }
 
@@ -347,6 +211,68 @@ int main ( int argc, char** argv )
             strCentralServer = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strCentralServer ) );
             CommandLineOptions << "--directoryserver";
+            ServerOnlyOptions << "--directoryserver";
+            continue;
+        }
+
+        // Server list filter --------------------------------------------------
+        if ( GetStringArgument ( argc, argv, i, "-f", "--listfilter", strArgument ) )
+        {
+            strServerListFilter = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- server list filter: %1" ).arg ( strServerListFilter ) );
+            CommandLineOptions << "--listfilter";
+            ServerOnlyOptions << "--listfilter";
+            continue;
+        }
+
+        // Use 64 samples frame size mode --------------------------------------
+        if ( GetFlagArgument ( argv, i, "-F", "--fastupdate" ) )
+        {
+            bUseDoubleSystemFrameSize = false; // 64 samples frame size
+            qInfo() << qUtf8Printable ( QString ( "- using %1 samples frame size mode" ).arg ( SYSTEM_FRAME_SIZE_SAMPLES ) );
+            CommandLineOptions << "--fastupdate";
+            ServerOnlyOptions << "--fastupdate";
+            continue;
+        }
+
+        // Use logging ---------------------------------------------------------
+        if ( GetStringArgument ( argc, argv, i, "-l", "--log", strArgument ) )
+        {
+            strLoggingFileName = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- logging file name: %1" ).arg ( strLoggingFileName ) );
+            CommandLineOptions << "--log";
+            ServerOnlyOptions << "--log";
+            continue;
+        }
+
+        // Use licence flag ----------------------------------------------------
+        if ( GetFlagArgument ( argv, i, "-L", "--licence" ) )
+        {
+            // LT_CREATIVECOMMONS is now used just to enable the pop up
+            eLicenceType = LT_CREATIVECOMMONS;
+            qInfo() << "- licence required";
+            CommandLineOptions << "--licence";
+            ServerOnlyOptions << "--licence";
+            continue;
+        }
+
+        // HTML status file ----------------------------------------------------
+        if ( GetStringArgument ( argc, argv, i, "-m", "--htmlstatus", strArgument ) )
+        {
+            strHTMLStatusFileName = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- HTML status file name: %1" ).arg ( strHTMLStatusFileName ) );
+            CommandLineOptions << "--htmlstatus";
+            ServerOnlyOptions << "--htmlstatus";
+            continue;
+        }
+
+        // Server info ---------------------------------------------------------
+        if ( GetStringArgument ( argc, argv, i, "-o", "--serverinfo", strArgument ) )
+        {
+            strServerInfo = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- server info: %1" ).arg ( strServerInfo ) );
+            CommandLineOptions << "--serverinfo";
+            ServerOnlyOptions << "--serverinfo";
             continue;
         }
 
@@ -361,6 +287,50 @@ int main ( int argc, char** argv )
             strServerPublicIP = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- server public IP: %1" ).arg ( strServerPublicIP ) );
             CommandLineOptions << "--serverpublicip";
+            ServerOnlyOptions << "--serverpublicip";
+            continue;
+        }
+
+        // Enable delay panning on startup -------------------------------------
+        if ( GetFlagArgument ( argv, i, "-P", "--delaypan" ) )
+        {
+            bDelayPan = true;
+            qInfo() << "- starting with delay panning";
+            CommandLineOptions << "--delaypan";
+            ServerOnlyOptions << "--delaypan";
+            continue;
+        }
+
+        // Recording directory -------------------------------------------------
+        if ( GetStringArgument ( argc, argv, i, "-R", "--recording", strArgument ) )
+        {
+            strRecordingDirName = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- recording directory name: %1" ).arg ( strRecordingDirName ) );
+            CommandLineOptions << "--recording";
+            ServerOnlyOptions << "--recording";
+            continue;
+        }
+
+        // Disable recording on startup ----------------------------------------
+        if ( GetFlagArgument ( argv,
+                               i,
+                               "--norecord", // no short form
+                               "--norecord" ) )
+        {
+            bDisableRecording = true;
+            qInfo() << "- recording will not take place until enabled";
+            CommandLineOptions << "--norecord";
+            ServerOnlyOptions << "--norecord";
+            continue;
+        }
+
+        // Server mode flag ----------------------------------------------------
+        if ( GetFlagArgument ( argv, i, "-s", "--server" ) )
+        {
+            bIsClient = false;
+            qInfo() << "- server mode chosen";
+            CommandLineOptions << "--server";
+            ServerOnlyOptions << "--server";
             continue;
         }
 
@@ -375,24 +345,29 @@ int main ( int argc, char** argv )
             strServerBindIP = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- server bind IP: %1" ).arg ( strServerBindIP ) );
             CommandLineOptions << "--serverbindip";
+            ServerOnlyOptions << "--serverbindip";
             continue;
         }
 
-        // Server info ---------------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-o", "--serverinfo", strArgument ) )
+        // Use multithreading --------------------------------------------------
+        if ( GetFlagArgument ( argv, i, "-T", "--multithreading" ) )
         {
-            strServerInfo = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- server info: %1" ).arg ( strServerInfo ) );
-            CommandLineOptions << "--serverinfo";
+            bUseMultithreading = true;
+            qInfo() << "- using multithreading";
+            CommandLineOptions << "--multithreading";
+            ServerOnlyOptions << "--multithreading";
             continue;
         }
 
-        // Server list filter --------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-f", "--listfilter", strArgument ) )
+        // Maximum number of channels ------------------------------------------
+        if ( GetNumericArgument ( argc, argv, i, "-u", "--numchannels", 1, MAX_NUM_CHANNELS, rDbleArgument ) )
         {
-            strServerListFilter = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- server list filter: %1" ).arg ( strServerListFilter ) );
-            CommandLineOptions << "--listfilter";
+            iNumServerChannels = static_cast<int> ( rDbleArgument );
+
+            qInfo() << qUtf8Printable ( QString ( "- maximum number of channels: %1" ).arg ( iNumServerChannels ) );
+
+            CommandLineOptions << "--numchannels";
+            ServerOnlyOptions << "--numchannels";
             continue;
         }
 
@@ -402,17 +377,21 @@ int main ( int argc, char** argv )
             strWelcomeMessage = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- welcome message: %1" ).arg ( strWelcomeMessage ) );
             CommandLineOptions << "--welcomemessage";
+            ServerOnlyOptions << "--welcomemessage";
             continue;
         }
 
-        // Initialization file -------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-i", "--inifile", strArgument ) )
+        // Start minimized -----------------------------------------------------
+        if ( GetFlagArgument ( argv, i, "-z", "--startminimized" ) )
         {
-            strIniFileName = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- initialization file name: %1" ).arg ( strIniFileName ) );
-            CommandLineOptions << "--inifile";
+            bStartMinimized = true;
+            qInfo() << "- start minimized enabled";
+            CommandLineOptions << "--startminimized";
+            ServerOnlyOptions << "--startminimized";
             continue;
         }
+
+        // Client only:
 
         // Connect on startup --------------------------------------------------
         if ( GetStringArgument ( argc, argv, i, "-c", "--connect", strArgument ) )
@@ -420,6 +399,17 @@ int main ( int argc, char** argv )
             strConnOnStartupAddress = NetworkUtil::FixAddress ( strArgument );
             qInfo() << qUtf8Printable ( QString ( "- connect on startup to address: %1" ).arg ( strConnOnStartupAddress ) );
             CommandLineOptions << "--connect";
+            ClientOnlyOptions << "--connect";
+            continue;
+        }
+
+        // Disabling auto Jack connections -------------------------------------
+        if ( GetFlagArgument ( argv, i, "-j", "--nojackconnect" ) )
+        {
+            bNoAutoJackConnect = true;
+            qInfo() << "- disable auto Jack connections";
+            CommandLineOptions << "--nojackconnect";
+            ClientOnlyOptions << "--nojackconnect";
             continue;
         }
 
@@ -429,6 +419,7 @@ int main ( int argc, char** argv )
             bMuteStream = true;
             qInfo() << "- mute stream activated";
             CommandLineOptions << "--mutestream";
+            ClientOnlyOptions << "--mutestream";
             continue;
         }
 
@@ -441,22 +432,71 @@ int main ( int argc, char** argv )
             bMuteMeInPersonalMix = true;
             qInfo() << "- mute me in my personal mix";
             CommandLineOptions << "--mutemyown";
+            ClientOnlyOptions << "--mutemyown";
             continue;
         }
 
-        // Version number ------------------------------------------------------
-        if ( ( !strcmp ( argv[i], "--version" ) ) || ( !strcmp ( argv[i], "-v" ) ) )
+        // Client Name ---------------------------------------------------------
+        if ( GetStringArgument ( argc,
+                                 argv,
+                                 i,
+                                 "--clientname", // no short form
+                                 "--clientname",
+                                 strArgument ) )
         {
-            qCritical() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
-            exit ( 1 );
+            strClientName = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- client name: %1" ).arg ( strClientName ) );
+            CommandLineOptions << "--clientname";
+            ClientOnlyOptions << "--clientname";
+            continue;
         }
 
-        // Help (usage) flag ---------------------------------------------------
-        if ( ( !strcmp ( argv[i], "--help" ) ) || ( !strcmp ( argv[i], "-h" ) ) || ( !strcmp ( argv[i], "-?" ) ) )
+        // Controller MIDI channel ---------------------------------------------
+        if ( GetStringArgument ( argc,
+                                 argv,
+                                 i,
+                                 "--ctrlmidich", // no short form
+                                 "--ctrlmidich",
+                                 strArgument ) )
         {
-            const QString strHelp = UsageArguments ( argv );
-            qInfo() << qUtf8Printable ( strHelp );
-            exit ( 0 );
+            strMIDISetup = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- MIDI controller settings: %1" ).arg ( strMIDISetup ) );
+            CommandLineOptions << "--ctrlmidich";
+            ClientOnlyOptions << "--ctrlmidich";
+            continue;
+        }
+
+        // Undocumented:
+
+        // Show all registered servers in the server list ----------------------
+        // Undocumented debugging command line argument: Show all registered
+        // servers in the server list regardless if a ping to the server is
+        // possible or not.
+        if ( GetFlagArgument ( argv,
+                               i,
+                               "--showallservers", // no short form
+                               "--showallservers" ) )
+        {
+            bShowComplRegConnList = true;
+            qInfo() << "- show all registered servers in server list";
+            CommandLineOptions << "--showallservers";
+            ClientOnlyOptions << "--showallservers";
+            continue;
+        }
+
+        // Show analyzer console -----------------------------------------------
+        // Undocumented debugging command line argument: Show the analyzer
+        // console to debug network buffer properties.
+        if ( GetFlagArgument ( argv,
+                               i,
+                               "--showanalyzerconsole", // no short form
+                               "--showanalyzerconsole" ) )
+        {
+            bShowAnalyzerConsole = true;
+            qInfo() << "- show analyzer console";
+            CommandLineOptions << "--showanalyzerconsole";
+            ClientOnlyOptions << "--showanalyzerconsole";
+            continue;
         }
 
         // Unknown option ------------------------------------------------------
@@ -490,53 +530,139 @@ int main ( int argc, char** argv )
     }
 #endif
 
-    // the inifile is not supported for the headless server mode
-    if ( !bIsClient && !bUseGUI && !strIniFileName.isEmpty() )
+    if ( bIsClient )
     {
-        qWarning() << "No initialization file support in headless server mode.";
-    }
-
-    // mute my own signal in personal mix is only supported for headless mode
-    if ( bIsClient && bUseGUI && bMuteMeInPersonalMix )
-    {
-        bMuteMeInPersonalMix = false;
-        qWarning() << "Mute my own signal in my personal mix is only supported in headless mode.";
-    }
-
-    if ( !strServerPublicIP.isEmpty() )
-    {
-        QHostAddress InetAddr;
-        if ( !InetAddr.setAddress ( strServerPublicIP ) )
+        if ( ServerOnlyOptions.size() != 0 )
         {
-            qWarning() << "Server Public IP is invalid. Only plain IP addresses are supported.";
+            qCritical() << qUtf8Printable ( QString ( "%1: Server only option(s) '%2' used.  Did you omit '--server'?" )
+                                                .arg ( argv[0] )
+                                                .arg ( ServerOnlyOptions.join ( ", " ) ) );
+            exit ( 1 );
         }
-        if ( strCentralServer.isEmpty() || bIsClient )
-        {
-            qWarning() << "Server Public IP will only take effect when registering a server with a directory server.";
-        }
-    }
 
-    if ( !strServerBindIP.isEmpty() )
-    {
-        QHostAddress InetAddr;
-        if ( !InetAddr.setAddress ( strServerBindIP ) )
+        // mute my own signal in personal mix is only supported for headless mode
+        if ( bUseGUI && bMuteMeInPersonalMix )
         {
-            qWarning() << "Server Bind IP is invalid. Only plain IP addresses are supported.";
+            bMuteMeInPersonalMix = false;
+            qWarning() << "Mute my own signal in my personal mix is only supported in headless mode.";
+        }
+
+        // adjust default port number for client: use different default port than the server since
+        // if the client is started before the server, the server would get a socket bind error
+        if ( !bCustomPortNumberGiven )
+        {
+            iPortNumber += 10; // increment by 10
+            qInfo() << qUtf8Printable ( QString ( "- allocated port number: %1" ).arg ( iPortNumber ) );
         }
     }
-
-    // per definition: if we are in "GUI" server mode and no directory server
-    // address is given, we use the default directory server address
-    if ( !bIsClient && bUseGUI && strCentralServer.isEmpty() )
+    else
     {
-        strCentralServer = DEFAULT_SERVER_ADDRESS;
-    }
+        if ( ClientOnlyOptions.size() != 0 )
+        {
+            qCritical() << qUtf8Printable (
+                QString ( "%1: Client only option(s) '%2' used.  See '--help' for help" ).arg ( argv[0] ).arg ( ClientOnlyOptions.join ( ", " ) ) );
+            exit ( 1 );
+        }
 
-    // adjust default port number for client: use different default port than the server since
-    // if the client is started before the server, the server would get a socket bind error
-    if ( bIsClient && !bCustomPortNumberGiven )
-    {
-        iPortNumber += 10; // increment by 10
+        if ( bUseGUI )
+        {
+            if ( strCentralServer.isEmpty() )
+            {
+                // per definition: if we are in "GUI" server mode and no directory server
+                // address is given, we use the default directory server address
+                strCentralServer = DEFAULT_SERVER_ADDRESS;
+                qInfo() << qUtf8Printable ( QString ( "- default directory server set: %1" ).arg ( strCentralServer ) );
+            }
+        }
+        else
+        {
+            // the inifile is not supported for the headless server mode
+            if ( !strIniFileName.isEmpty() )
+            {
+                qWarning() << "No initialization file support in headless server mode.";
+            }
+        }
+
+        if ( strCentralServer.isEmpty() )
+        {
+            // per definition, we must be a headless server and ignoring inifile, so we have all the information
+
+            if ( !strServerListFilter.isEmpty() )
+            {
+                qWarning() << "Server list filter will only take effect when running as a directory server.";
+                strServerListFilter = "";
+            }
+
+            if ( !strServerPublicIP.isEmpty() )
+            {
+                qWarning() << "Server Public IP will only take effect when registering a server with a directory server.";
+                strServerPublicIP = "";
+            }
+        }
+        else
+        {
+            // either we are not headless and there is an inifile, or a directory server was supplied on the command line
+
+            // if we are not headless, certain checks cannot be made, as the inifile state is not yet known
+            if ( !bUseGUI && strCentralServer.compare ( "localhost", Qt::CaseInsensitive ) != 0 && strCentralServer.compare ( "127.0.0.1" ) != 0 )
+            {
+                if ( !strServerListFilter.isEmpty() )
+                {
+                    qWarning() << "Server list filter will only take effect when running as a directory server.";
+                    strServerListFilter = "";
+                }
+            }
+            else
+            {
+                if ( !strServerListFilter.isEmpty() )
+                {
+                    QStringList slWhitelistAddresses = strServerListFilter.split ( ";" );
+                    for ( int iIdx = 0; iIdx < slWhitelistAddresses.size(); iIdx++ )
+                    {
+                        // check for special case: [version]
+                        if ( ( slWhitelistAddresses.at ( iIdx ).length() > 2 ) && ( slWhitelistAddresses.at ( iIdx ).left ( 1 ) == "[" ) &&
+                             ( slWhitelistAddresses.at ( iIdx ).right ( 1 ) == "]" ) )
+                        {
+                            // Good case - it seems QVersionNumber isn't fussy
+                        }
+                        else if ( slWhitelistAddresses.at ( iIdx ).isEmpty() )
+                        {
+                            qWarning() << "There is empty entry in the server list filter that will be ignored";
+                        }
+                        else
+                        {
+                            QHostAddress InetAddr;
+                            if ( !InetAddr.setAddress ( slWhitelistAddresses.at ( iIdx ) ) )
+                            {
+                                qWarning() << qUtf8Printable (
+                                    QString ( "%1 is not a valid server list filter entry. Only plain IP addresses are supported" )
+                                        .arg ( slWhitelistAddresses.at ( iIdx ) ) );
+                            }
+                        }
+                    }
+                }
+            }
+
+            if ( !strServerPublicIP.isEmpty() )
+            {
+                QHostAddress InetAddr;
+                if ( !InetAddr.setAddress ( strServerPublicIP ) )
+                {
+                    qWarning() << "Server Public IP is invalid. Only plain IP addresses are supported.";
+                    strServerPublicIP = "";
+                }
+            }
+        }
+
+        if ( !strServerBindIP.isEmpty() )
+        {
+            QHostAddress InetAddr;
+            if ( !InetAddr.setAddress ( strServerBindIP ) )
+            {
+                qWarning() << "Server Bind IP is invalid. Only plain IP addresses are supported.";
+                strServerBindIP = "";
+            }
+        }
     }
 
     // Application/GUI setup ---------------------------------------------------
@@ -739,59 +865,62 @@ int main ( int argc, char** argv )
 QString UsageArguments ( char** argv )
 {
     // clang-format off
-    return "\n"
-           "Usage: " + QString ( argv[0] ) + " [option] [optional argument]\n"
+    return QString (
            "\n"
-           "General options:\n"
+           "Usage: %1 [option] [option argument] ...\n"
+           "\n"
            "  -h, -?, --help        display this help text and exit\n"
+           "  -v, --version         display version information and exit\n"
+           "\n"
+           "Common options:\n"
            "  -i, --inifile         initialization file name\n"
            "                        (not supported for headless server mode)\n"
-           "  -n, --nogui           disable GUI\n"
+           "  -n, --nogui           disable GUI (\"headless\")\n"
            "  -p, --port            set the local port number\n"
            "  -Q, --qos             set the QoS value. Default is 128. Disable with 0\n"
            "                        (see the Jamulus website to enable QoS on Windows)\n"
            "  -t, --notranslation   disable translation (use English language)\n"
-           "  -v, --version         output version information and exit\n"
            "\n"
            "Server only:\n"
            "  -d, --discononquit    disconnect all clients on quit\n"
            "  -e, --directoryserver address of the directory server with which to register\n"
            "                        (or 'localhost' to host a server list on this server)\n"
-           "  -f, --listfilter      server list whitelist filter in the format:\n"
+           "  -f, --listfilter      server list whitelist filter.  Format:\n"
            "                        [IP address 1];[IP address 2];[IP address 3]; ...\n"
            "  -F, --fastupdate      use 64 samples frame size mode\n"
            "  -l, --log             enable logging, set file name\n"
            "  -L, --licence         show an agreement window before users can connect\n"
            "  -m, --htmlstatus      enable HTML status file, set file name\n"
-           "  -o, --serverinfo      infos of this server in the format:\n"
+           "  -o, --serverinfo      registration info for this server.  Format:\n"
            "                        [name];[city];[country as QLocale ID]\n"
+           "      --serverpublicip  public IP address for this server.  Needed when\n"
+           "                        registering with a server list hosted\n"
+           "                        behind the same NAT\n"
            "  -P, --delaypan        start with delay panning enabled\n"
            "  -R, --recording       sets directory to contain recorded jams\n"
            "      --norecord        disables recording (when enabled by default by -R)\n"
            "  -s, --server          start server\n"
+           "      --serverbindip    IP address the server will bind to (rather than all)\n"
            "  -T, --multithreading  use multithreading to make better use of\n"
            "                        multi-core CPUs and support more clients\n"
            "  -u, --numchannels     maximum number of channels\n"
-           "  -w, --welcomemessage  welcome message on connect\n"
+           "  -w, --welcomemessage  welcome message to display on connect\n"
+           "                        (string or filename)\n"
            "  -z, --startminimized  start minimizied\n"
-           "      --serverpublicip  specify your public IP address when\n"
-           "                        running a slave and your own directory server\n"
-           "                        behind the same NAT\n"
-           "      --serverbindip    specify the IP address the server will bind to\n"
            "\n"
            "Client only:\n"
+           "  -c, --connect         connect to given server address on startup\n"
+           "  -j, --nojackconnect   disable auto Jack connections\n"
            "  -M, --mutestream      starts the application in muted state\n"
            "      --mutemyown       mute me in my personal mix (headless only)\n"
-           "  -c, --connect         connect to given server address on startup\n"
-           "  -j, --nojackconnect   disable auto JACK connections\n"
+           "      --clientname      client name (window title and jack client name)\n"
            "      --ctrlmidich      MIDI controller channel to listen\n"
-           "      --clientname      client name (window title and JACK client name)\n"
            "\n"
-           "Example: " + QString ( argv[0] ) + " -s --inifile myinifile.ini\n"
+           "Example: %1 -s --inifile myinifile.ini\n"
            "\n"
            "For more information and localized help see:\n"
-           "\n"
-           "https://jamulus.io/wiki/Command-Line-Options\n";
+           "https://jamulus.io/wiki/Command-Line-Options\n"
+    ).arg( argv[0] );
     // clang-format on
 }
 
@@ -813,7 +942,7 @@ bool GetStringArgument ( int argc, char** argv, int& i, QString strShortOpt, QSt
     {
         if ( ++i >= argc )
         {
-            qCritical() << qUtf8Printable ( QString ( "%1: '%2' needs a string argument." ).arg ( argv[0] ).arg ( strLongOpt ) );
+            qCritical() << qUtf8Printable ( QString ( "%1: '%2' needs a string argument." ).arg ( argv[0] ).arg ( argv[i - 1] ) );
             exit ( 1 );
         }
 
@@ -841,7 +970,7 @@ bool GetNumericArgument ( int     argc,
         QString errmsg = "%1: '%2' needs a numeric argument between '%3' and '%4'.";
         if ( ++i >= argc )
         {
-            qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( strLongOpt ).arg ( rRangeStart ).arg ( rRangeStop ) );
+            qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( argv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );
             exit ( 1 );
         }
 
@@ -849,7 +978,7 @@ bool GetNumericArgument ( int     argc,
         rValue = strtod ( argv[i], &p );
         if ( *p || ( rValue < rRangeStart ) || ( rValue > rRangeStop ) )
         {
-            qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( strLongOpt ).arg ( rRangeStart ).arg ( rRangeStop ) );
+            qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( argv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );
             exit ( 1 );
         }
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

Review and refactor command line handling in `src/main.cpp` to standardise how it all works.

**Context: Fixes an issue?**

Was part of #1867 (persistent directory lists) but really is nothing to do with it.  Might unnecessarily cause conflicts in that change should `src/main.cpp` be amended by some other change, if left as part of it.

There's what appears to be a lot of code change - in fact, it's mostly moving existing code around.  The main _changes_ are from (new) line 533 onwards.

**Does this change need documentation? What needs to be documented and how?**

The code change should be self-documenting, I hope.

This change affects the `--help` output of Jamulus, so any documetation that references that will need reviewing.  I have not looked into that aspect.

**Status of this Pull Request**

Working, tested code.

**What is missing until this pull request can be merged?**

Needs reviewing as an independent pull request.  Had been reviewed under #1867 by @ann0see, I believe.  See https://github.com/jamulussoftware/jamulus/pull/1867#pullrequestreview-687932186

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
