### PR TITLE
Preserve environment variables when building

### DIFF
--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -31,4 +31,4 @@ echo "${VERSION} building..."
 
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control
 
-debuild -b -us -uc
+debuild --preserve-env -b -us -uc


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

This PR changes the building script to pass the `--preserve-env` option to `debuild`. This ensures the environment variables needed by CodeQL during the build are present.

<!-- A short description of your changes which might go into the change log -->

**Context: Fixes an issue?**

Fixes: https://github.com/github/codeql-action/issues/760

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

It does not - no changes to the project itself, only to the build script used in CI.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

Working implementation.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

Ready to merge.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
