### PR TITLE
Enable signing of macOS binaries via GitHub secrets

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -222,7 +222,7 @@ jobs:
       - name: "Notarize macOS Release Build"
         if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: notarize-macOS-app
-        uses: devbotsxyz/xcode-notarize@v1
+        uses: devbotsxyz/xcode-notarize@d7219e1c390b47db8bab0f6b4fc1e3b7943e4b3b
         with:
           product-path: deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
           primary-bundle-id: io.jamulus.Jamulus

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -219,7 +219,7 @@ jobs:
 
       # Notarize macOS build, if needed
       - name: "Notarize macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') }} #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: notarize-macOS-app
         uses: devbotsxyz/xcode-notarize@v1
         with:
@@ -229,7 +229,7 @@ jobs:
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
       # Apply successful notarization
       - name: "Staple macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') }} #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: staple-macOS-app
         uses: devbotsxyz/xcode-staple@v1
         with:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -91,6 +91,11 @@ jobs:
     strategy:
       fail-fast:                    false
       matrix: # Think of this like a foreach loop. Basically runs the steps with every combination of the contents of this. More info: https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+        shouldSign:
+          - ${{ secrets.MACOS_CERT_PWD != "" }}
+        exclude:
+          - shouldSign: true
+            flavor: MacOS Legacy (artifacts)
         config:
            - config_name:           AndroidAPK (artifact+codeQL)
              target_os:             android
@@ -120,7 +125,7 @@ jobs:
              target_os:             macos
              building_on_os:        macos-10.15
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
-             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh allow_signing_true"
+             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"
              uses_codeql:           false
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -86,13 +86,17 @@ jobs:
 
 
   release_assets:
+    env:
+      MACOS_CERTIFICATE:            ${{ secrets.MACOS_CERT}}
+      MACOS_CERTIFICATE_PWD:        ${{ secrets.MACOS_CERT_PWD }}
+      MACOS_CERTIFICATE_ID:         ${{ secrets.MACOS_CERT_ID }}
     name:                           Build assets for ${{ matrix.config.config_name }}
     needs:                          create_release
     strategy:
       fail-fast:                    false
       matrix: # Think of this like a foreach loop. Basically runs the steps with every combination of the contents of this. More info: https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
         shouldSign:
-          - ${{ secrets.MACOS_CERT_PWD != "" }}
+          - ${{ MACOS_CERTIFICATE_PWD != "" }}
         exclude:
           - shouldSign: true
             flavor: MacOS Legacy (artifacts)

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -178,6 +178,7 @@ jobs:
 
       # Build
       - name:                       "Build for ${{ matrix.config.config_name }}"
+        id:                         step_macos_build
         if:                         ${{ matrix.config.cmd2_build }}
         run:                        ${{ matrix.config.cmd2_build }} ${{ github.workspace }}
         env:
@@ -215,9 +216,26 @@ jobs:
           retention-days:           31
           if-no-files-found:        error # 'warn' or 'ignore' are also available, defaults to `warn`
 
+      # Notarize macOS build, if needed
+      - name: "Notarize macOS Release Build"
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') && secrets.NOTARIZATION_PASS != '' }}
+        id: notarize-macOS-app
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+      # Apply successful notarization
+      - name: "Staple macOS Release Build"
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') && secrets.NOTARIZATION_PASS != '' }}
+        id: staple-macOS-app
+        uses: devbotsxyz/xcode-staple@v1
+        with:
+          product-path: deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+
       # Upload Artifact to Release
       - name:                       Upload Artifact 1 to Release
-        if:                         ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') &&  contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if:                         ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id:                         upload-release-asset1
         uses:                       actions/upload-release-asset@v1
         env:
