### PR TITLE
Server UI changes

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -684,12 +684,6 @@ void CServer::OnAboutToQuit()
 
     Stop();
 
-    // if server was registered at the directory server, unregister on shutdown
-    if ( GetServerRegistered() )
-    {
-        Unregister();
-    }
-
     if ( bWriteStatusHTMLFile )
     {
         WriteHTMLServerQuit();

--- a/src/server.h
+++ b/src/server.h
@@ -190,70 +190,50 @@ public:
 
     void CreateCLServerListReqVerAndOSMes ( const CHostAddress& InetAddr ) { ConnLessProtocol.CreateCLReqVersionAndOSMes ( InetAddr ); }
 
-    // Jam recorder ------------------------------------------------------------
-    bool    GetRecorderInitialised() { return JamController.GetRecorderInitialised(); }
-    QString GetRecorderErrMsg() { return JamController.GetRecorderErrMsg(); }
-    bool    GetRecordingEnabled() { return JamController.GetRecordingEnabled(); }
-    bool    GetDisableRecording() { return bDisableRecording; }
-    void    RequestNewRecording() { JamController.RequestNewRecording(); }
-
-    void SetEnableRecording ( bool bNewEnableRecording );
-
-    QString GetRecordingDir() { return JamController.GetRecordingDir(); }
-
-    void SetRecordingDir ( QString newRecordingDir )
-    {
-        JamController.SetRecordingDir ( newRecordingDir, iServerFrameSizeSamples, bDisableRecording );
-    }
-
-    void CreateAndSendRecorderStateForAllConChannels();
-
-    // delay panning
-    void SetEnableDelayPanning ( bool bDelayPanningOn ) { bDelayPan = bDelayPanningOn; }
-    bool IsDelayPanningEnabled() { return bDelayPan; }
-
     // IPv6 Enabled
     bool IsIPv6Enabled() { return bEnableIPv6; }
 
-    // Server list management --------------------------------------------------
-    void UpdateServerList() { ServerListManager.Update(); }
+    // GUI settings ------------------------------------------------------------
+    int GetClientNumAudioChannels ( const int iChanNum ) { return vecChannels[iChanNum].GetNumAudioChannels(); }
 
-    void Unregister() { ServerListManager.Unregister(); }
-
-    void SetServerRegistered ( const bool bState ) { ServerListManager.SetEnabled ( bState ); }
-
-    bool GetServerRegistered() { return ServerListManager.GetEnabled(); }
-
-    void SetDirectoryAddress ( const QString& sNDirectoryAddress ) { ServerListManager.SetDirectoryAddress ( sNDirectoryAddress ); }
-
-    QString GetDirectoryAddress() { return ServerListManager.GetDirectoryAddress(); }
-
-    void SetDirectoryType ( const EDirectoryType eNCSAT ) { ServerListManager.SetDirectoryType ( eNCSAT ); }
-
+    void           SetDirectoryType ( const EDirectoryType eNCSAT ) { ServerListManager.SetDirectoryType ( eNCSAT ); }
     EDirectoryType GetDirectoryType() { return ServerListManager.GetDirectoryType(); }
+    bool           IsDirectoryServer() { return ServerListManager.IsDirectoryServer(); }
+    ESvrRegStatus  GetSvrRegStatus() { return ServerListManager.GetSvrRegStatus(); }
 
-    void SetServerName ( const QString& strNewName ) { ServerListManager.SetServerName ( strNewName ); }
-
-    QString GetServerName() { return ServerListManager.GetServerName(); }
-
-    void SetServerCity ( const QString& strNewCity ) { ServerListManager.SetServerCity ( strNewCity ); }
-
-    QString GetServerCity() { return ServerListManager.GetServerCity(); }
-
-    void SetServerCountry ( const QLocale::Country eNewCountry ) { ServerListManager.SetServerCountry ( eNewCountry ); }
-
+    void             SetServerName ( const QString& strNewName ) { ServerListManager.SetServerName ( strNewName ); }
+    QString          GetServerName() { return ServerListManager.GetServerName(); }
+    void             SetServerCity ( const QString& strNewCity ) { ServerListManager.SetServerCity ( strNewCity ); }
+    QString          GetServerCity() { return ServerListManager.GetServerCity(); }
+    void             SetServerCountry ( const QLocale::Country eNewCountry ) { ServerListManager.SetServerCountry ( eNewCountry ); }
     QLocale::Country GetServerCountry() { return ServerListManager.GetServerCountry(); }
+
+    bool    GetRecorderInitialised() { return JamController.GetRecorderInitialised(); }
+    void    SetEnableRecording ( bool bNewEnableRecording );
+    bool    GetDisableRecording() { return bDisableRecording; }
+    QString GetRecorderErrMsg() { return JamController.GetRecorderErrMsg(); }
+    bool    GetRecordingEnabled() { return JamController.GetRecordingEnabled(); }
+    void    RequestNewRecording() { JamController.RequestNewRecording(); }
+    void    SetRecordingDir ( QString newRecordingDir )
+    {
+        JamController.SetRecordingDir ( newRecordingDir, iServerFrameSizeSamples, bDisableRecording );
+    }
+    QString GetRecordingDir() { return JamController.GetRecordingDir(); }
 
     void    SetWelcomeMessage ( const QString& strNWelcMess );
     QString GetWelcomeMessage() { return strWelcomeMessage; }
 
-    ESvrRegStatus GetSvrRegStatus() { return ServerListManager.GetSvrRegStatus(); }
+    void    SetDirectoryAddress ( const QString& sNDirectoryAddress ) { ServerListManager.SetDirectoryAddress ( sNDirectoryAddress ); }
+    QString GetDirectoryAddress() { return ServerListManager.GetDirectoryAddress(); }
 
-    // GUI settings ------------------------------------------------------------
+    QString GetServerListFileName() { return ServerListManager.GetServerListFileName(); }
+    bool    SetServerListFileName ( QString strFilename ) { return ServerListManager.SetServerListFileName ( strFilename ); }
+
     void SetAutoRunMinimized ( const bool NAuRuMin ) { bAutoRunMinimized = NAuRuMin; }
     bool GetAutoRunMinimized() { return bAutoRunMinimized; }
 
-    int GetClientNumAudioChannels ( const int iChanNum ) { return vecChannels[iChanNum].GetNumAudioChannels(); }
+    void SetEnableDelayPanning ( bool bDelayPanningOn ) { bDelayPan = bDelayPanningOn; }
+    bool IsDelayPanningEnabled() { return bDelayPan; }
 
 protected:
     // access functions for actual channels
@@ -291,6 +271,8 @@ protected:
     void MixEncodeTransmitData ( const int iChanCnt, const int iNumClients );
 
     virtual void customEvent ( QEvent* pEvent );
+
+    void CreateAndSendRecorderStateForAllConChannels();
 
     // if server mode is normal or double system frame size
     bool bUseDoubleSystemFrameSize;
@@ -433,9 +415,8 @@ public slots:
 
     void OnCLSendEmptyMes ( CHostAddress TargetInetAddr )
     {
-        // only send empty message if server list is enabled and this is not
-        // a directory server
-        if ( ServerListManager.GetEnabled() && !ServerListManager.IsDirectoryServer() )
+        // only send empty message if not a directory server
+        if ( !ServerListManager.IsDirectoryServer() )
         {
             ConnLessProtocol.CreateCLEmptyMes ( TargetInetAddr );
         }

--- a/src/serverdlg.h
+++ b/src/serverdlg.h
@@ -94,31 +94,37 @@ protected:
     QMenu*          pSystemTrayIconMenu;
 
 public slots:
-    void OnRegisterServerStateChanged ( int value );
-    void OnStartOnOSStartStateChanged ( int value );
+    // From the GUI
+    void OnDirectoryTypeCurrentIndexChanged ( int iTypeIdx );
+    void OnServerNameEditingFinished();
+    void OnLocationCityEditingFinished();
+    void OnLocationCountryCurrentIndexChanged ( int iCntryListItem );
     void OnEnableRecorderStateChanged ( int value ) { pServer->SetEnableRecording ( Qt::CheckState::Checked == value ); }
+    void OnNewRecordingClicked() { pServer->RequestNewRecording(); }
+    void OnWelcomeMessageChanged() { pServer->SetWelcomeMessage ( tedWelcomeMessage->toPlainText() ); }
 
+    void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnCustomDirectoryEditingFinished();
-    void OnServerNameTextChanged ( const QString& strNewName );
-    void OnLocationCityTextChanged ( const QString& strNewCity );
-    void OnLocationCountryActivated ( int iCntryListItem );
-    void OnDirectoryTypeActivated ( int iTypeIdx );
-    void OnTimer();
-    void OnServerStarted();
-    void OnServerStopped();
-    void OnSvrRegStatusChanged() { UpdateGUIDependencies(); }
-    void OnStopRecorder();
+    void OnRecordingDirClicked();
+    void OnClearRecordingDirClicked();
+    void OnServerListPersistenceClicked();
+    void OnClearServerListPersistenceClicked();
+    void OnStartOnOSStartStateChanged ( int value );
+    void OnEnableDelayPanningStateChanged ( int value ) { pServer->SetEnableDelayPanning ( Qt::CheckState::Checked == value ); }
+
     void OnSysTrayMenuOpen() { ShowWindowInForeground(); }
     void OnSysTrayMenuHide() { hide(); }
     void OnSysTrayMenuExit() { close(); }
     void OnSysTrayActivated ( QSystemTrayIcon::ActivationReason ActReason );
-    void OnWelcomeMessageChanged() { pServer->SetWelcomeMessage ( tedWelcomeMessage->toPlainText() ); }
-    void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
-    void OnEnableDelayPanningStateChanged ( int value ) { pServer->SetEnableDelayPanning ( Qt::CheckState::Checked == value ); }
-    void OnNewRecordingClicked() { pServer->RequestNewRecording(); }
-    void OnRecordingDirClicked();
-    void OnClearRecordingDirClicked();
-    void OnRecordingSessionStarted ( QString sessionDir ) { UpdateRecorderStatus ( sessionDir ); }
 
+    // From the Server
+    void OnServerStarted();
+    void OnServerStopped();
+    void OnSvrRegStatusChanged() { UpdateGUIDependencies(); }
+    void OnRecordingSessionStarted ( QString sessionDir ) { UpdateRecorderStatus ( sessionDir ); }
+    void OnStopRecorder();
     void OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType, QString strVersion );
+
+    // Our timer
+    void OnTimer();
 };

