### PR TITLE
Jamulus.pro: Implement `(n)make clang_format`

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,3 +1,7 @@
-# exclude third party code from clang-format checks
+# Exclude third party code from clang-format checks.
+#
+# This file is used by the clang-format-lint-action on Github.
+# When updating this list, remember to update Jamulus.pro's CLANG_SOURCES
+# as well.
 ./libs
 ./windows/nsProcess

--- a/.github/workflows/coding-style-check.yml
+++ b/.github/workflows/coding-style-check.yml
@@ -18,4 +18,6 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@2a28e3a8d9553f244243f7e1ff94f6685dff87be
       with:
         clangFormatVersion: 10
+        # When updating the extension list, remember to update
+        # Jamulus.pro's CLANG_SOURCES as well.
         extensions: 'cpp,h,mm'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ If a feature or function can be achieved in another way by another system or met
 - Space before and after `(` and `)`, except no space between `)` and `;`, and no space before an empty `()`.
 - All bodies of `if`, `else`, `while`, `for`, etc., to be enclosed in braces `{` and `}`, on separate lines.
 
+You can use your editor's or IDE's clang-format support to accomplish that.
+On the command line, you can run `make clang_format` to do the same before committing.
+
 Do not use diff/patch to send your code changes but create a Github fork of the Jamulus code and create a Pull Request when you are done.
 
 Please run a local build test. Make sure there are no errors. After opening a pull request, keep an eye on the CI checks for quality or compile issues and fix them as required.

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1171,3 +1171,12 @@ contains(CONFIG, "disable_version_check") {
     message(The version check is disabled.)
     DEFINES += DISABLE_VERSION_CHECK
 }
+
+# Enable formatting all code via `make clang_format`.
+# Note: When extending the list of file extensions or when adding new code directories,
+# be sure to update .github/workflows/coding-style-check.yml and .clang-format-ignore as well.
+CLANG_FORMAT_SOURCES = $$files(*.cpp, true) $$files(*.mm, true) $$files(*.h, true)
+CLANG_FORMAT_SOURCES = $$find(CLANG_FORMAT_SOURCES, ^\(android|ios|mac|linux|src|windows\)/)
+CLANG_FORMAT_SOURCES ~= s!^\(windows/\(nsProcess|ASIOSDK2\)/|src/res/qrc_resources\.cpp\)\S*$!!g
+clang_format.commands = 'clang-format -i $$CLANG_FORMAT_SOURCES'
+QMAKE_EXTRA_TARGETS += clang_format


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
This simplifies submission of properly formatted code for users with no editor/IDE integration of clang-format (#1702).
It had previously been submitted as #1741 with larger scope (auto-fixing on build). This part has been removed.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Pays in on #1702.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
- [x] Contribution docs?

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready to be tested/reviewed.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- Tests (`make clang_format`):
  - [x] Linux
  - [x] Windows
  - [x] Mac
- Review

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want (on Linux; other platforms as mentioned above)
- [ ] ~My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)~ <!-- You can also check if your code passes clang-format --> no relevant style guide
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