@@ -227,6 +245,7 @@ jobs:
           asset_path:               deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
           asset_name:               ${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
           asset_content_type:       application/octet-stream
+      
       # Upload Artifact to Release
       - name:                       Upload Artifact 2 to Release
         if:                         ${{ (steps.step_cmd3_postbuild.outputs.artifact_2 != '') &&  contains(needs.create_release.outputs.publish_to_release, 'true') }}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -86,20 +86,11 @@ jobs:
 
 
   release_assets:
-    env:
-      MACOS_CERTIFICATE:            ${{ secrets.MACOS_CERT}}
-      MACOS_CERTIFICATE_PWD:        ${{ secrets.MACOS_CERT_PWD }}
-      MACOS_CERTIFICATE_ID:         ${{ secrets.MACOS_CERT_ID }}
     name:                           Build assets for ${{ matrix.config.config_name }}
     needs:                          create_release
     strategy:
       fail-fast:                    false
       matrix: # Think of this like a foreach loop. Basically runs the steps with every combination of the contents of this. More info: https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-        shouldSign:
-          - ${{ env.MACOS_CERTIFICATE_PWD != "" }}
-        exclude:
-          - shouldSign: true
-            flavor: MacOS Legacy (artifacts)
         config:
            - config_name:           AndroidAPK (artifact+codeQL)
              target_os:             android
@@ -129,7 +120,7 @@ jobs:
              target_os:             macos
              building_on_os:        macos-10.15
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
-             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh"
+             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh sign_if_possible"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"
              uses_codeql:           false
 
@@ -137,7 +128,7 @@ jobs:
              target_os:             macos
              building_on_os:        macos-10.15
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.9.9"
-             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh"
+             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh do_not_sign"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh legacy"
              uses_codeql:           false
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -219,7 +219,7 @@ jobs:
 
       # Notarize macOS build, if needed
       - name: "Notarize macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: notarize-macOS-app
         uses: devbotsxyz/xcode-notarize@v1
         with:
@@ -228,7 +228,7 @@ jobs:
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
       # Apply successful notarization
       - name: "Staple macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: staple-macOS-app
         uses: devbotsxyz/xcode-staple@v1
         with:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast:                    false
       matrix: # Think of this like a foreach loop. Basically runs the steps with every combination of the contents of this. More info: https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
         shouldSign:
-          - ${{ MACOS_CERTIFICATE_PWD != "" }}
+          - ${{ env.MACOS_CERTIFICATE_PWD != "" }}
         exclude:
           - shouldSign: true
             flavor: MacOS Legacy (artifacts)

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -224,6 +224,7 @@ jobs:
         uses: devbotsxyz/xcode-notarize@v1
         with:
           product-path: deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+          primary-bundle-id: io.jamulus.Jamulus
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
       # Apply successful notarization

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -120,7 +120,7 @@ jobs:
              target_os:             macos
              building_on_os:        macos-10.15
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
-             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh allow_signing"
+             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh allow_signing_true"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"
              uses_codeql:           false
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -119,10 +119,6 @@ jobs:
            - config_name:           MacOS (artifacts)
              target_os:             macos
              building_on_os:        macos-10.15
-             env: 
-               MACOS_CERTIFICATE:     ${{ secrets.MACOS_CERT}}
-               MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERT_PWD }}
-               MACOS_CERTIFICATE_ID:  ${{ secrets.MACOS_CERT_ID }}
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
              cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"
@@ -187,6 +183,9 @@ jobs:
         env:
           jamulus_project_path:       ${{ github.workspace }}
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
+          MACOS_CERTIFICATE:          ${{ secrets.MACOS_CERT}}
+          MACOS_CERTIFICATE_PWD:      ${{ secrets.MACOS_CERT_PWD }}
+          MACOS_CERTIFICATE_ID:       ${{ secrets.MACOS_CERT_ID }}
 
       - name:                       "Post-Build for ${{ matrix.config.config_name }}"
         id:                         step_cmd3_postbuild

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -188,6 +188,7 @@ jobs:
           MACOS_CERTIFICATE_PWD:      ${{ secrets.MACOS_CERT_PWD }}
           MACOS_CERTIFICATE_ID:       ${{ secrets.MACOS_CERT_ID }}
           NOTARIZATION_PASSWORD:      ${{ secrets.NOTARIZATION_PASSWORD }}
+          KEYCHAIN_PASSWORD:          ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name:                       "Post-Build for ${{ matrix.config.config_name }}"
         id:                         step_cmd3_postbuild

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -119,6 +119,10 @@ jobs:
            - config_name:           MacOS (artifacts)
              target_os:             macos
              building_on_os:        macos-10.15
