### PR TITLE
Improve channel lookup and logging

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -562,7 +562,7 @@ void CServer::SendProtMessage ( int iChID, CVector<uint8_t> vecMessage )
     Socket.SendPacket ( vecMessage, vecChannels[iChID].GetAddress() );
 }
 
-void CServer::OnNewConnection ( int iChID, CHostAddress RecHostAddr )
+void CServer::OnNewConnection ( int iChID, int iTotChans, CHostAddress RecHostAddr )
 {
     QMutexLocker locker ( &Mutex );
 
@@ -637,7 +637,7 @@ void CServer::OnNewConnection ( int iChID, CHostAddress RecHostAddr )
     DoubleFrameSizeConvBufOut[iChID].Reset();
 
     // logging of new connected channel
-    Logging.AddNewConnection ( RecHostAddr.InetAddr, GetNumberOfConnectedClients() );
+    Logging.AddNewConnection ( RecHostAddr.InetAddr, iTotChans );
 }
 
 void CServer::OnServerFull ( CHostAddress RecHostAddr )

--- a/src/server.h
+++ b/src/server.h
@@ -181,6 +181,8 @@ public:
 
     bool PutAudioData ( const CVector<uint8_t>& vecbyRecBuf, const int iNumBytesRead, const CHostAddress& HostAdr, int& iCurChanID );
 
+    int GetNumberOfConnectedClients();
+
     void GetConCliParam ( CVector<CHostAddress>& vecHostAddresses,
                           CVector<QString>&      vecsName,
                           CVector<int>&          veciJitBufNumFrames,
@@ -261,7 +263,6 @@ protected:
     void                  InitChannel ( const int iNewChanID, const CHostAddress& InetAddr );
     void                  FreeChannel ( const int iCurChanID );
     void                  DumpChannels ( const QString& title );
-    int                   GetNumberOfConnectedClients();
     CVector<CChannelInfo> CreateChannelList();
 
     virtual void CreateAndSendChanListForAllConChannels();
@@ -413,7 +414,7 @@ signals:
 public slots:
     void OnTimer();
 
-    void OnNewConnection ( int iChID, CHostAddress RecHostAddr );
+    void OnNewConnection ( int iChID, int iTotChans, CHostAddress RecHostAddr );
 
     void OnServerFull ( CHostAddress RecHostAddr );
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -69,7 +69,10 @@ CSocket::CSocket ( CServer* pNServP, const quint16 iPortNumber, const quint16 iQ
 
     QObject::connect ( this, &CSocket::ProtcolCLMessageReceived, pServer, &CServer::OnProtcolCLMessageReceived );
 
-    QObject::connect ( this, static_cast<void ( CSocket::* ) ( int, CHostAddress )> ( &CSocket::NewConnection ), pServer, &CServer::OnNewConnection );
+    QObject::connect ( this,
+                       static_cast<void ( CSocket::* ) ( int, int, CHostAddress )> ( &CSocket::NewConnection ),
+                       pServer,
+                       &CServer::OnNewConnection );
 
     QObject::connect ( this, &CSocket::ServerFull, pServer, &CServer::OnServerFull );
 }
@@ -463,7 +466,7 @@ void CSocket::OnDataReceived()
             if ( pServer->PutAudioData ( vecbyRecBuf, iNumBytesRead, RecHostAddr, iCurChanID ) )
             {
                 // we have a new connection, emit a signal
-                emit NewConnection ( iCurChanID, RecHostAddr );
+                emit NewConnection ( iCurChanID, pServer->GetNumberOfConnectedClients(), RecHostAddr );
 
                 // this was an audio packet, start server if it is in sleep mode
                 if ( !pServer->IsRunning() )

--- a/src/socket.h
+++ b/src/socket.h
@@ -97,7 +97,7 @@ public:
 signals:
     void NewConnection(); // for the client
 
-    void NewConnection ( int          iChID,
+    void NewConnection ( int iChID, int iTotChans,
                          CHostAddress RecHostAddr ); // for the server
 
     void ServerFull ( CHostAddress RecHostAddr );

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -922,7 +922,7 @@ int CHostAddress::Compare ( const CHostAddress& other ) const
     quint32 thisAddr  = InetAddr.toIPv4Address();
     quint32 otherAddr = other.InetAddr.toIPv4Address();
 
-    return (int) thisAddr - (int) otherAddr;
+    return thisAddr < otherAddr ? -1 : thisAddr > otherAddr ? 1 : 0;
 }
 
 // Instrument picture data base ------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

<!-- A short description of your changes which might go into the change log -->

In `CHostAddress::Compare()`, does an explicit comparison of IPv4 addresses instead of just subtracting them. This avoids a potential signed overflow inconsistency.

Also improves the logging of connections by fetching the channel count at the time of connection and passing it through to the logging, instead of fetching it later in the logging thread.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
May fix #2046 

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No, code improvement only

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

Working, but needs testing.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
