### PR TITLE
Don't imply that multiple drivers have errors

### DIFF
--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -174,7 +174,7 @@ QString CSoundBase::SetDev ( const QString strDevName )
                 sErrorMessage += "<b>" + GetDeviceName ( i ) + "</b>: " + vsErrorList[i] + "<br><br>";
             }
 
-#ifdef _WIN32
+#if defined( _WIN32 ) && !defined( WITH_JACK )
             // to be able to access the ASIO driver setup for changing, e.g., the sample rate, we
             // offer the user under Windows that we open the driver setups of all registered
             // ASIO drivers

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -167,23 +167,32 @@ QString CSoundBase::SetDev ( const QString strDevName )
         if ( !vsErrorList.isEmpty() )
         {
             // create error message with all details
-            QString sErrorMessage = "<b>" + QString ( tr ( "No usable %1 audio device found." ) ).arg ( strSystemDriverTechniqueName ) +
-                                    "</b><br><br>" + tr ( "These are all the available drivers with error messages:" ) + "<ul>";
+            QString sErrorMessage = tr ( "<b>No usable %1 audio device found.</b><br><br>" ).arg ( strSystemDriverTechniqueName );
 
             for ( int i = 0; i < lNumDevs; i++ )
             {
-                sErrorMessage += "<li><b>" + GetDeviceName ( i ) + "</b>: " + vsErrorList[i] + "</li>";
+                sErrorMessage += "<b>" + GetDeviceName ( i ) + "</b>: " + vsErrorList[i] + "<br><br>";
             }
-            sErrorMessage += "</ul>";
 
 #ifdef _WIN32
             // to be able to access the ASIO driver setup for changing, e.g., the sample rate, we
             // offer the user under Windows that we open the driver setups of all registered
             // ASIO drivers
-            sErrorMessage += "<br/>" + tr ( "Do you want to open the ASIO driver setup to try changing your configuration to a working state?" );
+            sErrorMessage += "<br>" + tr ( "You may be able to fix errors in the driver settings." );
 
-            if ( QMessageBox::Yes == QMessageBox::information ( nullptr, APP_NAME, sErrorMessage, QMessageBox::Yes | QMessageBox::No ) )
+            // for Windows use a QMessageBox to show the error
+            QMessageBox  qmASIOWarningBox;
+            QPushButton* btnASIOSettings = qmASIOWarningBox.addButton ( tr ( "Open ASIO settings" ), QMessageBox::AcceptRole );
+
+            qmASIOWarningBox.addButton ( QMessageBox::Cancel );
+            qmASIOWarningBox.setText ( sErrorMessage );
+            qmASIOWarningBox.setIcon ( QMessageBox::Warning );
+            qmASIOWarningBox.exec();
+
+            if ( qmASIOWarningBox.clickedButton() == btnASIOSettings )
             {
+                // TODO: This or some related code aborts the app even if the driver is valid after user changes.
+                // This should be handled differently. For reference, please see https://github.com/jamulussoftware/jamulus/pull/2168
                 LoadAndInitializeFirstValidDriver ( true );
             }
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**

If there's only one driver with an error message, there's no need to imply that multiple devices have errors. This change is done to simplify the error message.

The following is not exactly what my (fixed) code looks like.
![error message](https://user-images.githubusercontent.com/20726856/146690983-e5308297-ace6-4c92-81ca-bcb0f61bf999.png)

**Context: Fixes an issue?**

Idea from https://github.com/jamulussoftware/jamulus/discussions/2163#discussioncomment-1788094
**Does this change need documentation? What needs to be documented and how?**
No

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
Draft. It remains to test what happens if lNumDevs > 1.
**What is missing until this pull request can be merged?**
Untested since it's just a quick fix. Will test it by checking the artifacts.
## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
