### PR TITLE
Migrate from QRegExp to QRegularExpression for Qt6 compatibility

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -114,11 +114,11 @@ void CChatDlg::AddChatText ( QString strChatText )
     // analyze strChatText to check if hyperlink (limit ourselves to http(s)://) but do not
     // replace the hyperlinks if any HTML code for a hyperlink was found (the user has done the HTML
     // coding hisself and we should not mess with that)
-    if ( !strChatText.contains ( QRegExp ( "href\\s*=|src\\s*=" ) ) )
+    if ( !strChatText.contains ( QRegularExpression ( "href\\s*=|src\\s*=" ) ) )
     {
         // searches for all occurrences of http(s) and cuts until a space (\S matches any non-white-space
         // character and the + means that matches the previous element one or more times.)
-        strChatText.replace ( QRegExp ( "(https?://\\S+)" ), "<a href=\"\\1\">\\1</a>" );
+        strChatText.replace ( QRegularExpression ( "(https?://\\S+)" ), "<a href=\"\\1\">\\1</a>" );
     }
 
     // add new text in chat window

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -118,7 +118,14 @@ void CChatDlg::AddChatText ( QString strChatText )
     {
         // searches for all occurrences of http(s) and cuts until a space (\S matches any non-white-space
         // character and the + means that matches the previous element one or more times.)
-        // The (?<! sections exclude certain terminating characters from the match.
+        // This regex now contains three parts:
+        // - https?://\\S+ matches as much non-whitespace as possible after the http:// or https://,
+        //   subject to the next two parts, which exclude terminating punctuation
+        // - (?<![!\"'()+,.:;<=>?\\[\\]{}]) is a negative look-behind assertion that disallows the match
+        //   from ending with one of the characters !"'()+,.:;<=>?[]{}
+        // - (?<!\\?[!\"'()+,.:;<=>?\\[\\]{}]) is a negative look-behind assertion that disallows the match
+        //   from ending with a ? followed by one of the characters !"'()+,.:;<=>?[]{}
+        // These last two parts must be separate, as a look-behind assertion must be fixed length.
         strChatText.replace ( QRegularExpression ( "(https?://\\S+(?<![!\"'()+,.:;<=>?\\[\\]{}])(?<!\\?[!\"'()+,.:;<=>?\\[\\]{}]))" ),
                               "<a href=\"\\1\">\\1</a>" );
     }

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -118,7 +118,9 @@ void CChatDlg::AddChatText ( QString strChatText )
     {
         // searches for all occurrences of http(s) and cuts until a space (\S matches any non-white-space
         // character and the + means that matches the previous element one or more times.)
-        strChatText.replace ( QRegularExpression ( "(https?://\\S+)" ), "<a href=\"\\1\">\\1</a>" );
+        // The (?<! sections exclude certain terminating characters from the match.
+        strChatText.replace ( QRegularExpression ( "(https?://\\S+(?<![!\"'()+,.:;<=>?\\[\\]{}])(?<!\\?[!\"'()+,.:;<=>?\\[\\]{}]))" ),
+                              "<a href=\"\\1\">\\1</a>" );
     }
 
     // add new text in chat window

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -126,7 +126,8 @@ void CChatDlg::AddChatText ( QString strChatText )
         // - (?<!\\?[!\"'()+,.:;<=>?\\[\\]{}]) is a negative look-behind assertion that disallows the match
         //   from ending with a ? followed by one of the characters !"'()+,.:;<=>?[]{}
         // These last two parts must be separate, as a look-behind assertion must be fixed length.
-        strChatText.replace ( QRegularExpression ( "(https?://\\S+(?<![!\"'()+,.:;<=>?\\[\\]{}])(?<!\\?[!\"'()+,.:;<=>?\\[\\]{}]))" ),
+#define PUNCT_NOEND_URL "[!\"'()+,.:;<=>?\\[\\]{}]"
+        strChatText.replace ( QRegularExpression ( "(https?://\\S+(?<!" PUNCT_NOEND_URL ")(?<!\\?" PUNCT_NOEND_URL "))" ),
                               "<a href=\"\\1\">\\1</a>" );
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -704,25 +704,28 @@ bool NetworkUtil::ParseNetworkAddress ( QString strAddress, CHostAddress& HostAd
     // hostname:port
     // (where addr4or6 is a literal IPv4 or IPv6 address, and addr4 is a literal IPv4 address
 
-    bool    bLiteralAddr = false;
-    QRegExp rx1 ( "^\\[([^]]*)\\](?::(\\d+))?$" ); // [addr4or6] or [addr4or6]:port
-    QRegExp rx2 ( "^([^:]*)(?::(\\d+))?$" );       // addr4 or addr4:port or host or host:port
+    bool               bLiteralAddr = false;
+    QRegularExpression rx1 ( "^\\[([^]]*)\\](?::(\\d+))?$" ); // [addr4or6] or [addr4or6]:port
+    QRegularExpression rx2 ( "^([^:]*)(?::(\\d+))?$" );       // addr4 or addr4:port or host or host:port
 
     QString strPort;
 
+    QRegularExpressionMatch rx1match = rx1.match ( strAddress );
+    QRegularExpressionMatch rx2match = rx2.match ( strAddress );
+
     // parse input address with rx1 and rx2 in turn, capturing address/host and port
-    if ( rx1.indexIn ( strAddress ) == 0 )
+    if ( rx1match.capturedStart() == 0 )
     {
         // literal address within []
-        strAddress   = rx1.cap ( 1 );
-        strPort      = rx1.cap ( 2 );
+        strAddress   = rx1match.captured ( 1 );
+        strPort      = rx1match.captured ( 2 );
         bLiteralAddr = true; // don't allow hostname within []
     }
-    else if ( rx2.indexIn ( strAddress ) == 0 )
+    else if ( rx2match.capturedStart() == 0 )
     {
         // hostname or IPv4 address
-        strAddress = rx2.cap ( 1 );
-        strPort    = rx2.cap ( 2 );
+        strAddress = rx2match.captured ( 1 );
+        strPort    = rx2match.captured ( 2 );
     }
     else
     {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

Migrate QRegExp to QRegularExpression for compatibility with both Qt5 and Qt6

**Context: Fixes an issue?**

Prerequisite for supporting Qt6. The code for `src/util.cpp` was taken from the comment by @ngocdh at 
https://github.com/jamulussoftware/jamulus/pull/1999#issuecomment-925755890

Should ease further work towards Qt6, particularly the draft PR in #1999

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Tested on Qt5 to ensure backward compatibility. Not tested on Qt6, but should  be identical by design.

**What is missing until this pull request can be merged?**

Ready to merge.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
