### PR TITLE
Remove ASIO button from Audio/Network settings when using JACK

### DIFF
--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -117,13 +117,14 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     chbAutoJitBuf->setAccessibleName ( tr ( "Auto jitter buffer switch" ) );
     chbAutoJitBuf->setToolTip ( strJitterBufferSizeTT );
 
+#if !defined( WITH_JACK )
     // sound card device
     lblSoundcardDevice->setWhatsThis ( "<b>" +
-                                       QString ( tr ( "Sound Card Device" ) + ":</b> " +
-                                                 tr ( "The ASIO driver (sound card) can be selected using "
-                                                      "%1 under the Windows operating system. Under macOS/Linux, no sound "
-                                                      "card selection is possible. If the selected ASIO driver is not valid "
-                                                      "an error message is shown and the previous valid driver is selected." ) )
+                                       QString ( tr ( "Device" ) + ":</b> " +
+                                                 tr ( "Under the Windows operating system the ASIO driver (sound card) can be "
+                                                      "selected using %1. If the selected ASIO driver is not valid an error "
+                                                      "message is shown and the previous valid driver is selected. "
+                                                      "Under macOS the input and output hardware can be selected." ) )
                                            .arg ( APP_NAME ) +
                                        "<br>" +
                                        tr ( "If the driver is selected during an active connection, the connection "
@@ -132,7 +133,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     cbxSoundcard->setAccessibleName ( tr ( "Sound card device selector combo box" ) );
 
-#if defined( _WIN32 ) && !defined( JACK_REPLACES_ASIO )
+#    if defined( _WIN32 )
     // set Windows specific tool tip
     cbxSoundcard->setToolTip ( tr ( "If the ASIO4ALL driver is used, "
                                     "please note that this driver usually introduces approx. 10-30 ms of "
@@ -143,7 +144,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                     "driver, make sure to connect the ASIO inputs in the kX DSP settings "
                                     "panel." ) +
                                TOOLTIP_COM_END_TEXT );
-#endif
+#    endif
 
     // sound card input/output channel mapping
     QString strSndCrdChanMapp = "<b>" + tr ( "Sound Card Channel Mapping" ) + ":</b> " +
@@ -166,6 +167,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxLOutChan->setAccessibleName ( tr ( "Left output channel selection combo box" ) );
     cbxROutChan->setWhatsThis ( strSndCrdChanMapp );
     cbxROutChan->setAccessibleName ( tr ( "Right output channel selection combo box" ) );
+#endif
 
     // enable OPUS64
     chbEnableOPUS64->setWhatsThis (
@@ -229,6 +231,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                       .arg ( APP_NAME ) +
                                   TOOLTIP_COM_END_TEXT;
 
+#if defined( _WIN32 ) && !defined( WITH_JACK )
     // Driver setup button
     QString strSndCardDriverSetup = "<b>" + tr ( "Sound card driver settings" ) + ":</b> " +
                                     tr ( "This opens the driver settings of your sound card. Some drivers "
@@ -243,6 +246,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                           .arg ( APP_NAME )
                                           .arg ( SYSTEM_SAMPLE_RATE_HZ ) +
                                       TOOLTIP_COM_END_TEXT;
+#endif
 
     rbtBufferDelayPreferred->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayPreferred->setAccessibleName ( tr ( "64 samples setting radio button" ) );
@@ -253,9 +257,12 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     rbtBufferDelaySafe->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelaySafe->setAccessibleName ( tr ( "256 samples setting radio button" ) );
     rbtBufferDelaySafe->setToolTip ( strSndCrdBufDelayTT );
+
+#if defined( _WIN32 ) && !defined( WITH_JACK )
     butDriverSetup->setWhatsThis ( strSndCardDriverSetup );
     butDriverSetup->setAccessibleName ( tr ( "ASIO Device Settings push button" ) );
     butDriverSetup->setToolTip ( strSndCardDriverSetupTT );
+#endif
 
     // fancy skin
     lblSkin->setWhatsThis ( "<b>" + tr ( "Skin" ) + ":</b> " + tr ( "Select the skin to be used for the main window." ) );
@@ -388,7 +395,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     chbDetectFeedback->setAccessibleName ( tr ( "Feedback Protection check box" ) );
 
     // init driver button
-#if defined( _WIN32 ) && !defined( JACK_REPLACES_ASIO )
+#if defined( _WIN32 ) && !defined( WITH_JACK )
     butDriverSetup->setText ( tr ( "ASIO Device Settings" ) );
 #else
     // no use for this button for MacOS/Linux right now or when using JACK -> hide it
@@ -685,7 +692,10 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                        &CClientSettingsDlg::OnInputBoostChanged );
 
     // buttons
+#if defined( _WIN32 ) && !defined( WITH_JACK )
+    // Driver Setup button is only available for Windows when JACK is not used
     QObject::connect ( butDriverSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverSetupClicked );
+#endif
 
     // misc
     // sliders
@@ -894,7 +904,9 @@ void CClientSettingsDlg::SetEnableFeedbackDetection ( bool enable )
     chbDetectFeedback->setCheckState ( pSettings->bEnableFeedbackDetection ? Qt::Checked : Qt::Unchecked );
 }
 
+#if defined( _WIN32 ) && !defined( WITH_JACK )
 void CClientSettingsDlg::OnDriverSetupClicked() { pClient->OpenSndCrdDriverSetup(); }
+#endif
 
 void CClientSettingsDlg::OnNetBufValueChanged ( int value )
 {

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -132,7 +132,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     cbxSoundcard->setAccessibleName ( tr ( "Sound card device selector combo box" ) );
 
-#ifdef _WIN32
+#if defined( _WIN32 ) && !defined( JACK_REPLACES_ASIO )
     // set Windows specific tool tip
     cbxSoundcard->setToolTip ( tr ( "If the ASIO4ALL driver is used, "
                                     "please note that this driver usually introduces approx. 10-30 ms of "
@@ -388,10 +388,10 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     chbDetectFeedback->setAccessibleName ( tr ( "Feedback Protection check box" ) );
 
     // init driver button
-#ifdef _WIN32
+#if defined( _WIN32 ) && !defined( JACK_REPLACES_ASIO )
     butDriverSetup->setText ( tr ( "ASIO Device Settings" ) );
 #else
-    // no use for this button for MacOS/Linux right now -> hide it
+    // no use for this button for MacOS/Linux right now or when using JACK -> hide it
     butDriverSetup->hide();
 #endif
 

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -96,7 +96,6 @@ public slots:
     void OnAudioQualityActivated ( int iQualityIdx );
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnMeterStyleActivated ( int iMeterStyleIdx );
-    void OnDriverSetupClicked();
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnAliasTextChanged ( const QString& strNewName );
     void OnInstrumentActivated ( int iCntryListItem );
@@ -106,6 +105,11 @@ public slots:
     void OnTabChanged();
     void OnMakeTabChange ( int iTabIdx );
     void OnAudioPanValueChanged ( int value );
+
+#if defined( _WIN32 ) && !defined( WITH_JACK )
+    // Only include this slot for Windows when JACK is NOT used
+    void OnDriverSetupClicked();
+#endif
 
 signals:
     void GUIDesignChanged();


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight foward -->

**Short description of changes**
Remove the ASIO Settings button in the Audio/Network Setting dialog when using JACK or when using macOS.
<!-- A short description of your changes which might go into the change log -->

**Context: Fixes an issue?**
Fixes: #2186
The ASIO sound dialog (from soundbase.cpp) is not displayed when using JACK.
Therefore it is only needed to remove the button from the settings dialog.
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Complete
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Nothing
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
