### PR TITLE
Custom serverlist keyboard control

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -519,7 +519,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::AudioChannelsChanged, this, &CClientDlg::OnAudioChannelsChanged );
 
-    QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::DirectoryAddressChanged, &ConnectDlg, &CConnectDlg::OnCustomDirectoryAddressChanged );
+    QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::CustomDirectoriesChanged, &ConnectDlg, &CConnectDlg::OnCustomDirectoriesChanged );
 
     QObject::connect ( &ClientSettingsDlg, &CClientSettingsDlg::NumMixerPanelRowsChanged, this, &CClientDlg::OnNumMixerPanelRowsChanged );
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -353,13 +353,15 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxInputBoost->setAccessibleName ( tr ( "Input Boost combo box" ) );
 
     // custom directory server address
-    QString strCustomDirectoryAddress = "<b>" + tr ( "Custom Directory Server Address" ) + ":</b> " +
-                                        tr ( "Leave this blank unless you need to enter the address of a directory "
-                                             "server other than the default." );
+    QString strCustomDirectories = "<b>" + tr ( "Custom Directories" ) + ":</b> " +
+                                   tr ( "If you need to add additional directories to the Connect dialog Directory drop down, "
+                                        "you can enter the addresses here.<br>"
+                                        "To remove a value, select it, delete the text in the input box, "
+                                        "then move focus out of the control." );
 
-    lblDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
-    cbxDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
-    cbxDirectoryAddress->setAccessibleName ( tr ( "Directory server address combo box" ) );
+    lblCustomDirectories->setWhatsThis ( strCustomDirectories );
+    cbxCustomDirectories->setWhatsThis ( strCustomDirectories );
+    cbxCustomDirectories->setAccessibleName ( tr ( "Custom Directories combo box" ) );
 
     // current connection status parameter
     QString strConnStats = "<b>" + tr ( "Audio Upstream Rate" ) + ":</b> " +
@@ -445,8 +447,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxLanguage->Init ( pSettings->strLanguage );
 
     // init custom directory server address combo box (max MAX_NUM_SERVER_ADDR_ITEMS entries)
-    cbxDirectoryAddress->setMaxCount ( MAX_NUM_SERVER_ADDR_ITEMS );
-    cbxDirectoryAddress->setInsertPolicy ( QComboBox::NoInsert );
+    cbxCustomDirectories->setMaxCount ( MAX_NUM_SERVER_ADDR_ITEMS );
+    cbxCustomDirectories->setInsertPolicy ( QComboBox::NoInsert );
 
     // update new client fader level edit box
     edtNewClientLevel->setText ( QString::number ( pSettings->iNewClientFaderLevel ) );
@@ -667,12 +669,12 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                        this,
                        &CClientSettingsDlg::OnMeterStyleActivated );
 
-    QObject::connect ( cbxDirectoryAddress->lineEdit(), &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnDirectoryAddressEditingFinished );
+    QObject::connect ( cbxCustomDirectories->lineEdit(), &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnCustomDirectoriesEditingFinished );
 
-    QObject::connect ( cbxDirectoryAddress,
+    QObject::connect ( cbxCustomDirectories,
                        static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
                        this,
-                       &CClientSettingsDlg::OnDirectoryAddressEditingFinished );
+                       &CClientSettingsDlg::OnCustomDirectoriesEditingFinished );
 
     QObject::connect ( cbxLanguage, &CLanguageComboBox::LanguageChanged, this, &CClientSettingsDlg::OnLanguageChanged );
 
@@ -978,18 +980,17 @@ void CClientSettingsDlg::OnEnableOPUS64StateChanged ( int value )
 
 void CClientSettingsDlg::OnFeedbackDetectionChanged ( int value ) { pSettings->bEnableFeedbackDetection = value == Qt::Checked; }
 
-void CClientSettingsDlg::OnDirectoryAddressEditingFinished()
+void CClientSettingsDlg::OnCustomDirectoriesEditingFinished()
 {
-    if ( cbxDirectoryAddress->currentText().isEmpty() && cbxDirectoryAddress->currentData().isValid() )
+    if ( cbxCustomDirectories->currentText().isEmpty() && cbxCustomDirectories->currentData().isValid() )
     {
         // if the user has selected an entry in the combo box list and deleted the text in the input field,
         // and then focus moves off the control without selecting a new entry,
         // we delete the corresponding entry in the directory server address vector
-        pSettings->vstrDirectoryAddress[cbxDirectoryAddress->currentData().toInt()] = "";
+        pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()] = "";
     }
