### PR TITLE
Autobuild: Use aqt install-qt to fix deprecation warning

### DIFF
--- a/autobuild/mac/artifacts/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_1_prepare.sh
@@ -15,7 +15,7 @@ QT_VER=$1
 
 echo "Install dependencies..."
 python3 -m pip install aqtinstall
-python3 -m aqt install --outputdir /usr/local/opt/qt ${QT_VER} mac desktop
+python3 -m aqt install-qt --outputdir /usr/local/opt/qt mac desktop ${QT_VER}
 
 # add the qt binaries to the path
 export -p PATH=/usr/local/opt/qt/${QT_VER}/clang_64/bin:"${PATH}"

--- a/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
@@ -15,7 +15,7 @@ QT_VER=$1
 
 echo "Install dependencies..."
 python3 -m pip install aqtinstall
-python3 -m aqt install --outputdir /usr/local/opt/qt ${QT_VER} mac desktop
+python3 -m aqt install-qt --outputdir /usr/local/opt/qt mac desktop ${QT_VER}
 
 # add the qt binaries to the path
 export -p PATH=/usr/local/opt/qt/${QT_VER}/clang_64/bin:"${PATH}"

--- a/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
@@ -29,7 +29,7 @@ if ( !$? )
 
 echo "Get Qt 64 bit..."
 # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
-aqt install --outputdir C:\Qt 5.15.2 windows desktop win64_msvc2019_64
+aqt install-qt --outputdir C:\Qt windows desktop 5.15.2 win64_msvc2019_64
 if ( !$? )
 {
 		throw "64bit Qt installation failed with exit code $LastExitCode"
@@ -37,7 +37,7 @@ if ( !$? )
 
 echo "Get Qt 32 bit..."
 # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
-aqt install --outputdir C:\Qt 5.15.2 windows desktop win32_msvc2019
+aqt install-qt --outputdir C:\Qt windows desktop 5.15.2 win32_msvc2019
 if ( !$? )
 {
 		throw "32bit Qt installation failed with exit code $LastExitCode"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
`aqt install` is deprecated.
`aqt install-qt` should be used instead.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2278.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No. Not Changelog-worthy:
CHANGELOG: SKIP

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- [x] CI logs should be checked

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
