### PR TITLE
Correct minimum macOS version for legacy install

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -157,7 +157,11 @@ win32 {
         MACOSX_BUNDLE_ICON.path = Contents/Resources
         QMAKE_BUNDLE_DATA += MACOSX_BUNDLE_ICON
     } else {
-        QMAKE_INFO_PLIST = mac/Info-make.plist
+        equals(QT_VERSION, "5.9.9") {
+            QMAKE_INFO_PLIST = mac/Info-make-legacy.plist
+        } else {
+            QMAKE_INFO_PLIST = mac/Info-make.plist
+        }
     }
 
     LIBS += -framework CoreFoundation \

--- a/mac/Info-make-legacy.plist
+++ b/mac/Info-make-legacy.plist
@@ -21,7 +21,7 @@
         <key>LSApplicationCategoryType</key>
 	    <string>public.app-category.music</string>
         <key>LSMinimumSystemVersion</key>
-        <string>${MACOSX_DEPLOYMENT_TARGET}</string>
+        <string>10.10</string>
         <key>CFBundleExecutable</key>
         <string>@EXECUTABLE@</string>
         <key>CFBundleDevelopmentRegion</key>

--- a/mac/Info-xcode.plist
+++ b/mac/Info-xcode.plist
@@ -21,7 +21,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSMinimumSystemVersion</key>
-    <string>10.13.0</string>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
Allows recent Qt to set the macOS minimum target version, and provides a separate plist file for the Legacy build, that correctly specifies 10.10 as the minimum macOS version. (3.8.1 wrongly specified 10.13.0 as the minimum version for the legacy installer)

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2143 

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No documentation needed.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Tested building on Mojave with both 5.9.9 and 5.15.2 of Qt. ~Awaiting results of Github CI.~

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Test the assets created by the CI.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