-    else if ( cbxDirectoryAddress->currentData().isValid() &&
-              pSettings->vstrDirectoryAddress[cbxDirectoryAddress->currentData().toInt()].compare (
-                  NetworkUtil::FixAddress ( cbxDirectoryAddress->currentText() ) ) == 0 )
+    else if ( cbxCustomDirectories->currentData().isValid() && pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()].compare (
+                                                                   NetworkUtil::FixAddress ( cbxCustomDirectories->currentText() ) ) == 0 )
     {
         // if the user has selected another entry in the combo box list without changing anything,
         // there is no need to update any list
@@ -999,12 +1000,12 @@ void CClientSettingsDlg::OnDirectoryAddressEditingFinished()
     {
         // store new address at the top of the list, if the list was already
         // full, the last element is thrown out
-        pSettings->vstrDirectoryAddress.StringFiFoWithCompare ( NetworkUtil::FixAddress ( cbxDirectoryAddress->currentText() ) );
+        pSettings->vstrDirectoryAddress.StringFiFoWithCompare ( NetworkUtil::FixAddress ( cbxCustomDirectories->currentText() ) );
     }
 
     // update combo box list and inform connect dialog about the new address
     UpdateDirectoryServerComboBox();
-    emit DirectoryAddressChanged();
+    emit CustomDirectoriesChanged();
 }
 
 void CClientSettingsDlg::OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button )
