### PR TITLE
Display server version after name in mixer board

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -836,6 +836,7 @@ CAudioMixerBoard::CAudioMixerBoard ( QWidget* parent ) :
     iRunningNewClientCnt ( 0 ),
     iNumMixerPanelRows ( 1 ), // pSettings->iNumMixerPanelRows is not yet available
     strServerName ( "" ),
+    strServerVersion ( "" ),
     eRecorderState ( RS_UNDEFINED ),
     eChSortType ( ST_NO_SORT )
 {
@@ -931,6 +932,12 @@ void CAudioMixerBoard::SetServerName ( const QString& strNewServerName )
         // which is most striking (we use filled blocks and upper case letters).
         setTitle ( u8"\u2588\u2588\u2588\u2588\u2588  " + tr ( "T R Y I N G   T O   C O N N E C T" ) + u8"  \u2588\u2588\u2588\u2588\u2588" );
     }
+}
+
+void CAudioMixerBoard::SetServerVersion ( const QString& strNewServerVersion )
+{
+    // store the current server name
+    strServerVersion = strNewServerVersion;
 }
 
 void CAudioMixerBoard::SetGUIDesign ( const EGUIDesign eNewDesign )
@@ -1096,10 +1103,16 @@ void CAudioMixerBoard::ChangeFaderOrder ( const EChSortType eChSortType )
 void CAudioMixerBoard::UpdateTitle()
 {
     QString strTitlePrefix = "";
+    QString strTitleSuffix = " (<3.5.5)";
 
     if ( eRecorderState == RS_RECORDING )
     {
         strTitlePrefix = "[" + tr ( "RECORDING ACTIVE" ) + "] ";
+    }
+
+    if ( !strServerVersion.isEmpty() )
+    {
+        strTitleSuffix = " (" + strServerVersion + ")";
     }
 
     // replace & signs with && (See Qt documentation for QLabel)
@@ -1109,7 +1122,7 @@ void CAudioMixerBoard::UpdateTitle()
     QString strEscServerName = strServerName;
     strEscServerName.replace ( "&", "&&" );
 
-    setTitle ( strTitlePrefix + tr ( "Personal Mix at: " ) + strEscServerName );
+    setTitle ( strTitlePrefix + tr ( "Personal Mix at: " ) + strEscServerName + strTitleSuffix );
     setAccessibleName ( title() );
 }
 

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -936,7 +936,7 @@ void CAudioMixerBoard::SetServerName ( const QString& strNewServerName )
 
 void CAudioMixerBoard::SetServerVersion ( const QString& strNewServerVersion )
 {
-    // store the current server name
+    // store the current server version
     strServerVersion = strNewServerVersion;
 }
 

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -187,6 +187,7 @@ public:
     void    ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInfo );
     void    SetServerName ( const QString& strNewServerName );
     QString GetServerName() { return strServerName; }
+    void    SetServerVersion ( const QString& strNewServerVersion );
     void    SetGUIDesign ( const EGUIDesign eNewDesign );
     void    SetDisplayPans ( const bool eNDP );
     void    SetPanIsSupported();
@@ -260,6 +261,7 @@ protected:
     int                     iRunningNewClientCnt; // integer type is sufficient, will never overrun for its purpose
     int                     iNumMixerPanelRows;
     QString                 strServerName;
+    QString                 strServerVersion;
     ERecorderState          eRecorderState;
     QMutex                  Mutex;
     EChSortType             eChSortType;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -784,6 +784,8 @@ void CClientDlg::OnVersionAndOSReceived ( COSUtil::EOpSystemType, QString strVer
         MainMixerBoard->SetPanIsSupported();
     }
 #endif
+
+    MainMixerBoard->SetServerVersion ( strVersion );
 }
 
 void CClientDlg::OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType, QString strVersion )
@@ -1233,6 +1235,7 @@ void CClientDlg::Disconnect()
 
     // reset server name in audio mixer group box title
     MainMixerBoard->SetServerName ( "" );
+    MainMixerBoard->SetServerVersion ( "" );
 
     // stop timer for level meter bars and reset them
     TimerSigMet.stop();


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

Add the version of the connected server after its name in the title of the Audio Mixer Board

<!-- A short description of your changes which might go into the change log -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

Some issues are dependent on the version of the server the client is connected to. See for example the discussion at https://github.com/jamulussoftware/jamulus/issues/1935#issuecomment-893483589. At the moment, it is necessary to check [Jamulus Explorer](https://explorer.jamulus.io) to determine the version of a server. With this change, the version will be displayed after the server name in the client window, making diagnosis of issues easier. It might also encourage server operators to update their versions.

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

Documentation not really critical, as it should be self-explanatory. Servers before 3.5.5 will be shown as `<3.5.5`, as that is the first version that sends its version number to the client.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

Working implementation.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

Should be ready.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