+             env: 
+               MACOS_CERTIFICATE:     ${{ secrets.MACOS_CERT}}
+               MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERT_PWD }}
+               MACOS_CERTIFICATE_ID:  ${{ secrets.MACOS_CERT_ID }}
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
              cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -219,7 +219,7 @@ jobs:
 
       # Notarize macOS build, if needed
       - name: "Notarize macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') }} #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: notarize-macOS-app
         uses: devbotsxyz/xcode-notarize@v1
         with:
@@ -228,7 +228,7 @@ jobs:
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
       # Apply successful notarization
       - name: "Staple macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') }} #&& contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: staple-macOS-app
         uses: devbotsxyz/xcode-staple@v1
         with:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -187,6 +187,7 @@ jobs:
           MACOS_CERTIFICATE:          ${{ secrets.MACOS_CERT}}
           MACOS_CERTIFICATE_PWD:      ${{ secrets.MACOS_CERT_PWD }}
           MACOS_CERTIFICATE_ID:       ${{ secrets.MACOS_CERT_ID }}
+          NOTARIZATION_PASSWORD:      ${{ secrets.NOTARIZATION_PASSWORD }}
 
       - name:                       "Post-Build for ${{ matrix.config.config_name }}"
         id:                         step_cmd3_postbuild
@@ -218,7 +219,7 @@ jobs:
 
       # Notarize macOS build, if needed
       - name: "Notarize macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') && secrets.NOTARIZATION_PASS != '' }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: notarize-macOS-app
         uses: devbotsxyz/xcode-notarize@v1
         with:
@@ -227,7 +228,7 @@ jobs:
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
       # Apply successful notarization
       - name: "Staple macOS Release Build"
-        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') && secrets.NOTARIZATION_PASS != '' }}
+        if: ${{ (steps.step_cmd3_postbuild.outputs.artifact_1 != '') && (steps.step_macos_build.outputs.macos_signed == 'true') && contains(needs.create_release.outputs.publish_to_release, 'true') }}
         id: staple-macOS-app
         uses: devbotsxyz/xcode-staple@v1
         with:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -120,7 +120,7 @@ jobs:
              target_os:             macos
              building_on_os:        macos-10.15
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
-             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh"
+             cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh allow_signing"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"
              uses_codeql:           false
 

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -8,6 +8,8 @@
 ####################
 
 source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
+# Setting this to 'allow_signing_true' is needed so we don't try to sign on the legacy build
+SIGNING_ENABLED=$1
 
 ###################
 ###  PROCEDURE  ###
@@ -18,7 +20,10 @@ cd "${THIS_JAMULUS_PROJECT_PATH}"
 echo "Run deploy script..."
 
 # If we have certificate details, then prepare the signing
-if [ -z "${MACOS_CERTIFICATE_PWD}" ]; then
+if [ -z "${MACOS_CERTIFICATE_PWD}" ||
+     -z "${MACOS_CERTIFICATE}" ||
+     -z "${MACOS_CERTIFICATE_ID}" ||
+     "${SIGNING_ENABLED}" != "allow_signing_true" ]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else
     echo "Setting up signing, as credentials found"

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -7,6 +7,11 @@
 ###  PARAMETERS  ###
 ####################
 
+SIGN = $1
+if [ ${SIGN} ]; then
+    shift
+fi
+
 source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################
@@ -20,7 +25,8 @@ echo "Run deploy script..."
 # If we have certificate details, then prepare the signing
 if [ -z "${MACOS_CERTIFICATE_PWD}" ||
      -z "${MACOS_CERTIFICATE}" ||
-     -z "${MACOS_CERTIFICATE_ID}"]; then
+     -z "${MACOS_CERTIFICATE_ID}" ||
+     "${SIGN}" != "sign_if_possible" ]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else
     echo "Setting up signing, as credentials found"

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -8,7 +8,6 @@
 ####################
 
 SIGN=$1
