### PR TITLE
Client: Fix wrong truncation of unicode aliases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,8 +18,8 @@
 - Client: Added Conductor to list of instruments (#2140).
   (contributed by @henkdegroot)
 
-- Client: Fix wrong display of Unicode characters at line wrap (#1994).
-  (contributed by @djfun, @pljones)
+- Client: Fix wrong display of Unicode characters at line wrap and settings screen (#1994, #2274).
+  (contributed by @djfun, @pljones, @hoffie)
 
 - Client: Fixed incorrect operation of feedback detection on first connect in run (#2120).
   (contributed by @softins)

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -1093,7 +1093,7 @@ void CClientSettingsDlg::OnAliasTextChanged ( const QString& strNewName )
     else
     {
         // text is too long, update control with shortened text
-        pedtAlias->setText ( strNewName.left ( MAX_LEN_FADER_TAG ) );
+        pedtAlias->setText ( TruncateString ( strNewName, MAX_LEN_FADER_TAG ) );
     }
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -667,7 +667,7 @@ void CLanguageComboBox::OnLanguageActivated ( int iLanguageIdx )
     }
 }
 
-static inline QString TruncateString ( QString str, int position )
+QString TruncateString ( QString str, int position )
 {
     QTextBoundaryFinder tbfString ( QTextBoundaryFinder::Grapheme, str );
 

--- a/src/util.h
+++ b/src/util.h
@@ -99,6 +99,9 @@ inline int CalcBitRateBitsPerSecFromCodedBytes ( const int iCeltNumCodedBytes, c
 
 QString GetVersionAndNameStr ( const bool bDisplayInGui = true );
 QString MakeClientNameTitle ( QString win, QString client );
+#ifndef HEADLESS
+QString TruncateString ( QString str, int position );
+#endif
 
 /******************************************************************************\
 * CVector Base Class                                                           *


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
If the 16th char of the user-selected alias was a multi-byte unicode char, it would be incorrectly split in half, rendering it invalid. This commit makes the truncation unicode-aware.

The fix was initially developed in ce370e95d43b2051ba20160e5ec50f13b2de5748. It got lost during PR merge in commit a8853b6a7deb19e3596fb47bbb72a5baf29c4c7a, most likely during conflict resolution due to code reorganizations in d94fd69e1404a874beec53d6a721abcd74caf8fb.

This commit re-applies the fix to the new place (`CClientSettingsDlg::OnAliasTextChanged` instead of the no longer
existing `CMusProfDlg::OnAliasTextChanged`). It also adds a function declaration to the header to make inclusion by other files possible in the first place. This also required dropping the `static` and `inline` keywords.


Co-authored-by: @djfun

See #2274 for more context.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes: #1994 (for real)
Fixes: #2274

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No. ChangeLog has already been slightly adjusted to include this issue number.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready, should go into 3.8.2.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Needs review.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want (Linux)
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
