### PR TITLE
Fix typo: "Protcol" for "Protocol"

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -513,7 +513,7 @@ void CChannel::Disconnect()
     }
 }
 
-void CChannel::PutProtcolData ( const int iRecCounter, const int iRecID, const CVector<uint8_t>& vecbyMesBodyData, const CHostAddress& RecHostAddr )
+void CChannel::PutProtocolData ( const int iRecCounter, const int iRecID, const CVector<uint8_t>& vecbyMesBodyData, const CHostAddress& RecHostAddr )
 {
     // Only process protocol message if:
     // - for client only: the packet comes from the server we want to talk to

--- a/src/channel.h
+++ b/src/channel.h
@@ -68,7 +68,7 @@ public:
     // use constructor initialization in the server for a vector of channels
     CChannel ( const bool bNIsServer = true );
 
-    void PutProtcolData ( const int iRecCounter, const int iRecID, const CVector<uint8_t>& vecbyMesBodyData, const CHostAddress& RecHostAddr );
+    void PutProtocolData ( const int iRecCounter, const int iRecID, const CVector<uint8_t>& vecbyMesBodyData, const CHostAddress& RecHostAddr );
 
     EPutDataStat PutAudioData ( const CVector<uint8_t>& vecbyData, const int iNumBytes, CHostAddress RecHostAddr );
 
@@ -250,12 +250,12 @@ public slots:
         Protocol.ParseMessageBody ( vecbyMesBodyData, iRecCounter, iRecID );
     }
 
-    void OnProtcolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
+    void OnProtocolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
     {
-        PutProtcolData ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
+        PutProtocolData ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
     }
 
-    void OnProtcolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
+    void OnProtocolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
     {
         emit DetectedCLMessage ( vecbyMesBodyData, iRecID, RecHostAddr );
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1609,7 +1609,7 @@ void CServer::DumpChannels ( const QString& title )
     }
 }
 
-void CServer::OnProtcolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
+void CServer::OnProtocolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
 {
     QMutexLocker locker ( &Mutex );
 
@@ -1617,7 +1617,7 @@ void CServer::OnProtcolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMes
     ConnLessProtocol.ParseConnectionLessMessageBody ( vecbyMesBodyData, iRecID, RecHostAddr );
 }
 
-void CServer::OnProtcolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
+void CServer::OnProtocolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr )
 {
     QMutexLocker locker ( &Mutex );
 
@@ -1627,7 +1627,7 @@ void CServer::OnProtcolMessageReceived ( int iRecCounter, int iRecID, CVector<ui
     // if the channel exists, apply the protocol message to the channel
     if ( iCurChanID != INVALID_CHANNEL_ID )
     {
-        vecChannels[iCurChanID].PutProtcolData ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
+        vecChannels[iCurChanID].PutProtocolData ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -420,9 +420,9 @@ public slots:
 
     void OnSendCLProtMessage ( CHostAddress InetAddr, CVector<uint8_t> vecMessage );
 
-    void OnProtcolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr );
+    void OnProtocolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr );
 
-    void OnProtcolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr );
+    void OnProtocolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress RecHostAddr );
 
     void OnCLPingReceived ( CHostAddress InetAddr, int iMs ) { ConnLessProtocol.CreateCLPingMes ( InetAddr, iMs ); }
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -49,9 +49,9 @@ CSocket::CSocket ( CChannel* pNewChannel, const quint16 iPortNumber, const quint
     Init ( iPortNumber, iQosNumber, strServerBindIP );
 
     // client connections:
-    QObject::connect ( this, &CSocket::ProtcolMessageReceived, pChannel, &CChannel::OnProtcolMessageReceived );
+    QObject::connect ( this, &CSocket::ProtocolMessageReceived, pChannel, &CChannel::OnProtocolMessageReceived );
 
-    QObject::connect ( this, &CSocket::ProtcolCLMessageReceived, pChannel, &CChannel::OnProtcolCLMessageReceived );
+    QObject::connect ( this, &CSocket::ProtocolCLMessageReceived, pChannel, &CChannel::OnProtocolCLMessageReceived );
 
     QObject::connect ( this, static_cast<void ( CSocket::* )()> ( &CSocket::NewConnection ), pChannel, &CChannel::OnNewConnection );
 }
@@ -65,9 +65,9 @@ CSocket::CSocket ( CServer* pNServP, const quint16 iPortNumber, const quint16 iQ
     Init ( iPortNumber, iQosNumber, strServerBindIP );
 
     // server connections:
-    QObject::connect ( this, &CSocket::ProtcolMessageReceived, pServer, &CServer::OnProtcolMessageReceived );
+    QObject::connect ( this, &CSocket::ProtocolMessageReceived, pServer, &CServer::OnProtocolMessageReceived );
 
-    QObject::connect ( this, &CSocket::ProtcolCLMessageReceived, pServer, &CServer::OnProtcolCLMessageReceived );
+    QObject::connect ( this, &CSocket::ProtocolCLMessageReceived, pServer, &CServer::OnProtocolCLMessageReceived );
 
     QObject::connect ( this,
                        static_cast<void ( CSocket::* ) ( int, int, CHostAddress )> ( &CSocket::NewConnection ),
@@ -416,7 +416,7 @@ void CSocket::OnDataReceived()
 // TODO a copy of the vector is used -> avoid malloc in real-time routine
             // clang-format on
 
-            emit ProtcolCLMessageReceived ( iRecID, vecbyMesBodyData, RecHostAddr );
+            emit ProtocolCLMessageReceived ( iRecID, vecbyMesBodyData, RecHostAddr );
         }
         else
         {
@@ -425,7 +425,7 @@ void CSocket::OnDataReceived()
 // TODO a copy of the vector is used -> avoid malloc in real-time routine
             // clang-format on
 
-            emit ProtcolMessageReceived ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
+            emit ProtocolMessageReceived ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
         }
     }
     else

--- a/src/socket.h
+++ b/src/socket.h
@@ -104,9 +104,9 @@ signals:
 
     void InvalidPacketReceived ( CHostAddress RecHostAddr );
 
-    void ProtcolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress HostAdr );
+    void ProtocolMessageReceived ( int iRecCounter, int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress HostAdr );
 
-    void ProtcolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress HostAdr );
+    void ProtocolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress HostAdr );
 };
 
 /* Socket which runs in a separate high priority thread --------------------- */


### PR DESCRIPTION
"Protocol" is misspelled as "Protcol" in a few method names - it's correct in most places. This is a straightforward `s/Protcol/Protocol/g` across the code.

**Does this change need documentation? What needs to be documented and how?**

No changes to behaviour.

**Status of this Pull Request**

Working implementation.

**What is missing until this pull request can be merged?**

Nothing.

## Checklist
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) - I've run it through `clang-format`
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I've filled all the content above
