### PR TITLE
Add System Sound Setup Button for Windows and macOS

### DIFF
--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -406,10 +406,10 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 #endif
 
     // init sound setup button
-#if defined( _WIN32 ) || defined( Q_OS_MACX ) || defined( __linux__ )
+#if defined( _WIN32 ) || defined( Q_OS_MACX )
     butSoundSetup->setText ( tr ( "System Sound Settings" ) );
 #else
-    // no use for this button for iOS/Android right now -> hide it
+    // no use for this button for Linux/iOS/Android right now -> hide it
     butSoundSetup->hide();
 #endif
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -246,11 +246,10 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     // Sound settings button
     QString strSystemSndSetup = "<b>" + tr ( "System Sound Settings" ) + ":</b> " +
-                                    tr ( "This opens the sound settings of your system."
-                                         "You can use this to change the Input (Microphone) level" );
+                                tr ( "This opens the sound settings of your system."
+                                     "You can use this to change the Input (Microphone) level" );
 
-    QString strSystemSndSetupTT = tr ( "Opens the System Sound settings." ) +
-                                      TOOLTIP_COM_END_TEXT;
+    QString strSystemSndSetupTT = tr ( "Opens the System Sound settings." ) + TOOLTIP_COM_END_TEXT;
 
     rbtBufferDelayPreferred->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayPreferred->setAccessibleName ( tr ( "64 samples setting radio button" ) );
@@ -407,7 +406,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 #endif
 
     // init sound setup button
-#if defined ( _WIN32 ) || defined ( Q_OS_MACX ) || defined ( __linux__ )
+#if defined( _WIN32 ) || defined( Q_OS_MACX ) || defined( __linux__ )
     butSoundSetup->setText ( tr ( "System Sound Settings" ) );
 #else
     // no use for this button for iOS/Android right now -> hide it
@@ -920,8 +919,8 @@ void CClientSettingsDlg::OnDriverSetupClicked() { pClient->OpenSndCrdDriverSetup
 void CClientSettingsDlg::OnSoundSetupClicked()
 {
     // open sound settings panel in independent process
-    QProcess *detProcess = new QProcess(this);
-    detProcess->startDetached( OpenSoundSettingsCmd );
+    QProcess* detProcess = new QProcess ( this );
+    detProcess->startDetached ( OpenSoundSettingsCmd );
 }
 
 void CClientSettingsDlg::OnNetBufValueChanged ( int value )

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -244,6 +244,14 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                           .arg ( SYSTEM_SAMPLE_RATE_HZ ) +
                                       TOOLTIP_COM_END_TEXT;
 
+    // Sound settings button
+    QString strSystemSndSetup = "<b>" + tr ( "System Sound Settings" ) + ":</b> " +
+                                    tr ( "This opens the sound settings of your system."
+                                         "You can use this to change the Input (Microphone) level" );
+
+    QString strSystemSndSetupTT = tr ( "Opens the System Sound settings." ) +
+                                      TOOLTIP_COM_END_TEXT;
+
     rbtBufferDelayPreferred->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayPreferred->setAccessibleName ( tr ( "64 samples setting radio button" ) );
     rbtBufferDelayPreferred->setToolTip ( strSndCrdBufDelayTT );
@@ -256,6 +264,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     butDriverSetup->setWhatsThis ( strSndCardDriverSetup );
     butDriverSetup->setAccessibleName ( tr ( "ASIO Device Settings push button" ) );
     butDriverSetup->setToolTip ( strSndCardDriverSetupTT );
+    butSoundSetup->setWhatsThis ( strSystemSndSetup );
+    butSoundSetup->setAccessibleName ( tr ( "System Sound Settings push button" ) );
+    butSoundSetup->setToolTip ( strSystemSndSetupTT );
 
     // fancy skin
     lblSkin->setWhatsThis ( "<b>" + tr ( "Skin" ) + ":</b> " + tr ( "Select the skin to be used for the main window." ) );
@@ -393,6 +404,14 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 #else
     // no use for this button for MacOS/Linux right now -> hide it
     butDriverSetup->hide();
+#endif
+
+    // init sound setup button
+#if defined ( _WIN32 ) || defined ( Q_OS_MACX ) || defined ( __linux__ )
+    butSoundSetup->setText ( tr ( "System Sound Settings" ) );
+#else
+    // no use for this button for iOS/Android right now -> hide it
+    butSoundSetup->hide();
 #endif
 
     // init audio in fader
@@ -687,6 +706,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     // buttons
     QObject::connect ( butDriverSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverSetupClicked );
 
+    QObject::connect ( butSoundSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnSoundSetupClicked );
+
     // misc
     // sliders
     QObject::connect ( sldAudioPan, &QSlider::valueChanged, this, &CClientSettingsDlg::OnAudioPanValueChanged );
@@ -895,6 +916,13 @@ void CClientSettingsDlg::SetEnableFeedbackDetection ( bool enable )
 }
 
 void CClientSettingsDlg::OnDriverSetupClicked() { pClient->OpenSndCrdDriverSetup(); }
