### PR TITLE
Add missing initialisation of bDetectFeedback

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -39,6 +39,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     pSettings ( pNSetP ),
     bConnectDlgWasShown ( false ),
     bMIDICtrlUsed ( !strMIDISetup.isEmpty() ),
+    bDetectFeedback ( false ),
     bEnableIPv6 ( bNEnableIPv6 ),
     eLastRecorderState ( RS_UNDEFINED ), // for SetMixerBoardDeco
     eLastDesign ( GD_ORIGINAL ),         //          "


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

Due to missing initialisation, if feedback detection is _disabled_, then on the first connection after starting the program,
it is possible that all loud noises get detected as feedback. This PR fixes that by adding the initialisation.

<!-- A short description of your changes which might go into the change log -->

**Context: Fixes an issue?**

Fixes #2119

**Does this change need documentation? What needs to be documented and how?**

No, bug fix only.

**Status of this Pull Request**

Working

**What is missing until this pull request can be merged?**

Ready to merge.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
