### PR TITLE
Change "Central Server" to "Directory Server" in variables and settings

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -510,10 +510,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::AudioChannelsChanged, this, &CClientDlg::OnAudioChannelsChanged );
 
-    QObject::connect ( &ClientSettingsDlg,
-                       &CClientSettingsDlg::CustomCentralServerAddrChanged,
-                       &ConnectDlg,
-                       &CConnectDlg::OnCustomCentralServerAddrChanged );
+    QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::DirectoryAddressChanged, &ConnectDlg, &CConnectDlg::OnCustomDirectoryAddressChanged );
 
     QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::NumMixerPanelRowsChanged, this, &CClientDlg::OnNumMixerPanelRowsChanged );
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -353,13 +353,13 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxInputBoost->setAccessibleName ( tr ( "Input Boost combo box" ) );
 
     // custom directory server address
-    QString strCentrServAddr = "<b>" + tr ( "Custom Directory Server Address" ) + ":</b> " +
-                               tr ( "Leave this blank unless you need to enter the address of a directory "
-                                    "server other than the default." );
+    QString strCustomDirectoryAddress = "<b>" + tr ( "Custom Directory Server Address" ) + ":</b> " +
+                                        tr ( "Leave this blank unless you need to enter the address of a directory "
+                                             "server other than the default." );
 
-    lblCentralServerAddress->setWhatsThis ( strCentrServAddr );
-    cbxCentralServerAddress->setWhatsThis ( strCentrServAddr );
-    cbxCentralServerAddress->setAccessibleName ( tr ( "Directory server address combo box" ) );
+    lblDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
+    cbxDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
+    cbxDirectoryAddress->setAccessibleName ( tr ( "Directory server address combo box" ) );
 
     // current connection status parameter
     QString strConnStats = "<b>" + tr ( "Audio Upstream Rate" ) + ":</b> " +
@@ -445,8 +445,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxLanguage->Init ( pSettings->strLanguage );
 
     // init custom directory server address combo box (max MAX_NUM_SERVER_ADDR_ITEMS entries)
-    cbxCentralServerAddress->setMaxCount ( MAX_NUM_SERVER_ADDR_ITEMS );
-    cbxCentralServerAddress->setInsertPolicy ( QComboBox::NoInsert );
+    cbxDirectoryAddress->setMaxCount ( MAX_NUM_SERVER_ADDR_ITEMS );
+    cbxDirectoryAddress->setInsertPolicy ( QComboBox::NoInsert );
 
     // update new client fader level edit box
     edtNewClientLevel->setText ( QString::number ( pSettings->iNewClientFaderLevel ) );
@@ -667,15 +667,12 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                        this,
                        &CClientSettingsDlg::OnMeterStyleActivated );
 
-    QObject::connect ( cbxCentralServerAddress->lineEdit(),
-                       &QLineEdit::editingFinished,
-                       this,
-                       &CClientSettingsDlg::OnCentralServerAddressEditingFinished );
+    QObject::connect ( cbxDirectoryAddress->lineEdit(), &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnDirectoryAddressEditingFinished );
 
-    QObject::connect ( cbxCentralServerAddress,
+    QObject::connect ( cbxDirectoryAddress,
                        static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
                        this,
-                       &CClientSettingsDlg::OnCentralServerAddressEditingFinished );
+                       &CClientSettingsDlg::OnDirectoryAddressEditingFinished );
 
     QObject::connect ( cbxLanguage, &CLanguageComboBox::LanguageChanged, this, &CClientSettingsDlg::OnLanguageChanged );
 
@@ -731,7 +728,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 void CClientSettingsDlg::showEvent ( QShowEvent* )
 {
     UpdateDisplay();
-    UpdateCustomCentralServerComboBox();
+    UpdateDirectoryServerComboBox();
 
     // set the name
     pedtAlias->setText ( pClient->ChannelInfo.strName );
@@ -981,24 +978,24 @@ void CClientSettingsDlg::OnEnableOPUS64StateChanged ( int value )
 
 void CClientSettingsDlg::OnFeedbackDetectionChanged ( int value ) { pSettings->bEnableFeedbackDetection = value == Qt::Checked; }
 
-void CClientSettingsDlg::OnCentralServerAddressEditingFinished()
+void CClientSettingsDlg::OnDirectoryAddressEditingFinished()
 {
     // if the user has selected and deleted an entry in the combo box list,
     // we delete the corresponding entry in the directory server address vector
-    if ( cbxCentralServerAddress->currentText().isEmpty() && cbxCentralServerAddress->currentData().isValid() )
+    if ( cbxDirectoryAddress->currentText().isEmpty() && cbxDirectoryAddress->currentData().isValid() )
     {
-        pSettings->vstrCentralServerAddress[cbxCentralServerAddress->currentData().toInt()] = "";
+        pSettings->vstrDirectoryAddress[cbxDirectoryAddress->currentData().toInt()] = "";
     }
     else
     {
         // store new address at the top of the list, if the list was already
         // full, the last element is thrown out
-        pSettings->vstrCentralServerAddress.StringFiFoWithCompare ( NetworkUtil::FixAddress ( cbxCentralServerAddress->currentText() ) );
+        pSettings->vstrDirectoryAddress.StringFiFoWithCompare ( NetworkUtil::FixAddress ( cbxDirectoryAddress->currentText() ) );
     }
 
     // update combo box list and inform connect dialog about the new address
-    UpdateCustomCentralServerComboBox();
-    emit CustomCentralServerAddrChanged();
+    UpdateDirectoryServerComboBox();
+    emit DirectoryAddressChanged();
 }
 
 void CClientSettingsDlg::OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button )
