### PR TITLE
retain user's directory selection where possible

### DIFF
--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -959,7 +959,7 @@
              <item>
               <widget class="QLabel" name="lblCentralServerAddress">
                <property name="text">
-                <string>Custom Directory Server Address:</string>
+                <string>Custom Directories:</string>
                </property>
               </widget>
              </item>

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -547,7 +547,7 @@ void CConnectDlg::OnCustomCentralServerAddrChanged()
     {
         // check if the currently select custom directory still exists in the now potentially re-ordered vector,
         // if so, then change to its new index.  (addresses Issue #1899)
-        int iNewIndex = cbxDirectoryServer->findText ( strPreviousSelection );
+        int iNewIndex = cbxDirectoryServer->findText ( strPreviousSelection, Qt::MatchExactly );
         if ( iNewIndex == INVALID_INDEX )
         {
             // previously selected custom directory has been deleted.  change to default directory

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -548,7 +548,7 @@ void CConnectDlg::OnCustomCentralServerAddrChanged()
         // check if the currently select custom directory still exists in the now potentially re-ordered vector,
         // if so, then change to its new index.  (addresses Issue #1899)
         int iNewIndex = cbxDirectoryServer->findText ( strPreviousSelection );
-        if ( iNewIndex == -1 )
+        if ( iNewIndex == INVALID_INDEX )
         {
             // previously selected custom directory has been deleted.  change to default directory
             pSettings->eCentralServerAddressType = static_cast<ECSAddType> ( AT_DEFAULT );
@@ -949,6 +949,7 @@ void CConnectDlg::UpdateDirectoryServerComboBox()
     {
         if ( pSettings->vstrCentralServerAddress[i] != "" )
         {
+            // add vector index (i) to the combobox as user data
             cbxDirectoryServer->addItem ( pSettings->vstrCentralServerAddress[i], i );
         }
     }

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -32,7 +32,7 @@
      <item>
       <widget class="QLabel" name="lblList">
        <property name="text">
-        <string>List</string>
+        <string>Directory</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

<!-- A short description of your changes which might go into the change log -->
Upon modifications to the vector of custom directories, restore the user's selected directory on the Connect dialog, where possible.  If the previously selected directory has been deleted, select the 'default' directory.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
addresses discussion #1899

**Does this change need documentation? What needs to be documented and how?**
no

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Working implementation

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Please test and provide comments.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
