### PR TITLE
Add link to website if a new version is available

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1,4 +1,4 @@
-VERSION = 3.0.0dev
+VERSION = 3.8.0dev
 
 # use target name which does not use a captital letter at the beginning
 contains(CONFIG, "noupcasename") {

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1,4 +1,4 @@
-VERSION = 3.8.0dev
+VERSION = 3.0.0dev
 
 # use target name which does not use a captital letter at the beginning
 contains(CONFIG, "noupcasename") {

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -261,7 +261,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
     lblUpdateCheck->setText (
         "<font color=\"#c94a55\"><b>" +
-        tr ( "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+            APP_UPGRADE_AVAILABLE_MSG_TEXT
             .arg ( APP_NAME )
             .arg ( VERSION ) +
         "</b></font>" );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -258,7 +258,13 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     lblGlobalInfoLabel->hide();
 
     // prepare update check info label (invisible by default)
-    lblUpdateCheck->setText ( "<font color=\"red\"><b>" + QString ( APP_NAME ) + " " + tr ( "software upgrade available" ) + "</b></font>" );
+    lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
+    lblUpdateCheck->setText (
+        "<font color=\"#c94a55\"><b>" +
+        tr ( "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+            .arg ( APP_NAME )
+            .arg ( VERSION ) +
+        "</b></font>" );
     lblUpdateCheck->hide();
 
     // setup timers

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -259,7 +259,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
-    lblUpdateCheck->setText ( "<font color=\"#c94a55\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
+    lblUpdateCheck->setText ( "<font color=\"#ab202c\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
     lblUpdateCheck->hide();
 
     // setup timers

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -259,7 +259,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
-    lblUpdateCheck->setText ( "<font color=\"#ab202c\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
+    lblUpdateCheck->setText ( "<font color=\"red\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
     lblUpdateCheck->hide();
 
     // setup timers

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -259,12 +259,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
-    lblUpdateCheck->setText (
-        "<font color=\"#c94a55\"><b>" +
-            APP_UPGRADE_AVAILABLE_MSG_TEXT
-            .arg ( APP_NAME )
-            .arg ( VERSION ) +
-        "</b></font>" );
+    lblUpdateCheck->setText ( "<font color=\"#c94a55\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
     lblUpdateCheck->hide();
 
     // setup timers

--- a/src/global.h
+++ b/src/global.h
@@ -117,7 +117,9 @@ LED bar:      lbr
 
 // app update message
 #define APP_UPGRADE_AVAILABLE_MSG_TEXT \
-       QCoreApplication::translate ( "global", "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+    QCoreApplication::translate ( \
+        "global", \
+        "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
 
 // determining server internal address uses well-known host and port
 // We just need a valid, public Internet IP here. We will not send any

--- a/src/global.h
+++ b/src/global.h
@@ -115,6 +115,10 @@ LED bar:      lbr
 #define SERVER_GETTING_STARTED_URL "https://jamulus.io/wiki/Running-a-Server"
 #define SOFTWARE_MANUAL_URL        "https://jamulus.io/wiki/Software-Manual"
 
+// app update message
+#define APP_UPGRADE_AVAILABLE_MSG_TEXT \
+       QCoreApplication::translate ( "global", "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+
 // determining server internal address uses well-known host and port
 // We just need a valid, public Internet IP here. We will not send any
 // traffic there as we will only set up an UDP socket without sending any

--- a/src/global.h
+++ b/src/global.h
@@ -119,7 +119,7 @@ LED bar:      lbr
 #define APP_UPGRADE_AVAILABLE_MSG_TEXT \
     QCoreApplication::translate ( \
         "global", \
-        "A %1 upgrade is available: <a style='color:#ab202c;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+        "A %1 upgrade is available: <a style='color:red;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
 
 // determining server internal address uses well-known host and port
 // We just need a valid, public Internet IP here. We will not send any

--- a/src/global.h
+++ b/src/global.h
@@ -119,7 +119,7 @@ LED bar:      lbr
 #define APP_UPGRADE_AVAILABLE_MSG_TEXT \
     QCoreApplication::translate ( \
         "global", \
-        "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+        "A %1 upgrade is available: <a style='color:#ab202c;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
 
 // determining server internal address uses well-known host and port
 // We just need a valid, public Internet IP here. We will not send any

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -334,7 +334,7 @@ lvwClients->setMinimumHeight ( 140 );
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
     lblUpdateCheck->setText (
         "<font color=\"#c94a55\"><b>" +
-        tr ( "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+            APP_UPGRADE_AVAILABLE_MSG_TEXT
             .arg ( APP_NAME )
             .arg ( VERSION ) +
         "</b></font>" );

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -332,7 +332,7 @@ lvwClients->setMinimumHeight ( 140 );
 
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
-    lblUpdateCheck->setText ( "<font color=\"#c94a55\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
+    lblUpdateCheck->setText ( "<font color=\"#ab202c\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
     lblUpdateCheck->hide();
 
     // update GUI dependencies

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -332,12 +332,7 @@ lvwClients->setMinimumHeight ( 140 );
 
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
-    lblUpdateCheck->setText (
-        "<font color=\"#c94a55\"><b>" +
-            APP_UPGRADE_AVAILABLE_MSG_TEXT
-            .arg ( APP_NAME )
-            .arg ( VERSION ) +
-        "</b></font>" );
+    lblUpdateCheck->setText ( "<font color=\"#c94a55\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
     lblUpdateCheck->hide();
 
     // update GUI dependencies

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -331,7 +331,13 @@ lvwClients->setMinimumHeight ( 140 );
     tedWelcomeMessage->setText ( pServer->GetWelcomeMessage() );
 
     // prepare update check info label (invisible by default)
-    lblUpdateCheck->setText ( "<font color=\"red\"><b>" + QString ( APP_NAME ) + " " + tr ( "software upgrade available" ) + "</b></font>" );
+    lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
+    lblUpdateCheck->setText (
+        "<font color=\"#c94a55\"><b>" +
+        tr ( "A %1 upgrade is available: <a style='color:#c94a55;' href='https://jamulus.io/upgrade?progversion=%2'>go to details and downloads</a>" )
+            .arg ( APP_NAME )
+            .arg ( VERSION ) +
+        "</b></font>" );
     lblUpdateCheck->hide();
 
     // update GUI dependencies

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -332,7 +332,7 @@ lvwClients->setMinimumHeight ( 140 );
 
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
-    lblUpdateCheck->setText ( "<font color=\"#ab202c\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
+    lblUpdateCheck->setText ( "<font color=\"red\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
     lblUpdateCheck->hide();
 
     // update GUI dependencies


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

Adds a clickable link in the "new jamulus version available" message:
![update message server](https://user-images.githubusercontent.com/20726856/131998268-7fc75146-1d72-482a-9b2d-c7a544fce385.png)
![update message client](https://user-images.githubusercontent.com/20726856/131998271-4868218c-4d5d-4944-9ea4-8a84db182c60.png)


I think it would be good to have this one in the next release.

**Context: Fixes an issue?**

Sometimes users might find it confusing to only get notified that a new version is available but no actionable "solution" is provided. Therefore this will add a link to a page which is still to be created (currently just a redirect to jamulus.io).

Also see: https://github.com/jamulussoftware/jamulus/issues/370#issuecomment-697720156

**Does this change need documentation? What needs to be documented and how?**

* Screenshots needed???
* CHANGELOG: Link download page in "update available" message to make updating easier

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
Working implementation.

**What is missing until this pull request can be merged?**
Two approvals.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
