### PR TITLE
Bug Fix: Fix QRegularExpression-related compile error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,8 +28,9 @@
   (contributed by @ngocdh)
 
 - Client: Improved regex to highlight URLs in the chat window, avoiding terminating punctuation.
-  Also migrated from deprecated QRegExp to QRegularExpression, for future compatibility with Qt6 (#2124).
-  (contributed by @softins)
+  Also migrated from deprecated QRegExp to QRegularExpression, for future compatibility with
+  Qt6 (#2124, #2272, #2273).
+  (contributed by @softins, @corrados, @hoffie)
 
 - Client: Improved keyboard control of the list of Custom Directories (#2129).
   (contributed by @pljones)

--- a/src/chatdlg.h
+++ b/src/chatdlg.h
@@ -34,6 +34,7 @@
 #include <QAccessible>
 #include <QDesktopServices>
 #include <QMessageBox>
+#include <QRegularExpression>
 #include "global.h"
 #include "util.h"
 #include "ui_chatdlgbase.h"

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -31,6 +31,7 @@
 #include <QTimer>
 #include <QLocale>
 #include <QtConcurrent>
+#include <QRegularExpression>
 #include "global.h"
 #include "util.h"
 #include "settings.h"

--- a/src/util.h
+++ b/src/util.h
@@ -45,6 +45,7 @@
 #endif
 #include <QFile>
 #include <QDirIterator>
+#include <QRegularExpression>
 #include <QTranslator>
 #include <QLibraryInfo>
 #include <QUrl>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
b31e65033c796d5dc7e557b3753c14f67be718f8 updated regexps to QRegularExpression for Qt6 compatibility, but did not include QRegularExpression.h.

While this has apparently not been a problem in most environments, it breaks the build when using `CONFIG+=headless` (`CONFIG+="headless nosound"` is unaffected).

This PR adds the includes.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2272

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Reviews.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
