### PR TITLE
Autobuild: Refactor & use actions/cache

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -169,6 +169,38 @@ jobs:
         with:
           submodules:               true
 
+      # Enable caching of downloaded dependencies
+      - name:                       "Cache Mac dependencies"
+        if:                         ${{ matrix.config.target_os == 'macos' }}
+        uses:                       actions/cache@v2
+        with:
+          path: |
+            /usr/local/opt/qt
+            ~/Library/Caches/pip
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/mac/artifacts/autobuild_mac_1_prepare.sh', 'autobuild/mac/codeQL/autobuild_mac_1_prepare.sh') }}-${{ matrix.config.cmd1_prebuild }}
+
+      - name:                       "Cache Windows dependencies"
+        if:                         ${{ matrix.config.target_os == 'windows' }}
+        uses:                       actions/cache@v2
+        with:
+          path: |
+            C:\Qt
+            C:\ChocoCache
+            ~\AppData\Local\pip\Cache
+            ~\windows\NSIS
+            ~\windows\ASIOSDK2
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.cmd1_prebuild }}
+
+      - name:                       "Cache Android dependencies"
+        if:                         ${{ matrix.config.target_os == 'android' }}
+        uses:                       actions/cache@v2
+        with:
+          path: |
+            /opt/Qt
+            /opt/android/android-sdk
+            /opt/android/android-ndk
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/android/autobuild_apk_1_prepare.sh', 'autobuild/android/install-qt.sh') }}-${{ matrix.config.cmd1_prebuild }}
+
       # Prepare (install QT & dependencies)
       - name:                       "Prepare for ${{ matrix.config.config_name }}"
         if:                         ${{ matrix.config.cmd1_prebuild }}

--- a/autobuild/android/autobuild_apk_1_prepare.sh
+++ b/autobuild/android/autobuild_apk_1_prepare.sh
@@ -34,18 +34,26 @@ export ANDROID_NDK_HOST="linux-x86_64"
 export ANDROID_SDKMANAGER="${COMMANDLINETOOLS_DIR}/bin/sdkmanager"
 
 # paths for Android SDK
-mkdir -p "${COMMANDLINETOOLS_DIR}"
 mkdir -p "${ANDROID_SDK_ROOT}"/build-tools/latest/
 
 # Install Android sdk