@@ -1042,17 +1039,17 @@ void CClientSettingsDlg::UpdateDisplay()
     }
 }
 
-void CClientSettingsDlg::UpdateCustomCentralServerComboBox()
+void CClientSettingsDlg::UpdateDirectoryServerComboBox()
 {
-    cbxCentralServerAddress->clear();
-    cbxCentralServerAddress->clearEditText();
+    cbxDirectoryAddress->clear();
+    cbxDirectoryAddress->clearEditText();
 
     for ( int iLEIdx = 0; iLEIdx < MAX_NUM_SERVER_ADDR_ITEMS; iLEIdx++ )
     {
-        if ( !pSettings->vstrCentralServerAddress[iLEIdx].isEmpty() )
+        if ( !pSettings->vstrDirectoryAddress[iLEIdx].isEmpty() )
         {
             // store the index as user data to the combo box item, too
-            cbxCentralServerAddress->addItem ( pSettings->vstrCentralServerAddress[iLEIdx], iLEIdx );
+            cbxDirectoryAddress->addItem ( pSettings->vstrDirectoryAddress[iLEIdx], iLEIdx );
         }
     }
 }

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -65,7 +65,7 @@ public:
 protected:
     void    UpdateJitterBufferFrame();
     void    UpdateSoundCardFrame();
-    void    UpdateCustomCentralServerComboBox();
+    void    UpdateDirectoryServerComboBox();
     void    UpdateAudioFaderSlider();
     QString GenSndCrdBufferDelayString ( const int iFrameSize, const QString strAddText = "" );
 
@@ -83,7 +83,7 @@ public slots:
     void OnAutoJitBufStateChanged ( int value );
     void OnEnableOPUS64StateChanged ( int value );
     void OnFeedbackDetectionChanged ( int value );
-    void OnCentralServerAddressEditingFinished();
+    void OnDirectoryAddressEditingFinished();
     void OnNewClientLevelEditingFinished() { pSettings->iNewClientFaderLevel = edtNewClientLevel->text().toInt(); }
     void OnInputBoostChanged();
     void OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button );
@@ -111,6 +111,6 @@ signals:
     void GUIDesignChanged();
     void MeterStyleChanged();
     void AudioChannelsChanged();
-    void CustomCentralServerAddrChanged();
+    void DirectoryAddressChanged();
     void NumMixerPanelRowsChanged ( int value );
 };

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -967,14 +967,14 @@
               </spacer>
              </item>
              <item>
-              <widget class="QLabel" name="lblCentralServerAddress">
+              <widget class="QLabel" name="lblDirectoryAddress">
                <property name="text">
                 <string>Custom Directories:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QComboBox" name="cbxCentralServerAddress">
+              <widget class="QComboBox" name="cbxDirectoryAddress">
                <property name="editable">
                 <bool>true</bool>
                </property>
@@ -1298,7 +1298,7 @@
   <tabstop>sldNetBuf</tabstop>
   <tabstop>sldNetBufServer</tabstop>
   <tabstop>chbEnableOPUS64</tabstop>
-  <tabstop>cbxCentralServerAddress</tabstop>
+  <tabstop>cbxDirectoryAddress</tabstop>
   <tabstop>edtNewClientLevel</tabstop>
   <tabstop>cbxInputBoost</tabstop>
   <tabstop>chbDetectFeedback</tabstop>

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -73,7 +73,7 @@ protected:
     void             UpdateListFilter();
     void             ShowAllMusicians ( const bool bState );
     void             RequestServerList();
-    void             EmitCLServerListPingMes ( const CHostAddress& CurServerAddress );
+    void             EmitCLServerListPingMes ( const CHostAddress& haServerAddress );
     void             UpdateDirectoryServerComboBox();
 
     CClientSettings* pSettings;
@@ -81,7 +81,7 @@ protected:
     QTimer       TimerPing;
     QTimer       TimerReRequestServList;
     QTimer       TimerInitialSort;
-    CHostAddress CentralServerAddress;
+    CHostAddress haDirectoryAddress;
     QString      strSelectedAddress;
     QString      strSelectedServerName;
     bool         bShowCompleteRegList;
@@ -98,7 +98,7 @@ public slots:
     void OnDirectoryServerChanged ( int iTypeIdx );
     void OnFilterTextEdited ( const QString& ) { UpdateListFilter(); }
     void OnExpandAllStateChanged ( int value ) { ShowAllMusicians ( value == Qt::Checked ); }
-    void OnCustomCentralServerAddrChanged();
+    void OnCustomDirectoryAddressChanged();
     void OnConnectClicked();
     void OnTimerPing();
     void OnTimerReRequestServList();

--- a/src/global.h
+++ b/src/global.h
@@ -233,7 +233,7 @@ LED bar:      lbr
 // time interval for sending ping messages to servers in the server list
 #define SERVLIST_UPDATE_PING_SERVERS_MS 59000 // ms
 
-// time until a slave server registers in the server list
+// time between server registration refreshes
 #define SERVLIST_REGIST_INTERV_MINUTES 15 // minutes
 
 // defines the minimum time a server must run to be a permanent server

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ int main ( int argc, char** argv )
     QString      strHTMLStatusFileName       = "";
     QString      strLoggingFileName          = "";
     QString      strRecordingDirName         = "";
-    QString      strCentralServer            = "";
+    QString      strDirectoryServer          = "";
     QString      strServerListFileName       = "";
     QString      strServerInfo               = "";
     QString      strServerPublicIP           = "";
