### PR TITLE
Double-check feedback detection enable state

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1033,7 +1033,7 @@ void CClientDlg::OnTimerSigMet()
     lbrInputLevelL->SetValue ( pClient->GetLevelForMeterdBLeft() );
     lbrInputLevelR->SetValue ( pClient->GetLevelForMeterdBRight() );
 
-    if ( bDetectFeedback &&
+    if ( bDetectFeedback && pSettings->bEnableFeedbackDetection &&
          ( pClient->GetLevelForMeterdBLeft() > NUM_STEPS_LED_BAR - 0.5 || pClient->GetLevelForMeterdBRight() > NUM_STEPS_LED_BAR - 0.5 ) )
     {
         // mute locally and mute channel


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

This is a quick fix for issue #2066 and has been discussed there. It redundantly check whether the feedback detection is enabled in the UI. An assumption is that the timer for resetting the feedback detection 3 seconds after connecting does not work reliably on some operating systems.

<!-- A short description of your changes which might go into the change log -->

**Context: Fixes an issue?**

Fixes: #2066 

**Does this change need documentation? What needs to be documented and how?**

No documentation required.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Maybe the timer could be replaced by a comparison with the connection time plus the feedback protection time as suggested by @npostavs and @pljones.

<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