-wget -q -O downloadfile https://dl.google.com/android/repository/commandlinetools-linux-${COMMANDLINETOOLS_VERSION}_latest.zip
-unzip -q downloadfile
-mv cmdline-tools/* "${COMMANDLINETOOLS_DIR}"
+if [[ -d "${COMMANDLINETOOLS_DIR}" ]]; then
+    echo "Using commandlinetools installation from previous run (actions/cache)"
+else
+    mkdir -p "${COMMANDLINETOOLS_DIR}"
+    wget -q -O downloadfile https://dl.google.com/android/repository/commandlinetools-linux-${COMMANDLINETOOLS_VERSION}_latest.zip
+    unzip -q downloadfile
+    mv cmdline-tools/* "${COMMANDLINETOOLS_DIR}"
+fi
 
 # Install Android ndk
-wget -q -O downloadfile https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip
-unzip -q downloadfile
-mv android-ndk-${ANDROID_NDK_VERSION} "${ANDROID_NDK_ROOT}"
+if [[ -d "${ANDROID_NDK_ROOT}" ]]; then
+    echo "Using NDK installation from previous run (actions/cache)"
+else
+    wget -q -O downloadfile https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip
+    unzip -q downloadfile
+    mv android-ndk-${ANDROID_NDK_VERSION} "${ANDROID_NDK_ROOT}"
+fi
 
 # Install Android SDK
 yes | "${ANDROID_SDKMANAGER}" --licenses

--- a/autobuild/mac/artifacts/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/artifacts/autobuild_mac_1_prepare.sh
@@ -15,9 +15,13 @@ AQTINSTALL_VERSION=2.0.5
 ###  PROCEDURE  ###
 ###################
 
-echo "Install dependencies..."
-python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
-python3 -m aqt install-qt --outputdir "${QT_DIR}" mac desktop ${QT_VER}
+if [[ -d "${QT_DIR}" ]]; then
+    echo "Using Qt installation from previous run (actions/cache)"
+else
+    echo "Install dependencies..."
+    python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
+    python3 -m aqt install-qt --outputdir "${QT_DIR}" mac desktop ${QT_VER}
+fi
 
 # Add the qt binaries to the PATH.
 # The clang_64 entry can be dropped when Qt <6.2 compatibility is no longer needed.

--- a/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_1_prepare.sh
@@ -15,9 +15,13 @@ AQTINSTALL_VERSION=2.0.5
 ###  PROCEDURE  ###
 ###################
 
-echo "Install dependencies..."
-python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
-python3 -m aqt install-qt --outputdir "${QT_DIR}" mac desktop ${QT_VER}
+if [[ -d "${QT_DIR}" ]]; then
+    echo "Using Qt installation from previous run (actions/cache)"
+else
+    echo "Install dependencies..."
+    python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
+    python3 -m aqt install-qt --outputdir "${QT_DIR}" mac desktop ${QT_VER}
+fi
 
 # Add the qt binaries to the PATH.
 # The clang_64 entry can be dropped when Qt <6.2 compatibility is no longer needed.

--- a/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
@@ -20,34 +20,42 @@ $ErrorActionPreference = "Stop"
 ###################
 
 $QtDir = 'C:\Qt'
+$ChocoCacheDir = 'C:\ChocoCache'
 $Qt32Version = "5.15.2"
 $Qt64Version = "5.15.2"
 $AqtinstallVersion = "2.0.5"
 $JackVersion = "1.9.17"
 $MsvcVersion = "2019"
 
-echo "Install Qt..."
-# Install Qt
-pip install "aqtinstall==$AqtinstallVersion"
-if ( !$? )
+if ( Test-Path -Path $QtDir )
 {
-		throw "pip install aqtinstall failed with exit code $LastExitCode"
+    echo "Using Qt installation from previous run (actions/cache)"
 }
-
-echo "Get Qt 64 bit..."
-# intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
-aqt install-qt --outputdir "${QtDir}" windows desktop "${Qt64Version}" "win64_msvc${MsvcVersion}_64"
-if ( !$? )
+else
 {
-		throw "64bit Qt installation failed with exit code $LastExitCode"
-}
+    echo "Install Qt..."
+    # Install Qt
+    pip install "aqtinstall==$AqtinstallVersion"
+    if ( !$? )
+    {
+        throw "pip install aqtinstall failed with exit code $LastExitCode"
+    }
 
-echo "Get Qt 32 bit..."
-# intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
-aqt install-qt --outputdir "${QtDir}" windows desktop "${Qt32Version}" "win32_msvc${MsvcVersion}"
-if ( !$? )
-{
-		throw "32bit Qt installation failed with exit code $LastExitCode"
+    echo "Get Qt 64 bit..."
+    # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
+    aqt install-qt --outputdir "${QtDir}" windows desktop "${Qt64Version}" "win64_msvc${MsvcVersion}_64"
+    if ( !$? )
+    {
+        throw "64bit Qt installation failed with exit code $LastExitCode"
+    }
+
+    echo "Get Qt 32 bit..."
+    # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
+    aqt install-qt --outputdir "${QtDir}" windows desktop "${Qt32Version}" "win32_msvc${MsvcVersion}"
+    if ( !$? )
+    {
+            throw "32bit Qt installation failed with exit code $LastExitCode"
+    }
 }
 
 
@@ -57,6 +65,8 @@ if ( !$? )
 
 if ($BuildOption -Eq "jackonwindows")
 {
+    choco config set cacheLocation $ChocoCacheDir
+
     echo "Install JACK2 64-bit..."
     # Install JACK2 64-bit
     choco install --no-progress -y jack --version "${JackVersion}"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
This PR introduces an actions/cache step for Android, Mac and Windows builds. For Linux, this makes little sense as all dependencies are installed via apt, which should be almost locally anyway (Azure apt mirror).
    
For the caching to be effective and correct, all cached versions must be pinned. This is permits the caching logic to invalidate caches automatically based on a key (script content + invocation paramters). Pinning has partly been implemented already (Qt, NSIS, ASIOSDK, Android Command Line Tools, Android NDK, Android SDK). In addition, this PR requires #2345 which introduces version pinning for JACK and aqtinstaller.
    
The following environments are cached:
- Qt installation directory (Windows, Mac, Android)
- pip cache (Windows, Mac)
- choco cache (Windows)
- Android SDK & NDK (Android)
    
The cache is used if the workflow-provided calls (which include Qt versions) are unchanged and if certain files (most notably autobuild.yml, prepare scripts and prepare script dependencies) are unchanged. If anything changes, the cache is not used. Instead, everything starts clean and the result is cached for further reuse again.
    
Goals of this PR:
- Increase resilience against temporary external outages (e.g. Qt mirror problems)
- Make builds more deterministic
- Speed up builds by avoiding repeated downloads and some extractions

Risks:
- If we get our cache key wrong we might end up building in an unexpected build environment state. I took care to ensure that we fail in such cases, but there is no guarantee. We should check the cache keys extensively. Cache invalidation is hard (on the other hand: The [actions/cache](https://github.com/actions/cache) seems to be wildly used).
- Github Actions caches are limited to 10GB. If we reach this limit, old cache keys are evicted automatically and we no longer profit from caching. A full autobuild run corrently takes about 2300 MB (with Android taking the vast amount of it). Unless there are lots of pending PRs which touch autobuild-related code, this should cover our use case most of the time. See https://github.com/jamulussoftware/jamulus/issues/2277#issuecomment-1022014373 for further details.

Several refactorings in the build scripts have been necessary to be able to introduce those features. Therefore, they are part of this PR. In order to keep history clean and make review easier, they have been extracted as individual commits:
- Define versions and paths as variables
- Android: Avoid cleanups, condense calls
- Clean up Android Docker leftovers
- Use bash consistently

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2277

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
**Not** ready for merge. Should wait for 3.9.0.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- [x] #2276 should be merged first to avoid caching failed builds
- [ ] Thorough review of the Cache paths and `key` logic
- [ ] All officially supported release artifacts should be validated
  - [ ] Windows
  - [ ] Windows JACK (?)
  - [ ] Mac
  - [ ] Mac Legacy
  - [ ] Debian/Ubuntu

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [ ] ~My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)~ <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