@@ -204,8 +204,8 @@ int main ( int argc, char** argv )
         // Directory server ----------------------------------------------------
         if ( GetStringArgument ( argc, argv, i, "-e", "--directoryserver", strArgument ) )
         {
-            strCentralServer = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strCentralServer ) );
+            strDirectoryServer = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strDirectoryServer ) );
             CommandLineOptions << "--directoryserver";
             ServerOnlyOptions << "--directoryserver";
             continue;
@@ -219,8 +219,8 @@ int main ( int argc, char** argv )
                                  "--centralserver",
                                  strArgument ) )
         {
-            strCentralServer = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strCentralServer ) );
+            strDirectoryServer = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strDirectoryServer ) );
             CommandLineOptions << "--directoryserver";
             ServerOnlyOptions << "--directoryserver";
             continue;
@@ -592,12 +592,12 @@ int main ( int argc, char** argv )
 
         if ( bUseGUI )
         {
-            if ( strCentralServer.isEmpty() )
+            if ( strDirectoryServer.isEmpty() )
             {
                 // per definition: if we are in "GUI" server mode and no directory server
                 // address is given, we use the default directory server address
-                strCentralServer = DEFAULT_SERVER_ADDRESS;
-                qInfo() << qUtf8Printable ( QString ( "- default directory server set: %1" ).arg ( strCentralServer ) );
+                strDirectoryServer = DEFAULT_SERVER_ADDRESS;
+                qInfo() << qUtf8Printable ( QString ( "- default directory server set: %1" ).arg ( strDirectoryServer ) );
             }
         }
         else
@@ -609,7 +609,7 @@ int main ( int argc, char** argv )
             }
         }
 