--- a/src/serverdlgbase.ui
+++ b/src/serverdlgbase.ui
@@ -68,18 +68,11 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QCheckBox" name="chbRegisterServer">
-         <property name="text">
-          <string>Make My Server Public (Register My Server in the Server List)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <layout class="QHBoxLayout">
          <item>
-          <widget class="QLabel" name="label">
+          <widget class="QLabel" name="lblDirectoryType">
            <property name="text">
-            <string>List</string>
+            <string>Directory</string>
            </property>
           </widget>
          </item>
@@ -254,12 +247,33 @@
          <item>
           <widget class="QLabel" name="lblCustomDirectory">
            <property name="text">
-            <string>Custom Directory Server Address:</string>
+            <string>Custom Directory address</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QLineEdit" name="edtCustomDirectory"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QPushButton" name="pbtServerListPersistence">
+           <property name="text">
+            <string>Server List Filename</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="edtServerListPersistence">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="tbtClearServerListPersistence"/>
          </item>
         </layout>
        </item>
@@ -313,7 +327,6 @@
  <tabstops>
   <tabstop>lvwClients</tabstop>
   <tabstop>tabWidget</tabstop>
-  <tabstop>chbRegisterServer</tabstop>
   <tabstop>cbxDirectoryType</tabstop>
   <tabstop>edtServerName</tabstop>
   <tabstop>edtLocationCity</tabstop>
