### PR TITLE
Keep the list of free channels in sorted order

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1502,7 +1502,7 @@ int CServer::FindChannel ( const CHostAddress& CheckAddr, const bool bAllowNew )
             return vecChannelOrder[t];
         }
 
-        if ( cmp < 0 )
+        if ( cmp > 0 )
         {
             l = t + 1;
         }
@@ -1574,13 +1574,14 @@ void CServer::FreeChannel ( const int iCurChanID )
         {
             --iCurNumChannels;
 
-            // move channel IDs down by one starting at the bottom and working up
-            while ( i < iCurNumChannels )
+            // move channel IDs down by one starting at the freed channel and working up the active channels
+            // and then the free channels until its position in the free list is reached
+            while ( i < iCurNumChannels || ( i + 1 < iMaxNumChannels && vecChannelOrder[i + 1] < iCurChanID ) )
             {
                 int j              = i++;
                 vecChannelOrder[j] = vecChannelOrder[i];
             }
-            // put deleted channel at the end ready for re-use
+            // put deleted channel in the vacated position ready for re-use
             vecChannelOrder[i] = iCurChanID;
 
             // DumpChannels ( __FUNCTION__ );


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

Maintain the list of free channel IDs in sorted order, so that the lowest available channel ID will be used for a new client.

The fix has two parts, the first of which is not really necessary, but makes the output of `DumpChannels()` nicer:

* Reverse the polarity of the comparison in the binary search, so that the list of active channel IDs has the lowest ID first (this should have been done originally).
* When moving the channel IDs downwards in the list while freeing a channel, instead of stopping at the end of the active channels, keep going until the correct ordered place is found to insert the freed channel ID.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2144 

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No documentation - internal enhancement only.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Tested and ready to merge.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Nothing

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