+
+void CClientSettingsDlg::OnSoundSetupClicked()
+{
+    // open sound settings panel in independent process
+    QProcess *detProcess = new QProcess(this);
+    detProcess->startDetached( OpenSoundSettingsCmd );
+}
 
 void CClientSettingsDlg::OnNetBufValueChanged ( int value )
 {

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -37,6 +37,7 @@
 #include <QLayout>
 #include <QButtonGroup>
 #include <QMessageBox>
+#include <QProcess>
 #include "global.h"
 #include "util.h"
 #include "client.h"
@@ -68,6 +69,17 @@ protected:
     void    UpdateDirectoryServerComboBox();
     void    UpdateAudioFaderSlider();
     QString GenSndCrdBufferDelayString ( const int iFrameSize, const QString strAddText = "" );
+
+    //Define strings for launching System Sound Setup
+#ifdef _WIN32
+    QString OpenSoundSettingsCmd = "control mmsys.cpl,,1";
+#elif defined ( Q_OS_MACX )
+    QString OpenSoundSettingsCmd = "open /System/Library/PreferencePanes/Sound.prefPane";
+#elif defined ( __linux__ )
+    QString OpenSoundSettingsCmd = "gnome-control-center sound";
+#else
+    QString OpenSoundSettingsCmd = "";
+#endif
 
     virtual void showEvent ( QShowEvent* );
 
@@ -106,6 +118,7 @@ public slots:
     void OnTabChanged();
     void OnMakeTabChange ( int iTabIdx );
     void OnAudioPanValueChanged ( int value );
+    void OnSoundSetupClicked();
 
 signals:
     void GUIDesignChanged();

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -70,12 +70,12 @@ protected:
     void    UpdateAudioFaderSlider();
     QString GenSndCrdBufferDelayString ( const int iFrameSize, const QString strAddText = "" );
 
-    //Define strings for launching System Sound Setup
+    // Define strings for launching System Sound Setup
 #ifdef _WIN32
     QString OpenSoundSettingsCmd = "control mmsys.cpl,,1";
-#elif defined ( Q_OS_MACX )
+#elif defined( Q_OS_MACX )
     QString OpenSoundSettingsCmd = "open /System/Library/PreferencePanes/Sound.prefPane";
-#elif defined ( __linux__ )
+#elif defined( __linux__ )
     QString OpenSoundSettingsCmd = "gnome-control-center sound";
 #else
     QString OpenSoundSettingsCmd = "";

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -75,8 +75,6 @@ protected:
     QString OpenSoundSettingsCmd = "control mmsys.cpl,,1";
 #elif defined( Q_OS_MACX )
     QString OpenSoundSettingsCmd = "open /System/Library/PreferencePanes/Sound.prefPane";
-#elif defined( __linux__ )
-    QString OpenSoundSettingsCmd = "gnome-control-center sound";
 #else
     QString OpenSoundSettingsCmd = "";
 #endif

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -385,6 +385,22 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="butSoundSetup">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>System Sound Setup</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_5">
              <property name="orientation">
               <enum>Qt::Vertical</enum>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**
System Sound Setup button added to the Audio-/Network-setting functions.
This opens the System Sound Setup dialog on Windows and macOS.
<!-- A short description of your changes which might go into the change log -->

**Context: Fixes an issue?**
Fixes #2197 
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
Documentation needs updating to reflect the change and screenshots need to be updated as well.

Sample screenshot for Windows:
![system-sound-windows](https://user-images.githubusercontent.com/13550012/147931606-ddd18657-a929-47b4-8982-3fdf3cea4a8b.png)

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Complete
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Testing on different OS is appreciated. I have only tested using virtual machines.
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