@@ -327,7 +340,11 @@
   <tabstop>edtRecordingDir</tabstop>
   <tabstop>tbtClearRecordingDir</tabstop>
   <tabstop>edtCustomDirectory</tabstop>
+  <tabstop>pbtServerListPersistence</tabstop>
+  <tabstop>edtServerListPersistence</tabstop>
+  <tabstop>tbtClearServerListPersistence</tabstop>
   <tabstop>chbStartOnOSStart</tabstop>
+  <tabstop>chbEnableDelayPanning</tabstop>
  </tabstops>
  <resources>
   <include location="resources.qrc"/>

--- a/src/util.h
+++ b/src/util.h
@@ -558,6 +558,7 @@ enum EChSortType
 enum EDirectoryType
 {
     // used for settings -> enum values should be fixed
+    AT_NONE                 = -1, // means not registered, "invalid value"
     AT_DEFAULT              = 0,
     AT_ANY_GENRE2           = 1,
     AT_ANY_GENRE3           = 2,
@@ -572,8 +573,8 @@ inline QString DirectoryTypeToString ( EDirectoryType eAddrType )
 {
     switch ( eAddrType )
     {
-    case AT_CUSTOM:
-        return QCoreApplication::translate ( "CClientSettingsDlg", "Custom" );
+    case AT_NONE:
+        return QCoreApplication::translate ( "CServerDlg", "None" );
 
     case AT_ANY_GENRE2:
         return QCoreApplication::translate ( "CClientSettingsDlg", "Any Genre 2" );
@@ -593,6 +594,9 @@ inline QString DirectoryTypeToString ( EDirectoryType eAddrType )
     case AT_GENRE_CHORAL:
         return QCoreApplication::translate ( "CClientSettingsDlg", "Genre Choral/Barbershop" );
 
+    case AT_CUSTOM:
+        return QCoreApplication::translate ( "CClientSettingsDlg", "Custom" );
+
     default: // AT_DEFAULT
         return QCoreApplication::translate ( "CClientSettingsDlg", "Any Genre 1" );
     }
@@ -601,7 +605,7 @@ inline QString DirectoryTypeToString ( EDirectoryType eAddrType )
 // Server registration state ---------------------------------------------
 enum ESvrRegStatus
 {
-    SRS_UNREGISTERED,
+    SRS_NOT_REGISTERED,
     SRS_BAD_ADDRESS,
     SRS_REQUESTED,
     SRS_TIME_OUT,
@@ -616,8 +620,8 @@ inline QString svrRegStatusToString ( ESvrRegStatus eSvrRegStatus )
 {
     switch ( eSvrRegStatus )
     {
-    case SRS_UNREGISTERED:
-        return QCoreApplication::translate ( "CServerDlg", "Unregistered" );
+    case SRS_NOT_REGISTERED:
+        return QCoreApplication::translate ( "CServerDlg", "Not registered" );
 
     case SRS_BAD_ADDRESS:
         return QCoreApplication::translate ( "CServerDlg", "Bad address" );


### PR DESCRIPTION
**Short description of changes**

My initial goal was to add to the server UI a way of setting (and changing in flight) the server list persistence file for a Jamulus directory.

However, during that change, it became apparent that the design of the interface between GUI and service layers was not geared to such in flight changes - the server is more expectant that it will be run with a configuration and left running "as is".

CHANGELOG: UI: Amend server registration, add server persistence

**Context: Fixes an issue?**

* Jamulus Directory improvements: UI to set / amend / remove the server list persistence file;

* Jamulus Server improvements: the server can be switched between:
    - unregistered
    - registered as a public server
    - registered with a custom directory
    - run as a Jamulus Directory

without restart, through the UI.  That configuration will be saved and restored in the server inifile.  If set to unregistered, the server will start up _unregistered_, rather than registered in the default directory.  You can set the custom directory without registering, so you can set that whilst unregistered then switch to registering with the custom directory, and never register as a public server.

**Does this change need documentation? What needs to be documented and how?**

The UI has changed both in layout and behaviour.  All server documentation probably needs review as a result.

**Status of this Pull Request**

I've been running it for months in headless mode.  I've used it on Windows and Linux with the GUI and find it works much better than 3.8.1.

**What is missing until this pull request can be merged?**

More testing.  UX feedback.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
