### PR TITLE
Actions: Don't run copyright workflow on forks & Fix duplicate invocation

### DIFF
--- a/.github/workflows/update-copyright-notices.yml
+++ b/.github/workflows/update-copyright-notices.yml
@@ -32,7 +32,7 @@ jobs:
             gh pr comment "${existing_pr}" --body "PR has been updated by tools/update-copyright-notices.sh."
           else
             body=$'This automated Pull Request updates the copyright notices throughout the source.\n\n'
-            body="${body}This PR is the result of a `tools/update-copyright-notices.sh` run."
+            body="${body}This PR is the result of a tools/update-copyright-notices.sh run."
             gh pr create --base master --head "${pr_branch}" --title "Update copyright notice(s) for $(date +%Y)" --body "${body}"
           fi
 

--- a/.github/workflows/update-copyright-notices.yml
+++ b/.github/workflows/update-copyright-notices.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   check-and-update-copyright-notices:
-    if: ${{ github.event_name == 'push' }}
+    if: >-
+      github.repository_owner == 'jamulussoftware' &&
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -36,6 +38,7 @@ jobs:
 
   delete-old-pr-branch:
     if: >-
+      github.repository_owner == 'jamulussoftware' &&
       github.event_name == 'pull_request' &&
       startsWith(github.event.pull_request.head.label, 'jamulussoftware:updateCopyrightNotices')
     runs-on: ubuntu-latest

--- a/tools/update-copyright-notices.sh
+++ b/tools/update-copyright-notices.sh
@@ -3,9 +3,9 @@ set -eu
 
 YEAR=$(date +%Y)
 echo "Updating global copyright strings..."
-sed -re 's/(Copyright.*2[0-9]{3}-)[0-9]{4}/\1'$YEAR'/g' -i src/res/translation/*.ts src/util.cpp src/aboutdlgbase.ui
+sed -re 's/(Copyright.*2[0-9]{3}-)[0-9]{4}/\1'"${YEAR}"'/g' -i src/res/translation/*.ts src/util.cpp src/aboutdlgbase.ui
 
 echo "Updating copyright comment headers..."
 for file in $(find android ios linux mac src windows -regex '.*\.\(cpp\|h\|mm\)' -not -regex '\./\(\.git\|libs/\|moc_\|ui_\).*'); do
-		sed -re 's/(\*.*Copyright.*[^-][0-9]{4})(\s*-\s*\b[0-9]{4})?\s*$/\1-'${YEAR}'/' -i "${file}"
+		sed -re 's/(\*.*Copyright.*[^-][0-9]{4})(\s*-\s*\b[0-9]{4})?\s*$/\1-'"${YEAR}"'/' -i "${file}"
 done


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
- Currently, the workflow will also run on pushes to `master` in forks. This creates PRs in the forks. This is not what is usually wanted or expected. Therefore, only run when the repo owner is jamulussoftware.
- The body text contained the script file name within accents. This lead to bash running the script twice. The output looked strange.
- The bash script lacks quotes in two places, which Codacy told me just now.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
https://github.com/jamulussoftware/jamulus/pull/2285#issuecomment-1022484856

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.
CHANGELOG: SKIP

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Ready.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [ ] ~My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)~ <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
