### PR TITLE
Multichannel Input using phantom clients

### DIFF
--- a/autobuild/linux/autobuild_deb_1_prepare.sh
+++ b/autobuild/linux/autobuild_deb_1_prepare.sh
@@ -13,4 +13,4 @@ echo "Update system..."
 sudo apt-get -qq update
 
 echo "Install dependencies..."
-sudo apt-get -qq -y install devscripts build-essential debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools
+sudo apt-get -qq -y install devscripts build-essential debhelper libjack-jackd2-dev qt6-qtbase-dev qt6-qtbase-dev-tools


### PR DESCRIPTION
Multichannel Input using phantom clients

Dual Mono-in/Stereo-out added. Note this is not yet working for delay
panned servers. I don't understand the code, still looking on that.

There is no change to the protocol, works with old clients (of course they can't input 
dual mono, but the old client can receive and manipulate the channel).
Using version number 3.9.9 and requires that on the server and client to enable dual mono.

Also compiled with the new ASIOSDK2.3.3 seems to be working fine.

I'm thinking an addition to the protocol between the dual mono input
client and server might be nice to be able to give the phantom channel a
different name and instrument. That could still work with old clients at
the receiving end. Right now I am just appending -L and -R to the name.

Short description of changes

Multichannel Input using phantom clients

Context: Fixes an issue?

Does this change need documentation? What needs to be documented and how?

Status of this Pull Request
Draft and testing, note delay pan is not yet implemented for Dual Mono-in/Stereo-out

What is missing until this pull request can be merged?
Testing, testing, testing
Agreement that we should do multichannel like this
Checklist

I've verified that this Pull Request follows the general code principles
[x ] I tested my code and it does what I want
My code follows the style guide
I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
I've filled all the content above