-echo "${SIGN}"
 if [ -n "${SIGN}" ]; then
     shift
 fi
@@ -47,5 +46,4 @@ else
     # Set up the notarization and staple parts
     echo "::set-output name=macos_signed::true"
 fi
-
 

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -30,7 +30,7 @@ if [[ -z "${MACOS_CERTIFICATE_PWD}" ||
      "${SIGN}" != "sign_if_possible" ]]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else
-    echo "Setting up signing, as credentials found"
+    echo "Setting up signing, as all credentials found"
 
     # Get the cert to a file
     echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
@@ -46,4 +46,3 @@ else
     # Set up the notarization and staple parts
     echo "::set-output name=macos_signed::true"
 fi
-

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -27,6 +27,7 @@ echo "Run deploy script..."
 if [[ -z "${MACOS_CERTIFICATE_PWD}" ||
      -z "${MACOS_CERTIFICATE}" ||
      -z "${MACOS_CERTIFICATE_ID}" ||
+     -z "${NOTARIZATION_PASSWORD}" ||
      "${SIGN}" != "sign_if_possible" ]]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -27,6 +27,7 @@ if [[ -z "${MACOS_CERTIFICATE_PWD}" ||
      -z "${MACOS_CERTIFICATE}" ||
      -z "${MACOS_CERTIFICATE_ID}" ||
      -z "${NOTARIZATION_PASSWORD}" ||
+     -z "${KEYCHAIN_PASSWORD}" || 
      "${SIGN}" != "sign_if_possible" ]]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else
@@ -36,11 +37,11 @@ else
     echo ${MACOS_CERTIFICATE} | base64 --decode > certificate.p12
 
     # Set up a keychain for the build
-    security create-keychain -p T3mpP4ssword build.keychain
+    security create-keychain -p "${KEYCHAIN_PASSWORD}" build.keychain
     security default-keychain -s build.keychain
-    security unlock-keychain -p T3mpP4ssword build.keychain
+    security unlock-keychain -p "${KEYCHAIN_PASSWORD}" build.keychain
     security import certificate.p12 -k build.keychain -P "${MACOS_CERTIFICATE_PWD}" -T /usr/bin/codesign
-    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k T3mpP4ssword build.keychain
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${KEYCHAIN_PASSWORD}" build.keychain
 
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s "${MACOS_CERTIFICATE_ID}"
     # Set up the notarization and staple parts

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -39,7 +39,7 @@ else
     security create-keychain -p T3mpP4ssword build.keychain
     security default-keychain -s build.keychain
     security unlock-keychain -p T3mpP4ssword build.keychain
-    security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+    security import certificate.p12 -k build.keychain -P "${MACOS_CERTIFICATE_PWD}" -T /usr/bin/codesign
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k T3mpP4ssword build.keychain
 
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s "$MACOS_CERTIFICATE_ID"

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -8,6 +8,7 @@
 ####################
 
 SIGN=$1
+echo "${SIGN}"
 if [ -n "${SIGN}" ]; then
     shift
 fi
@@ -23,10 +24,10 @@ cd "${THIS_JAMULUS_PROJECT_PATH}"
 echo "Run deploy script..."
 
 # If we have certificate details, then prepare the signing
-if [ -z "${MACOS_CERTIFICATE_PWD}" ||
+if [[ -z "${MACOS_CERTIFICATE_PWD}" ||
      -z "${MACOS_CERTIFICATE}" ||
      -z "${MACOS_CERTIFICATE_ID}" ||
-     "${SIGN}" != "sign_if_possible" ]; then
+     "${SIGN}" != "sign_if_possible" ]]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else
     echo "Setting up signing, as credentials found"

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -7,9 +7,6 @@
 ###  PARAMETERS  ###
 ####################
 
-# Setting this to 'allow_signing_true' is needed so we don't try to sign on the legacy build
-SIGNING_ENABLED=$1
-
 source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################
