### PR TITLE
Reorder of serverdlg bits

### DIFF
--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -62,9 +62,9 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                            "to make sure that all servers in the connect dialog server list are "
                                            "actually available." ) );
 
-    // register server status label
+    // server registration status label
     lblRegSvrStatus->setWhatsThis ( "<b>" + tr ( "Register Server Status" ) + ":</b> " +
-                                    tr ( "If the Make My Server Public check box is checked, this will show "
+                                    tr ( "If the Register Server check box is checked, this will show "
                                          "whether registration with the directory server is successful. If the "
                                          "registration failed, please choose another server list." ) );
 

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -379,37 +379,36 @@ lvwClients->setMinimumHeight ( 140 );
     // check boxes
     QObject::connect ( chbRegisterServer, &QCheckBox::stateChanged, this, &CServerDlg::OnRegisterServerStateChanged );
 
-    QObject::connect ( chbStartOnOSStart, &QCheckBox::stateChanged, this, &CServerDlg::OnStartOnOSStartStateChanged );
-
     QObject::connect ( chbEnableRecorder, &QCheckBox::stateChanged, this, &CServerDlg::OnEnableRecorderStateChanged );
 
-    // delay panning
+    QObject::connect ( chbStartOnOSStart, &QCheckBox::stateChanged, this, &CServerDlg::OnStartOnOSStartStateChanged );
+
     QObject::connect ( chbEnableDelayPanning, &QCheckBox::stateChanged, this, &CServerDlg::OnEnableDelayPanningStateChanged );
 
     // line edits
-    QObject::connect ( edtCustomDirectory, &QLineEdit::editingFinished, this, &CServerDlg::OnCustomDirectoryEditingFinished );
-
     QObject::connect ( edtServerName, &QLineEdit::textChanged, this, &CServerDlg::OnServerNameTextChanged );
 
     QObject::connect ( edtLocationCity, &QLineEdit::textChanged, this, &CServerDlg::OnLocationCityTextChanged );
 
-    // combo boxes
-    QObject::connect ( cbxLocationCountry,
-                       static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
-                       this,
-                       &CServerDlg::OnLocationCountryActivated );
+    QObject::connect ( edtCustomDirectory, &QLineEdit::editingFinished, this, &CServerDlg::OnCustomDirectoryEditingFinished );
 
+    // combo boxes
     QObject::connect ( cbxDirectoryType,
                        static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
                        this,
                        &CServerDlg::OnDirectoryTypeActivated );
 
+    QObject::connect ( cbxLocationCountry,
+                       static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
+                       this,
+                       &CServerDlg::OnLocationCountryActivated );
+
     QObject::connect ( cbxLanguage, &CLanguageComboBox::LanguageChanged, this, &CServerDlg::OnLanguageChanged );
 
     // push buttons
-    QObject::connect ( pbtRecordingDir, &QPushButton::released, this, &CServerDlg::OnRecordingDirClicked );
-
     QObject::connect ( pbtNewRecording, &QPushButton::released, this, &CServerDlg::OnNewRecordingClicked );
+
+    QObject::connect ( pbtRecordingDir, &QPushButton::released, this, &CServerDlg::OnRecordingDirClicked );
 
     // tool buttons
     QObject::connect ( tbtClearRecordingDir, &QToolButton::released, this, &CServerDlg::OnClearRecordingDirClicked );

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -297,6 +297,23 @@ lvwClients->setMinimumHeight ( 140 );
         chbRegisterServer->setCheckState ( Qt::Unchecked );
     }
 
+    // Recorder controls
+    chbEnableRecorder->setChecked ( pServer->GetRecordingEnabled() );
+    edtCurrentSessionDir->setText ( "" );
+    pbtNewRecording->setAutoDefault ( false );
+
+    // setup welcome message GUI control
+    tedWelcomeMessage->setPlaceholderText ( tr ( "Type a message here. If no message is set, the server welcome is disabled." ) );
+    tedWelcomeMessage->setText ( pServer->GetWelcomeMessage() );
+
+    // language combo box (corrects the setting if language not found)
+    cbxLanguage->Init ( pSettings->strLanguage );
+
+    // recorder options
+    pbtRecordingDir->setAutoDefault ( false );
+    edtRecordingDir->setText ( pServer->GetRecordingDir() );
+    tbtClearRecordingDir->setText ( u8"\u232B" );
+
     // update start minimized check box (only available for Windows)
 #ifndef _WIN32
     chbStartOnOSStart->setVisible ( false );
