### PR TITLE
GUI: Load translations as early as possible to enable translated startup errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -795,6 +795,18 @@ int main ( int argc, char** argv )
         if ( bIsClient )
         {
             // Client:
+
+            // load settings from init-file (command line options override)
+            CClientSettings Settings ( strIniFileName );
+            Settings.LoadEarlySettings ( CommandLineOptions );
+
+            // load translation
+            if ( bUseGUI && bUseTranslation )
+            {
+                CLocale::LoadTranslation ( Settings.strLanguage, pApp );
+                CInstPictures::UpdateTableOnLanguageChange();
+            }
+
             // actual client object
             CClient Client ( iPortNumber,
                              iQosNumber,
@@ -805,17 +817,8 @@ int main ( int argc, char** argv )
                              bEnableIPv6,
                              bMuteMeInPersonalMix );
 
-            // load settings from init-file (command line options override)
-            CClientSettings Settings ( &Client, strIniFileName );
-            Settings.Load ( CommandLineOptions );
-
-            // load translation
-            if ( bUseGUI && bUseTranslation )
-            {
-                CLocale::LoadTranslation ( Settings.strLanguage, pApp );
-                CInstPictures::UpdateTableOnLanguageChange();
-            }
-
+            Settings.SetClient ( &Client );
+            Settings.LoadLateSettings ( CommandLineOptions );
 #ifndef HEADLESS
             if ( bUseGUI )
             {
@@ -846,6 +849,20 @@ int main ( int argc, char** argv )
         else
         {
             // Server:
+
+            CServerSettings Settings ( strIniFileName );
+            if ( bUseGUI )
+            {
+                // load settings from init-file (command line options override)
+                Settings.LoadEarlySettings ( CommandLineOptions );
+
+                // load translation
+                if ( bUseTranslation )
+                {
+                    CLocale::LoadTranslation ( Settings.strLanguage, pApp );
+                }
+            }
+
             // actual server object
             CServer Server ( iNumServerChannels,
                              strLoggingFileName,
@@ -872,14 +889,8 @@ int main ( int argc, char** argv )
             if ( bUseGUI )
             {
                 // load settings from init-file (command line options override)
-                CServerSettings Settings ( &Server, strIniFileName );
-                Settings.Load ( CommandLineOptions );
-
-                // load translation
-                if ( bUseGUI && bUseTranslation )
-                {
-                    CLocale::LoadTranslation ( Settings.strLanguage, pApp );
-                }
+                Settings.SetServer ( &Server );
+                Settings.LoadLateSettings ( CommandLineOptions );
 
                 // update server list AFTER restoring the settings from the
                 // settings file

--- a/src/settings.h
+++ b/src/settings.h
@@ -50,7 +50,8 @@ public:
         QObject::connect ( QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, &CSettings::OnAboutToQuit );
     }
 
-    void Load ( const QList<QString> CommandLineOptions );
+    void LoadEarlySettings ( const QList<QString> CommandLineOptions );
+    void LoadLateSettings ( const QList<QString> CommandLineOptions );
     void Save();
 
     // common settings
@@ -58,8 +59,9 @@ public:
     QString    strLanguage;
 
 protected:
-    virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument )                                                  = 0;
-    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions ) = 0;
+    virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument )                                                       = 0;
+    virtual void ReadEarlySettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions ) = 0;
+    virtual void ReadLateSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions )  = 0;
 
     void ReadFromFile ( const QString& strCurFileName, QDomDocument& XMLDocument );
 
@@ -109,7 +111,7 @@ public slots:
 class CClientSettings : public CSettings
 {
 public:
-    CClientSettings ( CClient* pNCliP, const QString& sNFiName ) :
+    CClientSettings ( const QString& sNFiName ) :
         CSettings(),
         vecStoredFaderTags ( MAX_NUM_STORED_FADER_SETTINGS, "" ),
         vecStoredFaderLevels ( MAX_NUM_STORED_FADER_SETTINGS, AUD_MIX_FADER_MAX ),
@@ -134,10 +136,12 @@ public:
         bWindowWasShownChat ( false ),
         bWindowWasShownConnect ( false ),
         bOwnFaderFirst ( false ),
-        pClient ( pNCliP )
+        pClient ( nullptr )
     {
         SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME );
     }
+
+    void SetClient ( CClient* pNCliP ) { pClient = pNCliP; };
 
     void LoadFaderSettings ( const QString& strCurFileName );
     void SaveFaderSettings ( const QString& strCurFileName );
@@ -173,7 +177,8 @@ public:
 protected:
     // No CommandLineOptions used when reading Client inifile
     virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument ) override;
-    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& ) override;
+    virtual void ReadEarlySettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& ) override;
+    virtual void ReadLateSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& ) override;
 
     void ReadFaderSettingsFromXML ( const QDomDocument& IniXMLDocument );
     void WriteFaderSettingsToXML ( QDomDocument& IniXMLDocument );
@@ -184,14 +189,13 @@ protected:
 class CServerSettings : public CSettings
 {
 public:
-    CServerSettings ( CServer* pNSerP, const QString& sNFiName ) : CSettings(), pServer ( pNSerP )
-    {
-        SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME_SERVER );
-    }
+    CServerSettings ( const QString& sNFiName ) : CSettings(), pServer ( nullptr ) { SetFileName ( sNFiName, DEFAULT_INI_FILE_NAME_SERVER ); }
+    void SetServer ( CServer* pNSerP ) { pServer = pNSerP; };
 
 protected:
     virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument ) override;
-    virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions ) override;
+    virtual void ReadEarlySettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions ) override;
+    virtual void ReadLateSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions ) override;
 
     CServer* pServer;
 };


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
This PR moves the translation loading to the earliest possible time. As translation loading depends on settings, this also implies that settings loading is moved to an earlier stage. However, this was only possible after splitting the setting loading into early settings (those which do not refer to `pClient` or `pServer`; this includes translations) and those who do rely on the respective object. The split means that the config has to be parsed twice. The alternative would be caching the parsed config, which occupies (a small amount of) memory and is prone to becoming out of date.

The alternative of the settings change would be to modify the Client (and possibly) Server initialization logic. This would imply moving most of the work out of CSound constructors into their own functions which could be explicitly called at a slightly later stage (after loading translations). However, this would be much more code moving as it would have to be done per-platform. Therefore, I decided to go the Settings reorg route.

**Context: Fixes an issue?**
This PR ensures that translations are available when the sound backends are started. It therefore fixes issues with untranslated sound-related error messages during startup (Fixes #2041).

CHANGELOG: GUI: Make startup errors translatable by loading translations as early as possible

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Working as expected on Linux/jack.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Other platforms should be tested:
- [ ] WIndows ASIO
- [ ] Windows JACK
- [ ] Mac
- [ ] (Android)
- [ ] (iOS)

In addition:
- [ ] It should be decided whether the usability improvements (translated startup error messages) are worth the code reorganization.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