@@ -23,8 +20,7 @@ echo "Run deploy script..."
 # If we have certificate details, then prepare the signing
 if [ -z "${MACOS_CERTIFICATE_PWD}" ||
      -z "${MACOS_CERTIFICATE}" ||
-     -z "${MACOS_CERTIFICATE_ID}" ||
-     "${SIGNING_ENABLED}" != "allow_signing_true" ]; then
+     -z "${MACOS_CERTIFICATE_ID}"]; then
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
 else
     echo "Setting up signing, as credentials found"

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -16,4 +16,24 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh
 cd "${THIS_JAMULUS_PROJECT_PATH}"
 
 echo "Run deploy script..."
-sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
+
+# If we have certificate details, then prepare the signing
+if [ -z "${MACOS_CERTIFICATE_PWD}" ]; then
+    sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh
+else
+    echo "Setting up signing, as credentials found"
+
+    # Get the cert to a file
+    echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+
+    # Set up a keychain for the build
+    security create-keychain -p T3mpP4ssword build.keychain
+    security default-keychain -s build.keychain
+    security unlock-keychain -p T3mpP4ssword build.keychain
+    security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k T3mpP4ssword build.keychain
+
+    sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s $MACOS_CERTIFICATE_ID
+fi
+
+

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -42,7 +42,7 @@ else
     security import certificate.p12 -k build.keychain -P "${MACOS_CERTIFICATE_PWD}" -T /usr/bin/codesign
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k T3mpP4ssword build.keychain
 
-    sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s "$MACOS_CERTIFICATE_ID"
+    sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s "${MACOS_CERTIFICATE_ID}"
     # Set up the notarization and staple parts
     echo "::set-output name=macos_signed::true"
 fi

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -43,6 +43,8 @@ else
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k T3mpP4ssword build.keychain
 
     sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s "$MACOS_CERTIFICATE_ID"
+    # Set up the notarization and staple parts
+    echo "::set-output name=macos_signed::true"
 fi
 
 

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -33,7 +33,7 @@ else
     echo "Setting up signing, as all credentials found"
 
     # Get the cert to a file
-    echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+    echo ${MACOS_CERTIFICATE} | base64 --decode > certificate.p12
 
     # Set up a keychain for the build
     security create-keychain -p T3mpP4ssword build.keychain

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -7,9 +7,10 @@
 ###  PARAMETERS  ###
 ####################
 
-source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 # Setting this to 'allow_signing_true' is needed so we don't try to sign on the legacy build
 SIGNING_ENABLED=$1
+
+source "$(dirname "${BASH_SOURCE[0]}")/../../ensure_THIS_JAMULUS_PROJECT_PATH.sh"
 
 ###################
 ###  PROCEDURE  ###

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -30,10 +30,10 @@ else
     security create-keychain -p T3mpP4ssword build.keychain
     security default-keychain -s build.keychain
     security unlock-keychain -p T3mpP4ssword build.keychain
-    security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+    security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k T3mpP4ssword build.keychain
 
-    sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s $MACOS_CERTIFICATE_ID
+    sh "${THIS_JAMULUS_PROJECT_PATH}"/mac/deploy_mac.sh -s "$MACOS_CERTIFICATE_ID"
 fi
 
 

--- a/autobuild/mac/artifacts/autobuild_mac_2_build.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_2_build.sh
@@ -7,8 +7,8 @@
 ###  PARAMETERS  ###
 ####################
 
-SIGN = $1
-if [ ${SIGN} ]; then
+SIGN=$1
+if [ -n "${SIGN}" ]; then
     shift
 fi
 


### PR DESCRIPTION
**Short description of changes**
This PR is a follow-up to the enabling of signing of the builds; it enables automated signing and notarization of macOS binaries for the non-legacy build.

**GitHub Secrets**
In order to have a successful sign / build, you need to have credentials in GitHub secrets:
`MACOS_CERT` base64 encoded certificate to sign with
`MACOS_CERT_ID` ID of the certificate used to sign
`MACOS_CERT_PWD` password to unlock the `MACOS_CERT` file
`NOTARIZATION_USERNAME` user account to notarize with
`NOTARIZATION_PASSWORD` password used to upload to apple
`KEYCHAIN_PASSWORD` password used to deal with the temporary keychain.

**Status of this Pull Request**
Ready for merge - verified locally using auto build branch.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