@@ -327,24 +344,6 @@ lvwClients->setMinimumHeight ( 140 );
         chbEnableDelayPanning->setCheckState ( Qt::Unchecked );
     }
 
-    // Recorder controls
-    chbEnableRecorder->setChecked ( pServer->GetRecordingEnabled() );
-    edtCurrentSessionDir->setText ( "" );
-    pbtNewRecording->setAutoDefault ( false );
-    pbtRecordingDir->setAutoDefault ( false );
-    edtRecordingDir->setText ( pServer->GetRecordingDir() );
-    tbtClearRecordingDir->setText ( u8"\u232B" );
-
-    UpdateRecorderStatus ( QString::null );
-
-    // language combo box (corrects the setting if language not found)
-    cbxLanguage->Init ( pSettings->strLanguage );
-
-    // setup welcome message GUI control
-    tedWelcomeMessage->setPlaceholderText ( tr ( "Type a message here. If no message is set, the server welcome is disabled." ) );
-
-    tedWelcomeMessage->setText ( pServer->GetWelcomeMessage() );
-
     // prepare update check info label (invisible by default)
     lblUpdateCheck->setOpenExternalLinks ( true ); // enables opening a web browser if one clicks on a html link
     lblUpdateCheck->setText ( "<font color=\"red\"><b>" + APP_UPGRADE_AVAILABLE_MSG_TEXT.arg ( APP_NAME ).arg ( VERSION ) + "</b></font>" );
@@ -352,6 +351,8 @@ lvwClients->setMinimumHeight ( 140 );
 
     // update GUI dependencies
     UpdateGUIDependencies();
+
+    UpdateRecorderStatus ( QString::null );
 
     // View menu  --------------------------------------------------------------
     QMenu* pViewMenu = new QMenu ( tr ( "&Window" ), this );

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -113,25 +113,6 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
     cbxLocationCountry->setAccessibleName ( tr ( "Combo box for location of this server" ) );
 
-    // recording directory
-    pbtRecordingDir->setAccessibleName ( tr ( "Display dialog to select recording directory button" ) );
-    pbtRecordingDir->setWhatsThis ( "<b>" + tr ( "Main Recording Directory" ) + ":</b> " +
-                                    tr ( "Click the button to open the dialog that allows the main recording directory to be selected."
-                                         "The chosen value must exist and be writeable (allow creation of sub-directories "
-                                         "by the user Jamulus is running as). " ) );
-
-    edtRecordingDir->setAccessibleName ( tr ( "Main recording directory text box (read-only)" ) );
-    edtRecordingDir->setWhatsThis ( "<b>" + tr ( "Main Recording Directory" ) + ":</b> " +
-                                    tr ( "The current value of the main recording directory. "
-                                         "The chosen value must exist and be writeable (allow creation of sub-directories "
-                                         "by the user Jamulus is running as). "
-                                         "Click the button to open the dialog that allows the main recording directory to be selected." ) );
-
-    tbtClearRecordingDir->setAccessibleName ( tr ( "Clear the recording directory button" ) );
-    tbtClearRecordingDir->setWhatsThis ( "<b>" + tr ( "Clear Recording Directory" ) + ":</b> " +
-                                         tr ( "Click the button to clear the currently selected recording directory. "
-                                              "This will prevent recording until a new value is selected." ) );
-
     // enable recorder
     chbEnableRecorder->setAccessibleName ( tr ( "Checkbox to turn on or off server recording" ) );
     chbEnableRecorder->setWhatsThis ( "<b>" + tr ( "Enable Recorder" ) + ":</b> " +
@@ -172,6 +153,25 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                            "musician enters the server. If no message is set, the server welcome is disabled." ) );
 
     // Tab: options
