### PR TITLE
Use the default server name in the mixer

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -716,13 +716,13 @@ void CClientDlg::OnConnectDlgAccepted()
             strMixerBoardLabel = strSelectedAddress;
 
             // special case: if the address is empty, we substitute the default
-            // directory server address so that a user which just pressed the connect
+            // directory address so that a user who just pressed the connect
             // button without selecting an item in the table or manually entered an
             // address gets a successful connection
             if ( strSelectedAddress.isEmpty() )
             {
                 strSelectedAddress = DEFAULT_SERVER_ADDRESS;
-                strMixerBoardLabel = tr ( "Directory Server" );
+                strMixerBoardLabel = tr ( "%1 Directory" ).arg ( DirectoryTypeToString ( AT_DEFAULT ) );
             }
         }
 


### PR DESCRIPTION
**Short description of changes**

Edge-case for user using no server details and clicking "connect" from the connect window.  They could be looking at _any_ of the directories when they hit connect.  For example:
![image](https://user-images.githubusercontent.com/1549463/146251553-e803f914-4b49-4ffe-a5a7-92e14fe7b2f7.png)

Hitting "Connect" used to title the mixer "Directory Server" (or translation).  Now it titles it with the default directory name as more of a clue:
![image](https://user-images.githubusercontent.com/1549463/146251631-16be8c1c-3af2-45de-a164-7241b5916cf3.png)

**Does this change need documentation? What needs to be documented and how?**

No.

**Translations** needed.

**Status of this Pull Request**

Working as expected.


**What is missing until this pull request can be merged?**

Should just work (except for translations changing).

## Checklist
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
