### PR TITLE
Windows Build: Fail early on all errors 

### DIFF
--- a/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
@@ -12,6 +12,8 @@ param(
     [string] $BuildOption = ""
 )
 
+# Fail early on all errors
+$ErrorActionPreference = "Stop"
 
 ###################
 ###  PROCEDURE  ###
@@ -20,13 +22,26 @@ param(
 echo "Install Qt..."
 # Install Qt
 pip install aqtinstall
+if ( !$? )
+{
+		throw "pip install aqtinstall failed with exit code $LastExitCode"
+}
+
 echo "Get Qt 64 bit..."
 # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
 aqt install --outputdir C:\Qt 5.15.2 windows desktop win64_msvc2019_64
+if ( !$? )
+{
+		throw "64bit Qt installation failed with exit code $LastExitCode"
+}
 
 echo "Get Qt 32 bit..."
 # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
 aqt install --outputdir C:\Qt 5.15.2 windows desktop win32_msvc2019
+if ( !$? )
+{
+		throw "32bit Qt installation failed with exit code $LastExitCode"
+}
 
 
 #################################
@@ -38,9 +53,17 @@ if ($BuildOption -Eq "jackonwindows")
     echo "Install JACK2 64-bit..."
     # Install JACK2 64-bit
     choco install --no-progress -y jack
+    if ( !$? )
+    {
+        throw "64bit jack installation failed with exit code $LastExitCode"
+    }
 
     echo "Install JACK2 32-bit..."
     # Install JACK2 32-bit (need to force choco install as it detects 64 bits as installed)
     choco install --no-progress -y -f --forcex86 jack
+    if ( !$? )
+    {
+        throw "32bit jack installation failed with exit code $LastExitCode"
+    }
 }
 

--- a/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
@@ -66,4 +66,3 @@ if ($BuildOption -Eq "jackonwindows")
         throw "32bit jack installation failed with exit code $LastExitCode"
     }
 }
-

--- a/autobuild/windows/autobuild_windowsinstaller_2_build.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_2_build.ps1
@@ -2,7 +2,6 @@
 
 # autobuild_2_build: actual build process
 
-
 ####################
 ###  PARAMETERS  ###
 ####################
@@ -12,6 +11,10 @@ param (
     [string] $jamulus_project_path = $Env:jamulus_project_path,
     [string] $BuildOption = ""
 )
+
+# Fail early on all errors
+$ErrorActionPreference = "Stop"
+
 # Sanity check of parameters
 if (("$jamulus_project_path" -eq $null) -or ("$jamulus_project_path" -eq "")) {
     throw "expecting ""jamulus_project_path"" as parameter or ENV"
@@ -35,4 +38,8 @@ if ($BuildOption -ne "")
 else
 {
     powershell "$jamulus_project_path\windows\deploy_windows.ps1" "C:\Qt\5.15.2"
+}
+if ( !$? )
+{
+    throw "deploy_windows.ps1 failed with exit code $LastExitCode"
 }

--- a/autobuild/windows/autobuild_windowsinstaller_2_build.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_2_build.ps1
@@ -19,7 +19,7 @@ $ErrorActionPreference = "Stop"
 if (("$jamulus_project_path" -eq $null) -or ("$jamulus_project_path" -eq "")) {
     throw "expecting ""jamulus_project_path"" as parameter or ENV"
 } elseif (!(Test-Path -Path $jamulus_project_path)) {
-    throw "non.existing jamulus_project_path: $jamulus_project_path"
+    throw "non-existing jamulus_project_path: $jamulus_project_path"
 } else {
     echo "jamulus_project_path is valid: $jamulus_project_path"
 }

--- a/autobuild/windows/autobuild_windowsinstaller_3_copy_files.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_3_copy_files.ps1
@@ -2,7 +2,6 @@
 
 # autobuild_3_copy_files: copy the built files to deploy folder
 
-
 ####################
 ###  PARAMETERS  ###
 ####################
@@ -13,6 +12,10 @@ param (
     [string] $jamulus_buildversionstring = $Env:jamulus_buildversionstring,
     [string] $BuildOption = ""
 )
+
+# Fail early on all errors
+$ErrorActionPreference = "Stop"
+
 # Sanity check of parameters
 if (("$jamulus_project_path" -eq $null) -or ("$jamulus_project_path" -eq "")) {
     throw "expecting ""jamulus_project_path"" as parameter or ENV"
@@ -51,6 +54,10 @@ else
 
 echo "rename deploy file to $artifact_deploy_filename"
 cp "$jamulus_project_path\deploy\Jamulus*installer-win.exe" "$jamulus_project_path\deploy\$artifact_deploy_filename"
+if ( !$? )
+{
+		throw "cp failed with exit code $LastExitCode";
+}
 
 
 Function github_output_value

--- a/autobuild/windows/autobuild_windowsinstaller_3_copy_files.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_3_copy_files.ps1
@@ -41,8 +41,8 @@ switch ($BuildOption)
 ###  PROCEDURE  ###
 ###################
 
-# Rename the file
-echo "rename"
+# Copy the file
+echo "copy"
 if ($BuildOption -ne "")
 {
     $artifact_deploy_filename = "jamulus_${Env:jamulus_buildversionstring}_win_${BuildOption}.exe"
@@ -52,7 +52,7 @@ else
     $artifact_deploy_filename = "jamulus_${Env:jamulus_buildversionstring}_win.exe"
 }
 
-echo "rename deploy file to $artifact_deploy_filename"
+echo "copying deploy file to $artifact_deploy_filename"
 cp "$jamulus_project_path\deploy\Jamulus*installer-win.exe" "$jamulus_project_path\deploy\$artifact_deploy_filename"
 if ( !$? )
 {

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -1,4 +1,4 @@
-param(
+param (
     # Replace default path with system Qt installation folder if necessary
     [string] $QtInstallPath = "C:\Qt\5.15.2",
     [string] $QtCompile32 = "msvc2019",
@@ -10,6 +10,9 @@ param(
     [string] $BuildOption = ""
 )
 
+# Fail early on all errors
+$ErrorActionPreference = "Stop"
+
 # change directory to the directory above (if needed)
 Set-Location -Path "$PSScriptRoot\..\"
 
@@ -19,10 +22,6 @@ $BuildPath = "$RootPath\build"
 $DeployPath = "$RootPath\deploy"
 $WindowsPath ="$RootPath\windows"
 $AppName = "Jamulus"
-
-# Stop at all errors
-$ErrorActionPreference = "Stop"
-
 
 # Execute native command with errorlevel handling
 Function Invoke-Native-Command {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
Currently, build errors such as failure to download Qt do not fail the script. As such, they do not fail the workflow step either. The workflow continues and fails at a very late stage, which is annoying and wastes ressources.
    
This commit sets `$ErrorActionPreference = "Stop"` for all relevant PowerShell scripts in order to fail early for PowerShell-internal errors.
    
This commits also adds exit code checks for all relevant external commands as PowerShell does not consider them to be errors otherwise.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2276

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No. Does not need a ChangeLog entry either.
CHANGELOG: SKIP

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Ready.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want: **A [synthetically introduced error](https://github.com/hoffie/jamulus/commit/0c558504818e3be11e461371c1350de5197723a5) fails [the workflow](https://github.com/hoffie/jamulus/runs/4940760373?check_suite_focus=true) as expected.**
- [ ] ~My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)~ <!-- You can also check if your code passes clang-format --> no relevant style guide
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