-        if ( strCentralServer.isEmpty() )
+        if ( strDirectoryServer.isEmpty() )
         {
             // per definition, we must be a headless server and ignoring inifile, so we have all the information
 
@@ -636,7 +636,7 @@ int main ( int argc, char** argv )
             // either we are not headless and there is an inifile, or a directory server was supplied on the command line
 
             // if we are not headless, certain checks cannot be made, as the inifile state is not yet known
-            if ( !bUseGUI && strCentralServer.compare ( "localhost", Qt::CaseInsensitive ) != 0 && strCentralServer.compare ( "127.0.0.1" ) != 0 )
+            if ( !bUseGUI && strDirectoryServer.compare ( "localhost", Qt::CaseInsensitive ) != 0 && strDirectoryServer.compare ( "127.0.0.1" ) != 0 )
             {
                 if ( !strServerListFileName.isEmpty() )
                 {
@@ -852,7 +852,7 @@ int main ( int argc, char** argv )
                              iPortNumber,
                              iQosNumber,
                              strHTMLStatusFileName,
-                             strCentralServer,
+                             strDirectoryServer,
                              strServerListFileName,
                              strServerInfo,
                              strServerPublicIP,
@@ -902,7 +902,7 @@ int main ( int argc, char** argv )
                 qInfo() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
 
                 // enable server list if a directory server is defined
-                Server.SetServerListEnabled ( !strCentralServer.isEmpty() );
+                Server.SetServerRegistered ( !strDirectoryServer.isEmpty() );
 
                 // update serverlist
                 Server.UpdateServerList();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -306,8 +306,8 @@ CONNECTION LESS MESSAGES
       NOTE: In the PROTMESSID_CLM_SERVER_LIST list, this field will be empty
       as only the initial IP address should be used by the client.  Where
       necessary, that value will contain the server internal address.
-      When running a directory server and a slave server behind the same NAT,
-      this field is used the other way round: It will contain the public
+      When running a directory server and a registered server behind the same
+      NAT, this field is used the other way round: It will contain the public
       IP in this case which will be served to clients from the Internet.
 
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -2573,7 +2573,7 @@ bool CProtocol::EvaluateCLRegisterServerResp ( const CHostAddress& InetAddr, con
     // server registration result (1 byte)
     const int iSvrRegResult = static_cast<int> ( GetValFromStream ( vecData, iPos, 1 ) );
 
-    if ( ( iSvrRegResult != SRR_REGISTERED ) && ( iSvrRegResult != SRR_CENTRAL_SVR_FULL ) && ( iSvrRegResult != SRR_VERSION_TOO_OLD ) &&
+    if ( ( iSvrRegResult != SRR_REGISTERED ) && ( iSvrRegResult != SRR_SERVER_LIST_FULL ) && ( iSvrRegResult != SRR_VERSION_TOO_OLD ) &&
          ( iSvrRegResult != SRR_NOT_FULFILL_REQIREMENTS ) )
     {
         return true;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -687,7 +687,7 @@ void CServer::OnAboutToQuit()
     // if server was registered at the directory server, unregister on shutdown
     if ( GetServerRegistered() )
     {
-        UnregisterSlaveServer();
+        Unregister();
     }
 
     if ( bWriteStatusHTMLFile )

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -218,7 +218,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
                    const quint16      iPortNumber,
                    const quint16      iQosNumber,
                    const QString&     strHTMLStatusFileName,
-                   const QString&     strCentralServer,
+                   const QString&     strDirectoryServer,
                    const QString&     strServerListFileName,
                    const QString&     strServerInfo,
                    const QString&     strServerListFilter,
@@ -243,7 +243,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
     strServerHTMLFileListName ( strHTMLStatusFileName ),
     HighPrecisionTimer ( bNUseDoubleSystemFrameSize ),
     ServerListManager ( iPortNumber,
-                        strCentralServer,
+                        strDirectoryServer,
                         strServerListFileName,
                         strServerInfo,
                         strServerPublicIP,
@@ -685,7 +685,7 @@ void CServer::OnAboutToQuit()
     Stop();
 
     // if server was registered at the directory server, unregister on shutdown
-    if ( GetServerListEnabled() )
+    if ( GetServerRegistered() )
     {
         UnregisterSlaveServer();
     }

--- a/src/server.h
+++ b/src/server.h
@@ -218,7 +218,7 @@ public:
     // Server list management --------------------------------------------------
     void UpdateServerList() { ServerListManager.Update(); }
 
-    void UnregisterSlaveServer() { ServerListManager.SlaveServerUnregister(); }
+    void Unregister() { ServerListManager.Unregister(); }
 
     void SetServerRegistered ( const bool bState ) { ServerListManager.SetEnabled ( bState ); }
 

--- a/src/server.h
+++ b/src/server.h
@@ -158,7 +158,7 @@ public:
               const quint16      iPortNumber,
               const quint16      iQosNumber,
               const QString&     strHTMLStatusFileName,
-              const QString&     strCentralServer,
+              const QString&     strDirectoryServer,
               const QString&     strServerListFileName,
               const QString&     strServerInfo,
               const QString&     strServerListFilter,
@@ -220,17 +220,17 @@ public:
 
     void UnregisterSlaveServer() { ServerListManager.SlaveServerUnregister(); }
 
-    void SetServerListEnabled ( const bool bState ) { ServerListManager.SetEnabled ( bState ); }
+    void SetServerRegistered ( const bool bState ) { ServerListManager.SetEnabled ( bState ); }
 
-    bool GetServerListEnabled() { return ServerListManager.GetEnabled(); }
+    bool GetServerRegistered() { return ServerListManager.GetEnabled(); }
 
-    void SetServerListCentralServerAddress ( const QString& sNCentServAddr ) { ServerListManager.SetCentralServerAddress ( sNCentServAddr ); }
+    void SetDirectoryAddress ( const QString& sNDirectoryAddress ) { ServerListManager.SetDirectoryAddress ( sNDirectoryAddress ); }
 
-    QString GetServerListCentralServerAddress() { return ServerListManager.GetCentralServerAddress(); }
+    QString GetDirectoryAddress() { return ServerListManager.GetDirectoryAddress(); }
 
-    void SetCentralServerAddressType ( const ECSAddType eNCSAT ) { ServerListManager.SetCentralServerAddressType ( eNCSAT ); }
+    void SetDirectoryType ( const EDirectoryType eNCSAT ) { ServerListManager.SetDirectoryType ( eNCSAT ); }
 
-    ECSAddType GetCentralServerAddressType() { return ServerListManager.GetCentralServerAddressType(); }
+    EDirectoryType GetDirectoryType() { return ServerListManager.GetDirectoryType(); }
 
     void SetServerName ( const QString& strNewName ) { ServerListManager.SetServerName ( strNewName ); }
 
@@ -435,13 +435,13 @@ public slots:
     {
         // only send empty message if server list is enabled and this is not
         // a directory server
-        if ( ServerListManager.GetEnabled() && !ServerListManager.GetIsCentralServer() )
+        if ( ServerListManager.GetEnabled() && !ServerListManager.IsDirectoryServer() )
         {
             ConnLessProtocol.CreateCLEmptyMes ( TargetInetAddr );
         }
     }
 
-    void OnCLReqServerList ( CHostAddress InetAddr ) { ServerListManager.CentralServerQueryServerList ( InetAddr ); }
+    void OnCLReqServerList ( CHostAddress InetAddr ) { ServerListManager.RetrieveAll ( InetAddr ); }
 
     void OnCLReqVersionAndOS ( CHostAddress InetAddr ) { ConnLessProtocol.CreateCLVersionAndOSMes ( InetAddr ); }
 
@@ -449,7 +449,7 @@ public slots:
 
     void OnCLRegisterServerReceived ( CHostAddress InetAddr, CHostAddress LInetAddr, CServerCoreInfo ServerInfo )
     {
-        ServerListManager.CentralServerRegisterServer ( InetAddr, LInetAddr, ServerInfo );
+        ServerListManager.Append ( InetAddr, LInetAddr, ServerInfo );
     }
 
     void OnCLRegisterServerExReceived ( CHostAddress    InetAddr,
@@ -458,12 +458,12 @@ public slots:
                                         COSUtil::EOpSystemType,
                                         QString strVersion )
     {
-        ServerListManager.CentralServerRegisterServer ( InetAddr, LInetAddr, ServerInfo, strVersion );
+        ServerListManager.Append ( InetAddr, LInetAddr, ServerInfo, strVersion );
     }
 
     void OnCLRegisterServerResp ( CHostAddress /* unused */, ESvrRegResult eResult ) { ServerListManager.StoreRegistrationResult ( eResult ); }
 
-    void OnCLUnregisterServerReceived ( CHostAddress InetAddr ) { ServerListManager.CentralServerUnregisterServer ( InetAddr ); }
+    void OnCLUnregisterServerReceived ( CHostAddress InetAddr ) { ServerListManager.Remove ( InetAddr ); }
 
     void OnCLDisconnection ( CHostAddress InetAddr );
 

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -72,17 +72,17 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                          "registration failed, please choose another server list." ) );
 
     // custom directory server address
-    QString strCentrServAddr = "<b>" + tr ( "Custom Directory Server Address" ) + ":</b> " +
-                               tr ( "The custom directory server address is the IP address or URL of the directory "
-                                    "server at which the server list of the connection dialog is managed." );
+    QString strCustomDirectoryAddress = "<b>" + tr ( "Custom Directory Server Address" ) + ":</b> " +
+                                        tr ( "The custom directory server address is the IP address or URL of the directory "
+                                             "server at which the server list of the connection dialog is managed." );
 
-    lblCentralServerAddress->setWhatsThis ( strCentrServAddr );
-    edtCentralServerAddress->setWhatsThis ( strCentrServAddr );
-    edtCentralServerAddress->setAccessibleName ( tr ( "Directory server address line edit" ) );
+    lblDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
+    edtDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
+    edtDirectoryAddress->setAccessibleName ( tr ( "Directory server address line edit" ) );
 
-    cbxCentServAddrType->setWhatsThis ( "<b>" + tr ( "Server List Selection" ) + ":</b> " +
-                                        tr ( "Selects the server list (i.e. directory server address) in which your server will be added." ) );
-    cbxCentServAddrType->setAccessibleName ( tr ( "Server list selection combo box" ) );
+    cbxDirectoryType->setWhatsThis ( "<b>" + tr ( "Server List Selection" ) + ":</b> " +
+                                     tr ( "Selects the server list (i.e. directory server address) in which your server will be added." ) );
+    cbxDirectoryType->setAccessibleName ( tr ( "Server list selection combo box" ) );
 
     // server name
     QString strServName = "<b>" + tr ( "Server Name" ) + ":</b> " +
@@ -229,20 +229,20 @@ lvwClients->setMinimumHeight ( 140 );
         vecpListViewItems[i]->setHidden ( true );
     }
 
-    // directory server address type combo box
-    cbxCentServAddrType->clear();
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_DEFAULT ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_ANY_GENRE2 ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_ANY_GENRE3 ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_GENRE_ROCK ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_GENRE_JAZZ ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_GENRE_CLASSICAL_FOLK ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_GENRE_CHORAL ) );
-    cbxCentServAddrType->addItem ( csCentServAddrTypeToString ( AT_CUSTOM ) );
-    cbxCentServAddrType->setCurrentIndex ( static_cast<int> ( pServer->GetCentralServerAddressType() ) );
+    // directory type combo box
+    cbxDirectoryType->clear();
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_DEFAULT ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_ANY_GENRE2 ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_ANY_GENRE3 ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_GENRE_ROCK ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_GENRE_JAZZ ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_GENRE_CLASSICAL_FOLK ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_GENRE_CHORAL ) );
+    cbxDirectoryType->addItem ( DirectoryTypeToString ( AT_CUSTOM ) );
+    cbxDirectoryType->setCurrentIndex ( static_cast<int> ( pServer->GetDirectoryType() ) );
 
     // custom directory server address