@@ -1050,15 +1051,15 @@ void CClientSettingsDlg::UpdateDisplay()
 
 void CClientSettingsDlg::UpdateDirectoryServerComboBox()
 {
-    cbxDirectoryAddress->clear();
-    cbxDirectoryAddress->clearEditText();
+    cbxCustomDirectories->clear();
+    cbxCustomDirectories->clearEditText();
 
     for ( int iLEIdx = 0; iLEIdx < MAX_NUM_SERVER_ADDR_ITEMS; iLEIdx++ )
     {
         if ( !pSettings->vstrDirectoryAddress[iLEIdx].isEmpty() )
         {
             // store the index as user data to the combo box item, too
-            cbxDirectoryAddress->addItem ( pSettings->vstrDirectoryAddress[iLEIdx], iLEIdx );
+            cbxCustomDirectories->addItem ( pSettings->vstrDirectoryAddress[iLEIdx], iLEIdx );
         }
     }
 }

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -980,11 +980,20 @@ void CClientSettingsDlg::OnFeedbackDetectionChanged ( int value ) { pSettings->b
 
 void CClientSettingsDlg::OnDirectoryAddressEditingFinished()
 {
-    // if the user has selected and deleted an entry in the combo box list,
-    // we delete the corresponding entry in the directory server address vector
     if ( cbxDirectoryAddress->currentText().isEmpty() && cbxDirectoryAddress->currentData().isValid() )
     {
+        // if the user has selected an entry in the combo box list and deleted the text in the input field,
+        // and then focus moves off the control without selecting a new entry,
+        // we delete the corresponding entry in the directory server address vector
         pSettings->vstrDirectoryAddress[cbxDirectoryAddress->currentData().toInt()] = "";
+    }
+    else if ( cbxDirectoryAddress->currentData().isValid() &&
+              pSettings->vstrDirectoryAddress[cbxDirectoryAddress->currentData().toInt()].compare (
+                  NetworkUtil::FixAddress ( cbxDirectoryAddress->currentText() ) ) == 0 )
+    {
+        // if the user has selected another entry in the combo box list without changing anything,
+        // there is no need to update any list
+        return;
     }
     else
     {

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -352,7 +352,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxInputBoost->setWhatsThis ( strInputBoost );
     cbxInputBoost->setAccessibleName ( tr ( "Input Boost combo box" ) );
 
-    // custom directory server address
+    // custom directories
     QString strCustomDirectories = "<b>" + tr ( "Custom Directories" ) + ":</b> " +
                                    tr ( "If you need to add additional directories to the Connect dialog Directory drop down, "
                                         "you can enter the addresses here.<br>"
@@ -446,7 +446,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     // language combo box (corrects the setting if language not found)
     cbxLanguage->Init ( pSettings->strLanguage );
 
-    // init custom directory server address combo box (max MAX_NUM_SERVER_ADDR_ITEMS entries)
+    // init custom directories combo box (max MAX_NUM_SERVER_ADDR_ITEMS entries)
     cbxCustomDirectories->setMaxCount ( MAX_NUM_SERVER_ADDR_ITEMS );
     cbxCustomDirectories->setInsertPolicy ( QComboBox::NoInsert );
 
@@ -986,7 +986,7 @@ void CClientSettingsDlg::OnCustomDirectoriesEditingFinished()
     {
         // if the user has selected an entry in the combo box list and deleted the text in the input field,
         // and then focus moves off the control without selecting a new entry,
-        // we delete the corresponding entry in the directory server address vector
+        // we delete the corresponding entry in the vector
         pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()] = "";
     }
     else if ( cbxCustomDirectories->currentData().isValid() && pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()].compare (

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -83,7 +83,7 @@ public slots:
     void OnAutoJitBufStateChanged ( int value );
     void OnEnableOPUS64StateChanged ( int value );
     void OnFeedbackDetectionChanged ( int value );
-    void OnDirectoryAddressEditingFinished();
+    void OnCustomDirectoriesEditingFinished();
     void OnNewClientLevelEditingFinished() { pSettings->iNewClientFaderLevel = edtNewClientLevel->text().toInt(); }
     void OnInputBoostChanged();
     void OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button );
@@ -111,6 +111,6 @@ signals:
     void GUIDesignChanged();
     void MeterStyleChanged();
     void AudioChannelsChanged();
-    void DirectoryAddressChanged();
+    void CustomDirectoriesChanged();
     void NumMixerPanelRowsChanged ( int value );
 };

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -967,14 +967,14 @@
               </spacer>
              </item>
              <item>
-              <widget class="QLabel" name="lblDirectoryAddress">
+              <widget class="QLabel" name="lblCustomDirectories">
                <property name="text">
                 <string>Custom Directories:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QComboBox" name="cbxDirectoryAddress">
+              <widget class="QComboBox" name="cbxCustomDirectories">
                <property name="editable">
                 <bool>true</bool>
                </property>
@@ -1298,7 +1298,7 @@
   <tabstop>sldNetBuf</tabstop>
   <tabstop>sldNetBufServer</tabstop>
   <tabstop>chbEnableOPUS64</tabstop>
-  <tabstop>cbxDirectoryAddress</tabstop>
+  <tabstop>cbxCustomDirectories</tabstop>
   <tabstop>edtNewClientLevel</tabstop>
   <tabstop>cbxInputBoost</tabstop>
   <tabstop>chbDetectFeedback</tabstop>

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -239,10 +239,10 @@ void CConnectDlg::RequestServerList()
 
     // Get the IP address of the directory server (using the ParseNetworAddress
     // function) when the connect dialog is opened, this seems to be the correct
-    // time to do it. Note that in case of custom directory server address we
+    // time to do it. Note that in case of custom directories we
     // use iCustomDirectoryIndex as an index into the vector.
 
-    // Allow IPv4 only for communicating with Directory Servers
+    // Allow IPv4 only for communicating with Directories
     if ( NetworkUtil().ParseNetworkAddress (
              NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
              haDirectoryAddress,
@@ -267,7 +267,7 @@ void CConnectDlg::hideEvent ( QHideEvent* )
 
 void CConnectDlg::OnDirectoryServerChanged ( int iTypeIdx )
 {
-    // store the new directory server address type and request new list
+    // store the new directory type and request new list
     // if iTypeIdx == AT_CUSTOM, then iCustomDirectoryIndex is the index into the vector holding the user's custom directory servers
     // if iTypeIdx != AT_CUSTOM, then iCustomDirectoryIndex MUST be 0;
     if ( iTypeIdx >= AT_CUSTOM )
@@ -950,7 +950,7 @@ void CConnectDlg::DeleteAllListViewItemChilds ( QTreeWidgetItem* pItem )
 
 void CConnectDlg::UpdateDirectoryServerComboBox()
 {
-    // directory server address type combo box
+    // directory type combo box
     cbxDirectoryServer->clear();
     cbxDirectoryServer->addItem ( DirectoryTypeToString ( AT_DEFAULT ) );
     cbxDirectoryServer->addItem ( DirectoryTypeToString ( AT_ANY_GENRE2 ) );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -551,7 +551,7 @@ void CConnectDlg::OnServerAddrEditTextChanged ( const QString& )
     lvwServers->clearSelection();
 }
 
-void CConnectDlg::OnCustomDirectoryAddressChanged()
+void CConnectDlg::OnCustomDirectoriesChanged()
 {
 
     QString strPreviousSelection = cbxDirectoryServer->currentText();

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -98,7 +98,7 @@ public slots:
     void OnDirectoryServerChanged ( int iTypeIdx );
     void OnFilterTextEdited ( const QString& ) { UpdateListFilter(); }
     void OnExpandAllStateChanged ( int value ) { ShowAllMusicians ( value == Qt::Checked ); }
-    void OnCustomDirectoryAddressChanged();
+    void OnCustomDirectoriesChanged();
     void OnConnectClicked();
     void OnTimerPing();
     void OnTimerReRequestServList();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -456,8 +456,7 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
 
     // clang-format off
 // TODO compatibility to old version (< 3.6.1)
-// NOTE that the strCurAddr and "check for empty" can be removed if compatibility mode is removed
-vstrDirectoryAddress[0] = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
+QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
     // clang-format on
 
     // directory server addresses
@@ -465,14 +464,10 @@ vstrDirectoryAddress[0] = GetIniSetting ( IniXMLDocument, "client", "centralserv
     {
         // clang-format off
 // TODO compatibility to old version (< 3.8.2)
-QString strCurAddr = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), "" );
+strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
         // clang-format on
-        strCurAddr = GetIniSetting ( IniXMLDocument, "client", QString ( "directoryaddress%1" ).arg ( iIdx ), strCurAddr );
-
-        if ( !strCurAddr.isEmpty() )
-        {
-            vstrDirectoryAddress[iIdx] = strCurAddr;
-        }
+        vstrDirectoryAddress[iIdx] = GetIniSetting ( IniXMLDocument, "client", QString ( "directoryaddress%1" ).arg ( iIdx ), strDirectoryAddress );
+        strDirectoryAddress        = "";
     }
 
     // directory server address type
@@ -483,13 +478,11 @@ if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "clie
 {
     eDirectoryType = AT_CUSTOM;
 }
-    // clang-format on
-    // clang-format off
 // TODO compatibility to old version (< 3.8.2)
-    else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
-    {
-        eDirectoryType = static_cast<EDirectoryType> ( iValue );
-    }
+else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
+{
+    eDirectoryType = static_cast<EDirectoryType> ( iValue );
+}
     // clang-format on
     else if ( GetNumericIniSet ( IniXMLDocument, "client", "directorytype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
     {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -454,12 +454,11 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         pClient->SetAudioQuality ( static_cast<EAudioQuality> ( iValue ) );
     }
 
+    // custom directories
     // clang-format off
 // TODO compatibility to old version (< 3.6.1)
 QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
     // clang-format on
-
-    // directory server addresses
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
         // clang-format off
@@ -470,7 +469,7 @@ strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centr
         strDirectoryAddress        = "";
     }
 
-    // directory server address type
+    // directory type
     // clang-format off
 // TODO compatibility to old version (<3.4.7)
 // only the case that "centralservaddr" was set in old ini must be considered
@@ -494,7 +493,7 @@ else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, st
         eDirectoryType = AT_DEFAULT;
     }
 
-    // custom directory server index
+    // custom directory index
     if ( ( eDirectoryType == AT_CUSTOM ) &&
          GetNumericIniSet ( IniXMLDocument, "client", "customdirectoryindex", 0, MAX_NUM_SERVER_ADDR_ITEMS, iValue ) )
     {
@@ -695,16 +694,16 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // audio quality
     SetNumericIniSet ( IniXMLDocument, "client", "audioquality", static_cast<int> ( pClient->GetAudioQuality() ) );
 
-    // directory server addresses
+    // custom directories
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
         PutIniSetting ( IniXMLDocument, "client", QString ( "directoryaddress%1" ).arg ( iIdx ), vstrDirectoryAddress[iIdx] );
     }
 
-    // directory server address type
+    // directory type
     SetNumericIniSet ( IniXMLDocument, "client", "directorytype", static_cast<int> ( eDirectoryType ) );
 
-    // custom directory server index
+    // custom directory index
     SetNumericIniSet ( IniXMLDocument, "client", "customdirectoryindex", iCustomDirectoryIndex );
 
     // window position of the main window
@@ -884,7 +883,7 @@ void CServerSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument )
     // directory server address
     PutIniSetting ( IniXMLDocument, "server", "directoryaddress", pServer->GetDirectoryAddress() );
 
-    // directory server address type
+    // directory type
     SetNumericIniSet ( IniXMLDocument, "server", "directorytype", static_cast<int> ( pServer->GetDirectoryType() ) );
 
     // server list enabled flag

--- a/src/util.h
+++ b/src/util.h
@@ -540,7 +540,7 @@ enum EChSortType
     ST_BY_CITY       = 4
 };
 
-// Directory server address type -----------------------------------------------
+// Directory type --------------------------------------------------------------
 enum EDirectoryType
 {
     // used for settings -> enum values should be fixed


### PR DESCRIPTION
**Short description of changes**

Enable cursor key access to the server list in settings.

Also includes more of the "Central" to "Directory" changes, relevant to this area.

**Context: Fixes an issue?**

Currently, selecting the second entry in the list triggers a signal that makes the list get sorted, making the second entry first and the first entry second.  The selection moves and is now first, also.  This prevents selection of the third entry using the keyboard.

**Does this change need documentation? What needs to be documented and how?**

Updated translation strings.

**Status of this Pull Request**

Works for me (I've been running this version for quite a while).

**What is missing until this pull request can be merged?**

Nothing I'm aware of, although a review of my help text is always worth it.

## Checklist
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I've filled all the content above