+
+    // recording directory
+    pbtRecordingDir->setAccessibleName ( tr ( "Display dialog to select recording directory button" ) );
+    pbtRecordingDir->setWhatsThis ( "<b>" + tr ( "Main Recording Directory" ) + ":</b> " +
+                                    tr ( "Click the button to open the dialog that allows the main recording directory to be selected.  "
+                                         "The chosen value must exist and be writeable (allow creation of sub-directories "
+                                         "by the user Jamulus is running as)." ) );
+
+    edtRecordingDir->setAccessibleName ( tr ( "Main recording directory text box (read-only)" ) );
+    edtRecordingDir->setWhatsThis ( "<b>" + tr ( "Main Recording Directory" ) + ":</b> " +
+                                    tr ( "The current value of the main recording directory. "
+                                         "The chosen value must exist and be writeable (allow creation of sub-directories "
+                                         "by the user Jamulus is running as). "
+                                         "Click the button to open the dialog that allows the main recording directory to be selected." ) );
+
+    tbtClearRecordingDir->setAccessibleName ( tr ( "Clear the recording directory button" ) );
+    tbtClearRecordingDir->setWhatsThis ( "<b>" + tr ( "Clear Recording Directory" ) + ":</b> " +
+                                         tr ( "Click the button to clear the currently selected recording directory. "
+                                              "This will prevent recording until a new value is selected." ) );
 
     // start minimized on operating system start
     chbStartOnOSStart->setWhatsThis ( "<b>" + tr ( "Start Minimized on Operating System Start" ) + ":</b> " +

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -37,6 +37,9 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
     setupUi ( this );
 
+    // set window title
+    setWindowTitle ( tr ( "%1 Server", "%1 is the name of the main application" ).arg ( APP_NAME ) );
+
     // Add help text to controls -----------------------------------------------
     // client list
     lvwClients->setWhatsThis ( "<b>" + tr ( "Client List" ) + ":</b> " +
@@ -336,9 +339,6 @@ lvwClients->setMinimumHeight ( 140 );
 
     // update GUI dependencies
     UpdateGUIDependencies();
-
-    // set window title
-    setWindowTitle ( tr ( "%1 Server", "%1 is the name of the main application" ).arg ( APP_NAME ) );
 
     // View menu  --------------------------------------------------------------
     QMenu* pViewMenu = new QMenu ( tr ( "&Window" ), this );

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -154,6 +154,13 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
     // Tab: options
 
+    // Interface Language
+    QString strWTLanguage = "<b>" + tr ( "Language" ) + ":</b> " + tr ( "Select the language to be used for the user interface." );
+    lblLanguage->setWhatsThis ( strWTLanguage );
+    cbxLanguage->setWhatsThis ( strWTLanguage );
+
+    cbxLanguage->setAccessibleName ( tr ( "Language combo box" ) );
+
     // recording directory
     pbtRecordingDir->setAccessibleName ( tr ( "Display dialog to select recording directory button" ) );
     pbtRecordingDir->setWhatsThis ( "<b>" + tr ( "Main Recording Directory" ) + ":</b> " +

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -52,15 +52,6 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
     lvwClients->setAccessibleName ( tr ( "Connected clients list view" ) );
 
-    // start minimized on operating system start
-    chbStartOnOSStart->setWhatsThis ( "<b>" +
-                                      tr ( "Start Minimized on Operating "
-                                           "System Start" ) +
-                                      ":</b> " +
-                                      tr ( "If the start minimized on operating system start "
-                                           "check box is checked, the server will be "
-                                           "started when the operating system starts up and is automatically "
-                                           "minimized to a system task bar icon." ) );
 
     // Make My Server Public flag
     chbRegisterServer->setWhatsThis ( "<b>" + tr ( "Make My Server Public" ) + ":</b> " +
@@ -181,6 +172,13 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                            "musician enters the server. If no message is set, the server welcome is disabled." ) );
 
     // Tab: options
+
+    // start minimized on operating system start
+    chbStartOnOSStart->setWhatsThis ( "<b>" + tr ( "Start Minimized on Operating System Start" ) + ":</b> " +
+                                      tr ( "If the start minimized on operating system start "
+                                           "check box is checked, the server will be "
+                                           "started when the operating system starts up and is automatically "
+                                           "minimized to a system task bar icon." ) );
 
     // Application initialisation
 

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -215,11 +215,13 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     }
 
     // act on "start minimized" flag (note, this has to be done after setting
-    // the correct value for the system tray icon availablility)
+    // and acting on the correct value for the system tray icon availablility)
     if ( bStartMinimized )
     {
         showMinimized();
     }
+
+    // UI initialisation
 
     // set up list view for connected clients
     lvwClients->setColumnWidth ( 0, 170 ); // 170 //  IP:port

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -41,6 +41,9 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     setWindowTitle ( tr ( "%1 Server", "%1 is the name of the main application" ).arg ( APP_NAME ) );
 
     // Add help text to controls -----------------------------------------------
+
+    // Tab: Server setup
+
     // client list
     lvwClients->setWhatsThis ( "<b>" + tr ( "Client List" ) + ":</b> " +
                                tr ( "The client list shows all clients which are currently connected to this "
@@ -176,6 +179,10 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     tedWelcomeMessage->setWhatsThis ( "<b>" + tr ( "Server Welcome Message" ) + ":</b> " +
                                       tr ( "A server welcome message text is displayed in the chat window if a "
                                            "musician enters the server. If no message is set, the server welcome is disabled." ) );
+
+    // Tab: options
+
+    // Application initialisation
 
     // init system tray icon
     if ( bSystemTrayIconAvailable )

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -52,7 +52,6 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
     lvwClients->setAccessibleName ( tr ( "Connected clients list view" ) );
 
-
     // Make My Server Public flag
     chbRegisterServer->setWhatsThis ( "<b>" + tr ( "Make My Server Public" ) + ":</b> " +
                                       tr ( "If the Make My Server Public check box is checked, this server registers "
@@ -67,15 +66,6 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                     tr ( "If the Register Server check box is checked, this will show "
                                          "whether registration with the directory server is successful. If the "
                                          "registration failed, please choose another server list." ) );
-
-    // custom directory server address
-    QString strCustomDirectoryAddress = "<b>" + tr ( "Custom Directory Server Address" ) + ":</b> " +
-                                        tr ( "The custom directory server address is the IP address or URL of the directory "
-                                             "server at which the server list of the connection dialog is managed." );
-
-    lblDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
-    edtDirectoryAddress->setWhatsThis ( strCustomDirectoryAddress );
-    edtDirectoryAddress->setAccessibleName ( tr ( "Directory server address line edit" ) );
 
     cbxDirectoryType->setWhatsThis ( "<b>" + tr ( "Server List Selection" ) + ":</b> " +
                                      tr ( "Selects the server list (i.e. directory server address) in which your server will be added." ) );
@@ -180,6 +170,15 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                          tr ( "Click the button to clear the currently selected recording directory. "
                                               "This will prevent recording until a new value is selected." ) );
 
+    // custom directory
+    QString strCustomDirectory = "<b>" + tr ( "Custom Directory" ) + ":</b> " +
+                                 tr ( "The custom directory is the IP address or URL of the directory "
+                                      "server at which the server list of the connection dialog is managed." );
+
+    lblCustomDirectory->setWhatsThis ( strCustomDirectory );
+    edtCustomDirectory->setWhatsThis ( strCustomDirectory );
+    edtCustomDirectory->setAccessibleName ( tr ( "Custom Directory line edit" ) );
+
     // start minimized on operating system start
     chbStartOnOSStart->setWhatsThis ( "<b>" + tr ( "Start Minimized on Operating System Start" ) + ":</b> " +
                                       tr ( "If the start minimized on operating system start "
@@ -259,7 +258,7 @@ lvwClients->setMinimumHeight ( 140 );
     cbxDirectoryType->setCurrentIndex ( static_cast<int> ( pServer->GetDirectoryType() ) );
 
     // custom directory server address
-    edtDirectoryAddress->setText ( pServer->GetDirectoryAddress() );
+    edtCustomDirectory->setText ( pServer->GetDirectoryAddress() );
 
     // update server name line edit
     edtServerName->setText ( pServer->GetServerName() );
@@ -387,7 +386,7 @@ lvwClients->setMinimumHeight ( 140 );
     QObject::connect ( chbEnableDelayPanning, &QCheckBox::stateChanged, this, &CServerDlg::OnEnableDelayPanningStateChanged );
 
     // line edits
-    QObject::connect ( edtDirectoryAddress, &QLineEdit::editingFinished, this, &CServerDlg::OnDirectoryAddressEditingFinished );
+    QObject::connect ( edtCustomDirectory, &QLineEdit::editingFinished, this, &CServerDlg::OnCustomDirectoryEditingFinished );
 
     QObject::connect ( edtServerName, &QLineEdit::textChanged, this, &CServerDlg::OnServerNameTextChanged );
 
@@ -495,10 +494,10 @@ void CServerDlg::OnRegisterServerStateChanged ( int value )
     UpdateGUIDependencies();
 }
 
-void CServerDlg::OnDirectoryAddressEditingFinished()
+void CServerDlg::OnCustomDirectoryEditingFinished()
 {
     // apply new setting to the server and update it
-    pServer->SetDirectoryAddress ( edtDirectoryAddress->text() );
+    pServer->SetDirectoryAddress ( edtCustomDirectory->text() );
 
     pServer->UpdateServerList();
 }

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -33,7 +33,7 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     BitmapSystemTrayActive ( QString::fromUtf8 ( ":/png/LEDs/res/CLEDGreenArrow.png" ) )
 {
     // check if system tray icon can be used
-    bSystemTrayIconAvaialbe = SystemTrayIcon.isSystemTrayAvailable();
+    bSystemTrayIconAvailable = SystemTrayIcon.isSystemTrayAvailable();
 
     setupUi ( this );
 
@@ -175,7 +175,7 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
                                            "musician enters the server. If no message is set, the server welcome is disabled." ) );
 
     // init system tray icon
-    if ( bSystemTrayIconAvaialbe )
+    if ( bSystemTrayIconAvailable )
     {
         // prepare context menu to be added to the system tray icon
         pSystemTrayIconMenu = new QMenu ( this );
@@ -702,7 +702,7 @@ void CServerDlg::UpdateGUIDependencies()
 
 void CServerDlg::UpdateSystemTrayIcon ( const bool bIsActive )
 {
-    if ( bSystemTrayIconAvaialbe )
+    if ( bSystemTrayIconAvailable )
     {
         if ( bIsActive )
         {
@@ -818,7 +818,7 @@ void CServerDlg::changeEvent ( QEvent* pEvent )
 {
     // if we have a system tray icon, we make the window invisible if it is
     // minimized
-    if ( bSystemTrayIconAvaialbe && ( pEvent->type() == QEvent::WindowStateChange ) )
+    if ( bSystemTrayIconAvailable && ( pEvent->type() == QEvent::WindowStateChange ) )
     {
         if ( isMinimized() )
         {

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -87,7 +87,7 @@ protected:
 
     QMenuBar* pMenu;
 
-    bool            bSystemTrayIconAvaialbe;
+    bool            bSystemTrayIconAvailable;
     QSystemTrayIcon SystemTrayIcon;
     QPixmap         BitmapSystemTrayInactive;
     QPixmap         BitmapSystemTrayActive;

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -98,7 +98,7 @@ public slots:
     void OnStartOnOSStartStateChanged ( int value );
     void OnEnableRecorderStateChanged ( int value ) { pServer->SetEnableRecording ( Qt::CheckState::Checked == value ); }
 
-    void OnDirectoryAddressEditingFinished();
+    void OnCustomDirectoryEditingFinished();
     void OnServerNameTextChanged ( const QString& strNewName );
     void OnLocationCityTextChanged ( const QString& strNewCity );
     void OnLocationCountryActivated ( int iCntryListItem );

--- a/src/serverdlgbase.ui
+++ b/src/serverdlgbase.ui
@@ -252,14 +252,14 @@
        <item>
         <layout class="QHBoxLayout">
          <item>
-          <widget class="QLabel" name="lblDirectoryAddress">
+          <widget class="QLabel" name="lblCustomDirectory">
            <property name="text">
             <string>Custom Directory Server Address:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="edtDirectoryAddress"/>
+          <widget class="QLineEdit" name="edtCustomDirectory"/>
          </item>
         </layout>
        </item>
@@ -326,7 +326,7 @@
   <tabstop>pbtRecordingDir</tabstop>
   <tabstop>edtRecordingDir</tabstop>
   <tabstop>tbtClearRecordingDir</tabstop>
-  <tabstop>edtDirectoryAddress</tabstop>
+  <tabstop>edtCustomDirectory</tabstop>
   <tabstop>chbStartOnOSStart</tabstop>
  </tabstops>
  <resources>


### PR DESCRIPTION
**Short description of changes**

This starts to get to making _actual changes_ in behaviour of the server dialog code.

**I _STRONGLY_ recommend viewing each commit separately before viewing the full diff.**  The aim was to keep each change small, self-contained and then test so that I was confident I'd not broken anything along the way.

(Admittedly, skimming the full diff now, it doesn't look too bad...)

**Context: Fixes an issue?**

The aim is multifold but primarily to make it easier to tie the UI as displayed to the code that implements it.  This means code gets moved around quite a lot, meaning the diff looks like inserts/deletes, unfortunately -- hence the recommendation above.

It also fixes a few bits (like adding missing "What's This" help).
![image](https://user-images.githubusercontent.com/1549463/147093575-b3789130-641d-4003-9d11-623973c66352.png) -> ![image](https://user-images.githubusercontent.com/1549463/147093653-2c9c8ea5-a228-459c-bbf5-42bab331fc8b.png)


**Does this change need documentation? What needs to be documented and how?**

New / changed translation(s).  May need new screenshots.  (I've been using it too long to remember, now.)

**Status of this Pull Request**

Ready to merge (IMO).

## Checklist
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