-    edtCentralServerAddress->setText ( pServer->GetServerListCentralServerAddress() );
+    edtDirectoryAddress->setText ( pServer->GetDirectoryAddress() );
 
     // update server name line edit
     edtServerName->setText ( pServer->GetServerName() );
@@ -272,7 +272,7 @@ lvwClients->setMinimumHeight ( 140 );
     cbxLocationCountry->setCurrentIndex ( cbxLocationCountry->findData ( static_cast<int> ( pServer->GetServerCountry() ) ) );
 
     // update register server check box
-    if ( pServer->GetServerListEnabled() )
+    if ( pServer->GetServerRegistered() )
     {
         chbRegisterServer->setCheckState ( Qt::Checked );
     }
@@ -373,7 +373,7 @@ lvwClients->setMinimumHeight ( 140 );
     QObject::connect ( chbEnableDelayPanning, &QCheckBox::stateChanged, this, &CServerDlg::OnEnableDelayPanningStateChanged );
 
     // line edits
-    QObject::connect ( edtCentralServerAddress, &QLineEdit::editingFinished, this, &CServerDlg::OnCentralServerAddressEditingFinished );
+    QObject::connect ( edtDirectoryAddress, &QLineEdit::editingFinished, this, &CServerDlg::OnDirectoryAddressEditingFinished );
 
     QObject::connect ( edtServerName, &QLineEdit::textChanged, this, &CServerDlg::OnServerNameTextChanged );
 
@@ -385,10 +385,10 @@ lvwClients->setMinimumHeight ( 140 );
                        this,
                        &CServerDlg::OnLocationCountryActivated );
 
-    QObject::connect ( cbxCentServAddrType,
+    QObject::connect ( cbxDirectoryType,
                        static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
                        this,
-                       &CServerDlg::OnCentServAddrTypeActivated );
+                       &CServerDlg::OnDirectoryTypeActivated );
 
     QObject::connect ( cbxLanguage, &CLanguageComboBox::LanguageChanged, this, &CServerDlg::OnLanguageChanged );
 
@@ -467,7 +467,7 @@ void CServerDlg::OnRegisterServerStateChanged ( int value )
     const bool bRegState = ( value == Qt::Checked );
 
     // apply new setting to the server and update it
-    pServer->SetServerListEnabled ( bRegState );
+    pServer->SetServerRegistered ( bRegState );
 
     // if registering is disabled, unregister slave server
     if ( !bRegState )
@@ -481,10 +481,10 @@ void CServerDlg::OnRegisterServerStateChanged ( int value )
     UpdateGUIDependencies();
 }
 
-void CServerDlg::OnCentralServerAddressEditingFinished()
+void CServerDlg::OnDirectoryAddressEditingFinished()
 {
     // apply new setting to the server and update it
-    pServer->SetServerListCentralServerAddress ( edtCentralServerAddress->text() );
+    pServer->SetDirectoryAddress ( edtDirectoryAddress->text() );
 
     pServer->UpdateServerList();
 }
