### PR TITLE
Use dch instead of hack to generate changelog

### DIFF
--- a/.github/actions_scripts/getChangelog.pl
+++ b/.github/actions_scripts/getChangelog.pl
@@ -2,12 +2,12 @@
 
 use strict;
 use warnings;
-# get the file path
-my $ChangeLogFile = $ARGV[0];
-# get the version
-my $Version = $ARGV[1];
+# get arguments
+my ($ChangeLogFile, $Version, $FormatOption) = @ARGV;
 # open the file
 open my $fh, '<', $ChangeLogFile or die;
+
+my $SingleLineEntries = ($FormatOption or '') eq '--line-per-entry';
 
 my $logversion = "";
 my $entry;
@@ -18,13 +18,17 @@ while (my $line = <$fh>) {
        next;
    }
    if ($logversion eq $Version) {
-       if ($line =~ /^- (.*)$/) { # beginning of entry
-           $entry = $1;
-       } elsif ($line =~ /^ ( \S.*)$/) { # continuation of entry
-           $entry .= $1;
-       } else { # otherwise, separator between entries
-           print "${entry}\n" if $entry;
-           $entry = undef;
+       if ($SingleLineEntries) {
+           if ($line =~ /^- (.*)$/) { # beginning of entry
+               $entry = $1;
+           } elsif ($line =~ /^ ( \S.*)$/) { # continuation of entry
+               $entry .= $1;
+           } else { # otherwise, separator between entries
+               print "${entry}\n" if $entry;
+               $entry = undef;
+           }
+       } else {
+           print $line;
        }
    }
 }

--- a/.github/actions_scripts/getChangelog.pl
+++ b/.github/actions_scripts/getChangelog.pl
@@ -11,13 +11,20 @@ my $SingleLineEntries = ($FormatOption or '') eq '--line-per-entry';
 
 my $logversion = "";
 my $entry;
+my $matchedLogversion = 0;
 while (my $line = <$fh>) {
    if ($line =~ /^### (\S+)[^#]*###$/m) {
        # The version for this section of the ChangeLog
+       if ($matchedLogversion) {
+           # We've processed the lines corresponding to $Version, and
+           # we're now on the next section.  There's no more to do.
+           last;
+       }
        $logversion = $1;
        next;
    }
    if ($logversion eq $Version) {
+       $matchedLogversion = 1;
        if ($SingleLineEntries) {
            if ($line =~ /^- (.*)$/) { # beginning of entry
                $entry = $1;
@@ -32,4 +39,9 @@ while (my $line = <$fh>) {
        }
    }
 }
+
 close $fh;
+
+if (!$matchedLogversion) {
+    die "Failed to find entry for version '${Version}'";
+}

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -8,9 +8,12 @@ cd ..
 # get the jamulus version from pro file
 VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
 
+export DEBFULLNAME=GitHubActions DEBEMAIL=noemail@example.com
+
 # Generate Changelog
 echo -n generating changelog
-dch --newversion "${VERSION}" ''
+rm -f debian/changelog
+dch --create --package jamulus --empty --newversion "${VERSION}" ''
 perl .github/actions_scripts/getChangelog.pl ChangeLog "${VERSION}" | while read entry
 do
     echo -n .

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -14,7 +14,7 @@ export DEBFULLNAME=GitHubActions DEBEMAIL=noemail@example.com
 echo -n generating changelog
 rm -f debian/changelog
 dch --create --package jamulus --empty --newversion "${VERSION}" ''
-perl .github/actions_scripts/getChangelog.pl ChangeLog "${VERSION}" | while read entry
+perl .github/actions_scripts/getChangelog.pl ChangeLog "${VERSION}" --line-per-entry | while read entry
 do
     echo -n .
     dch "$entry"

--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -2,30 +2,21 @@
 
 # Create deb files
 
-# set armhf
-#sudo dpkg --add-architecture armhf
-
 cp -r debian ..
 cd ..
 
 # get the jamulus version from pro file
 VERSION=$(cat Jamulus.pro | grep -oP 'VERSION = \K\w[^\s\\]*')
 
-# patch changelog (with hack)
-
-DATE=$(date "+%a, %d %b %Y %T" )
-echo "jamulus (${VERSION}-0) UNRELEASED; urgency=medium" > debian/changelog
-echo "" >> debian/changelog
-perl .github/actions_scripts/getChangelog.pl ChangeLog ${VERSION} >> debian/changelog
-echo "" >> debian/changelog
-echo " -- GitHubActions <noemail@example.com> ${DATE} +0001" >> debian/changelog
-echo "" >> debian/changelog
-cat distributions/debian/changelog >> debian/changelog
-
-# patch the control file
-# cp the modified control file here
-
-cp distributions/autobuilddeb/control debian/control
+# Generate Changelog
+echo -n generating changelog
+dch --newversion "${VERSION}" ''
+perl .github/actions_scripts/getChangelog.pl ChangeLog "${VERSION}" | while read entry
+do
+    echo -n .
+    dch "$entry"
+done
+echo
 
 echo "${VERSION} building..."
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

Use dch to generate Debian changelog instead of handrolled shell calls

**Context: Fixes an issue?**

This is an alternate version of #1767

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

Working implementation, a sample output is [changelog.dch.log](https://github.com/jamulussoftware/jamulus/files/7620907/changelog.dch.log). (updated with Nov 29th changes)

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
~~Possibly the "initial release" line needs to be removed somehow.~~

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [X] I tested my code and it does what I want
- [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [X] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [X] I've filled all the content above
