### PR TITLE
src/buffer.cpp: Avoid CodeQL warning about multiplication overflow

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -146,6 +146,7 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
         const int iNumBlocks = /* floor */ ( iInSize / iBlockSize );
 
         // copy new data in internal buffer
+        // iBlock is a long to avoid overflowing a mulitplication later in the code
         for ( long iBlock = 0; iBlock < iNumBlocks; iBlock++ )
         {
             // extract sequence number of current received block (per definition
@@ -263,6 +264,7 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
         // copy new data in internal buffer
         const int iNumBlocks = iInSize / iBlockSize;
 
+        // iBlock is a long to avoid overflowing a mulitplication later in the code
         for ( long iBlock = 0; iBlock < iNumBlocks; iBlock++ )
         {
             // for simultion buffer only update pointer, no data copying

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -146,7 +146,7 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
         const int iNumBlocks = /* floor */ ( iInSize / iBlockSize );
 
         // copy new data in internal buffer
-        for ( int iBlock = 0; iBlock < iNumBlocks; iBlock++ )
+        for ( long iBlock = 0; iBlock < iNumBlocks; iBlock++ )
         {
             // extract sequence number of current received block (per definition
             // the sequence number is appended after the coded audio data)
@@ -263,7 +263,7 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
         // copy new data in internal buffer
         const int iNumBlocks = iInSize / iBlockSize;
 
-        for ( int iBlock = 0; iBlock < iNumBlocks; iBlock++ )
+        for ( long iBlock = 0; iBlock < iNumBlocks; iBlock++ )
         {
             // for simultion buffer only update pointer, no data copying
             if ( !bIsSimulation )


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
Satisfy CodeQL multiplication overflow warnings by changing a loop variable from `int` to `long`

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes some high-severity code alerts raised by Github, even though they wouldn't be encountered in practice.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No documentation needed

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Trivial change, ready to merge

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Validate that the warnings on `src/buffer.cpp` are no longer raised by Github

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