@@ -529,11 +529,11 @@ void CServerDlg::OnLocationCountryActivated ( int iCntryListItem )
     pServer->UpdateServerList();
 }
 
-void CServerDlg::OnCentServAddrTypeActivated ( int iTypeIdx )
+void CServerDlg::OnDirectoryTypeActivated ( int iTypeIdx )
 {
 
     // apply new setting to the server and update it
-    pServer->SetCentralServerAddressType ( static_cast<ECSAddType> ( iTypeIdx ) );
+    pServer->SetDirectoryType ( static_cast<EDirectoryType> ( iTypeIdx ) );
     pServer->UpdateServerList();
 
     // update GUI dependencies
@@ -669,13 +669,13 @@ void CServerDlg::OnTimer()
 void CServerDlg::UpdateGUIDependencies()
 {
     // get the states which define the GUI dependencies from the server
-    const bool          bCurSerListEnabled = pServer->GetServerListEnabled();
-    const ESvrRegStatus eSvrRegStatus      = pServer->GetSvrRegStatus();
+    const bool          bIsRegistered = pServer->GetServerRegistered();
+    const ESvrRegStatus eSvrRegStatus = pServer->GetSvrRegStatus();
 
     // if register server is not enabled, we disable all the configuration
     // controls for the server list
-    cbxCentServAddrType->setEnabled ( bCurSerListEnabled );
-    grbServerInfo->setEnabled ( bCurSerListEnabled );
+    cbxDirectoryType->setEnabled ( bIsRegistered );
+    grbServerInfo->setEnabled ( bIsRegistered );
 
     QString strStatus = svrRegStatusToString ( eSvrRegStatus );
 
@@ -683,7 +683,7 @@ void CServerDlg::UpdateGUIDependencies()
     {
     case SRS_BAD_ADDRESS:
     case SRS_TIME_OUT:
-    case SRS_CENTRAL_SVR_FULL:
+    case SRS_SERVER_LIST_FULL:
     case SRS_VERSION_TOO_OLD:
     case SRS_NOT_FULFILL_REQUIREMENTS:
         strStatus = "<font color=\"red\"><b>" + strStatus + "</b></font>";

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -469,10 +469,10 @@ void CServerDlg::OnRegisterServerStateChanged ( int value )
     // apply new setting to the server and update it
     pServer->SetServerRegistered ( bRegState );
 
-    // if registering is disabled, unregister slave server
+    // if registering is disabled, unregister server
     if ( !bRegState )
     {
-        pServer->UnregisterSlaveServer();
+        pServer->Unregister();
     }
 
     pServer->UpdateServerList();

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -98,11 +98,11 @@ public slots:
     void OnStartOnOSStartStateChanged ( int value );
     void OnEnableRecorderStateChanged ( int value ) { pServer->SetEnableRecording ( Qt::CheckState::Checked == value ); }
 
-    void OnCentralServerAddressEditingFinished();
+    void OnDirectoryAddressEditingFinished();
     void OnServerNameTextChanged ( const QString& strNewName );
     void OnLocationCityTextChanged ( const QString& strNewCity );
     void OnLocationCountryActivated ( int iCntryListItem );
-    void OnCentServAddrTypeActivated ( int iTypeIdx );
+    void OnDirectoryTypeActivated ( int iTypeIdx );
     void OnTimer();
     void OnServerStarted();
     void OnServerStopped();

--- a/src/serverdlgbase.ui
+++ b/src/serverdlgbase.ui
@@ -84,7 +84,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="cbxCentServAddrType"/>
+          <widget class="QComboBox" name="cbxDirectoryType"/>
          </item>
          <item>
           <widget class="QLabel" name="lblRegSvrStatus">
@@ -252,14 +252,14 @@
        <item>
         <layout class="QHBoxLayout">
          <item>
-          <widget class="QLabel" name="lblCentralServerAddress">
+          <widget class="QLabel" name="lblDirectoryAddress">
            <property name="text">
             <string>Custom Directory Server Address:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="edtCentralServerAddress"/>
+          <widget class="QLineEdit" name="edtDirectoryAddress"/>
          </item>
         </layout>
        </item>
@@ -314,7 +314,7 @@
   <tabstop>lvwClients</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>chbRegisterServer</tabstop>
-  <tabstop>cbxCentServAddrType</tabstop>
+  <tabstop>cbxDirectoryType</tabstop>
   <tabstop>edtServerName</tabstop>
   <tabstop>edtLocationCity</tabstop>
   <tabstop>cbxLocationCountry</tabstop>
@@ -326,7 +326,7 @@
   <tabstop>pbtRecordingDir</tabstop>
   <tabstop>edtRecordingDir</tabstop>
   <tabstop>tbtClearRecordingDir</tabstop>
-  <tabstop>edtCentralServerAddress</tabstop>
+  <tabstop>edtDirectoryAddress</tabstop>
   <tabstop>chbStartOnOSStart</tabstop>
  </tabstops>
  <resources>

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -146,7 +146,7 @@ public:
     void SetEnabled ( const bool bState ) { bEnabled = bState; }
     bool GetEnabled() const { return bEnabled; }
 
-    void SlaveServerUnregister() { SlaveServerRegisterServer ( false ); }
+    void Unregister() { SetRegistered ( false ); }
 
     // set server infos -> per definition the server info of this server is
     // stored in the first entry of the list, we assume here that the first
@@ -185,7 +185,7 @@ protected:
     int  IndexOf ( CHostAddress haSearchTerm );
     void Load ( const QString strServerList );
     void Save();
-    void SlaveServerRegisterServer ( const bool bIsRegister );
+    void SetRegistered ( const bool bIsRegister );
     void SetSvrRegStatus ( ESvrRegStatus eNSvrRegStatus );
 
     QMutex Mutex;
@@ -202,9 +202,9 @@ protected:
     // server registration status
     ESvrRegStatus eSvrRegStatus;
 
-    CHostAddress SlaveCurCentServerHostAddress;
-    CHostAddress SlaveCurLocalHostAddress;
-    CHostAddress SlaveCurLocalHostAddress6;
+    CHostAddress DirectoryAddress;
+    CHostAddress ServerPublicIP;
+    CHostAddress ServerPublicIP6;
 
     QString ServerListFileName;
 
@@ -226,7 +226,7 @@ public slots:
     void OnTimerPollList();
     void OnTimerPingServerInList();
     void OnTimerPingServers();
-    void OnTimerRefreshRegistration() { SlaveServerRegisterServer ( true ); }
+    void OnTimerRefreshRegistration() { SetRegistered ( true ); }
     void OnTimerCLRegisterServerResp();
 
     void OnTimerIsPermanent() { ServerList[0].bPermanentOnline = true; }

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -134,7 +134,7 @@ class CServerListManager : public QObject
 
 public:
     CServerListManager ( const quint16  iNPortNum,
-                         const QString& sNCentServAddr,
+                         const QString& sNDirectoryAddress,
                          const QString& strServerListFileName,
                          const QString& strServerInfo,
                          const QString& strServerListFilter,
@@ -160,13 +160,13 @@ public:
     void             SetServerCountry ( const QLocale::Country eNewCountry ) { ServerList[0].eCountry = eNewCountry; }
     QLocale::Country GetServerCountry() { return ServerList[0].eCountry; }
 
-    void    SetCentralServerAddress ( const QString sNCentServAddr );
-    QString GetCentralServerAddress() { return strCentralServerAddress; }
+    void    SetDirectoryAddress ( const QString sNDirectoryAddress );
+    QString GetDirectoryAddress() { return strDirectoryAddress; }
 
-    void       SetCentralServerAddressType ( const ECSAddType eNCSAT );
-    ECSAddType GetCentralServerAddressType() { return eCentralServerAddressType; }
+    void           SetDirectoryType ( const EDirectoryType eNCSAT );
+    EDirectoryType GetDirectoryType() { return eDirectoryType; }
 
-    bool GetIsCentralServer() const { return bIsCentralServer; }
+    bool IsDirectoryServer() const { return bIsDirectoryServer; }
 
     ESvrRegStatus GetSvrRegStatus() { return eSvrRegStatus; }
 
@@ -174,20 +174,17 @@ public:
     // properties was done
     void Update();
 
-    void CentralServerRegisterServer ( const CHostAddress&    InetAddr,
-                                       const CHostAddress&    LInetAddr,
-                                       const CServerCoreInfo& ServerInfo,
-                                       const QString          strVersion = "" );
-    void CentralServerUnregisterServer ( const CHostAddress& InetAddr );
-    void CentralServerQueryServerList ( const CHostAddress& InetAddr );
+    void Append ( const CHostAddress& InetAddr, const CHostAddress& LInetAddr, const CServerCoreInfo& ServerInfo, const QString strVersion = "" );
+    void Remove ( const CHostAddress& InetAddr );
+    void RetrieveAll ( const CHostAddress& InetAddr );
 
     void StoreRegistrationResult ( ESvrRegResult eStatus );
 
 protected:
-    void SetCentralServerState();
+    void SetIsDirectoryServer();
     int  IndexOf ( CHostAddress haSearchTerm );
-    void CentralServerLoadServerList ( const QString strServerList );
-    void CentralServerSaveServerList();
+    void Load ( const QString strServerList );
+    void Save();
     void SlaveServerRegisterServer ( const bool bIsRegister );
     void SetSvrRegStatus ( ESvrRegStatus eNSvrRegStatus );
 
@@ -197,10 +194,10 @@ protected:
 
     QList<CServerListEntry> ServerList;
 
-    QString    strCentralServerAddress;
-    ECSAddType eCentralServerAddressType;
-    bool       bIsCentralServer;
-    bool       bEnableIPv6;
+    QString        strDirectoryAddress;
+    EDirectoryType eDirectoryType;
+    bool           bIsDirectoryServer;
+    bool           bEnableIPv6;
 
     // server registration status
     ESvrRegStatus eSvrRegStatus;
@@ -221,19 +218,19 @@ protected:
 
     QTimer TimerPollList;
     QTimer TimerPingServerInList;
-    QTimer TimerPingCentralServer;
+    QTimer TimerPingServers;
     QTimer TimerRegistering;
     QTimer TimerCLRegisterServerResp;
 
 public slots:
     void OnTimerPollList();
     void OnTimerPingServerInList();
-    void OnTimerPingCentralServer();
-    void OnTimerRegistering() { SlaveServerRegisterServer ( true ); }
+    void OnTimerPingServers();
+    void OnTimerRefreshRegistration() { SlaveServerRegisterServer ( true ); }
     void OnTimerCLRegisterServerResp();
 
     void OnTimerIsPermanent() { ServerList[0].bPermanentOnline = true; }
-    void OnAboutToQuit() { CentralServerSaveServerList(); }
+    void OnAboutToQuit() { Save(); }
 
 signals:
     void SvrRegStatusChanged();

--- a/src/settings.h
+++ b/src/settings.h
@@ -124,8 +124,8 @@ public:
         bConnectDlgShowAllMusicians ( true ),
         eChannelSortType ( ST_NO_SORT ),
         iNumMixerPanelRows ( 1 ),
-        vstrCentralServerAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
-        eCentralServerAddressType ( AT_DEFAULT ),
+        vstrDirectoryAddress ( MAX_NUM_SERVER_ADDR_ITEMS, "" ),
+        eDirectoryType ( AT_DEFAULT ),
         bEnableFeedbackDetection ( true ),
         vecWindowPosSettings(), // empty array
         vecWindowPosChat(),     // empty array
@@ -155,9 +155,9 @@ public:
     bool             bConnectDlgShowAllMusicians;
     EChSortType      eChannelSortType;
     int              iNumMixerPanelRows;
-    CVector<QString> vstrCentralServerAddress;
-    ECSAddType       eCentralServerAddressType;
-    int              iCustomDirectoryIndex; // index of selected custom central server
+    CVector<QString> vstrDirectoryAddress;
+    EDirectoryType   eDirectoryType;
+    int              iCustomDirectoryIndex; // index of selected custom directory server
     bool             bEnableFeedbackDetection;
 
     // window position/state settings

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -829,12 +829,12 @@ CHostAddress NetworkUtil::GetLocalAddress6()
     }
 }
 
-QString NetworkUtil::GetCentralServerAddress ( const ECSAddType eCentralServerAddressType, const QString& strCentralServerAddress )
+QString NetworkUtil::GetDirectoryAddress ( const EDirectoryType eDirectoryType, const QString& strDirectoryAddress )
 {
-    switch ( eCentralServerAddressType )
+    switch ( eDirectoryType )
     {
     case AT_CUSTOM:
-        return strCentralServerAddress;
+        return strDirectoryAddress;
     case AT_ANY_GENRE2:
         return CENTSERV_ANY_GENRE2;
     case AT_ANY_GENRE3:

--- a/src/util.h
+++ b/src/util.h
@@ -540,7 +540,7 @@ enum EChSortType
 };
 
 // Directory server address type -----------------------------------------------
-enum ECSAddType
+enum EDirectoryType
 {
     // used for settings -> enum values should be fixed
     AT_DEFAULT              = 0,
@@ -553,7 +553,7 @@ enum ECSAddType
     AT_CUSTOM               = 7 // Must be the last entry!
 };
 
-inline QString csCentServAddrTypeToString ( ECSAddType eAddrType )
+inline QString DirectoryTypeToString ( EDirectoryType eAddrType )
 {
     switch ( eAddrType )
     {
@@ -592,7 +592,7 @@ enum ESvrRegStatus
     SRS_TIME_OUT,
     SRS_UNKNOWN_RESP,
     SRS_REGISTERED,
-    SRS_CENTRAL_SVR_FULL,
+    SRS_SERVER_LIST_FULL,
     SRS_VERSION_TOO_OLD,
     SRS_NOT_FULFILL_REQUIREMENTS
 };
@@ -619,7 +619,7 @@ inline QString svrRegStatusToString ( ESvrRegStatus eSvrRegStatus )
     case SRS_REGISTERED:
         return QCoreApplication::translate ( "CServerDlg", "Registered" );
 
-    case SRS_CENTRAL_SVR_FULL:
+    case SRS_SERVER_LIST_FULL:
         return QCoreApplication::translate ( "CServerDlg", "Directory Server full" );
 
     case SRS_VERSION_TOO_OLD:
@@ -637,7 +637,7 @@ enum ESvrRegResult
 {
     // used for protocol -> enum values must be fixed!
     SRR_REGISTERED              = 0,
-    SRR_CENTRAL_SVR_FULL        = 1,
+    SRR_SERVER_LIST_FULL        = 1,
     SRR_VERSION_TOO_OLD         = 2,
     SRR_NOT_FULFILL_REQIREMENTS = 3
 };
@@ -1004,7 +1004,7 @@ public:
     static QString      FixAddress ( const QString& strAddress );
     static CHostAddress GetLocalAddress();
     static CHostAddress GetLocalAddress6();
-    static QString      GetCentralServerAddress ( const ECSAddType eCentralServerAddressType, const QString& strCentralServerAddress );
+    static QString      GetDirectoryAddress ( const EDirectoryType eDirectoryType, const QString& strDirectoryAddress );
     static bool         IsPrivateNetworkIP ( const QHostAddress& qhAddr );
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -583,7 +583,7 @@ inline QString DirectoryTypeToString ( EDirectoryType eAddrType )
     }
 }
 
-// Slave server registration state ---------------------------------------------
+// Server registration state ---------------------------------------------
 enum ESvrRegStatus
 {
     SRS_UNREGISTERED,


### PR DESCRIPTION
**Short description of changes**

Nothing changes!  At least, nothing should _visibly_ change -- this is the follow-up to my UI changes from "Central Server" to "Directory Server/Server List" (still in flux).  I've also got rid of "slave server" references, replacing with "registered server".

**Context: Fixes an issue?**

Jamulus isn't centralised any more.

**Does this change need documentation? What needs to be documented and how?**

No documentation changes required.

It's probably worth highlighting that settings files *must be backed up* before upgrading Jamulus, because we don't have forwards compatibilty (i.e. we don't write the old versions as well as the new versions).

**Status of this Pull Request**

Ready to merge _after_ 3.8.1 release - ideally straight away so everything (else...) can break and have time to be fixed.

**What is missing until this pull request can be merged?**

Careful code review.  Ideally someone else to confirm it works for them.  Checking the settings code is particularly important.

Release 3.8.1 needs to go out.

## Checklist
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I've filled all the content above