### PR TITLE
unclear error message made precise

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1044,7 +1044,7 @@ bool GetNumericArgument ( int     argc,
 {
     if ( ( !strShortOpt.compare ( argv[i] ) ) || ( !strLongOpt.compare ( argv[i] ) ) )
     {
-        QString errmsg = "%1: '%2' needs a numeric argument between '%3' and '%4'.";
+        QString errmsg = "%1: '%2' needs a numeric argument from '%3' to '%4'.";
         if ( ++i >= argc )
         {
             qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( argv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

<!-- A short description of your changes which might go into the change log -->
At line 1047, or nearby, in jamulus/master/src/main.cpp:
QString errmsg = "%1: '%2' needs a numeric argument between '%3' and '%4'.";
Should be rewritten in the Queen's English to be:
QString errmsg = "%1: '%2' needs a numeric argument from '%3' to '%4'.";
In order to be mathematically correct in English.
This fixes the meaning in all places where this message ocurrs.
**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
