### PR TITLE
Hoist block offset multiplication to top of the loops

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -146,12 +146,14 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
         const int iNumBlocks = /* floor */ ( iInSize / iBlockSize );
 
         // copy new data in internal buffer
-        // iBlock is a long to avoid overflowing a mulitplication later in the code
-        for ( long iBlock = 0; iBlock < iNumBlocks; iBlock++ )
+        for ( int iBlock = 0; iBlock < iNumBlocks; iBlock++ )
         {
+            // calculate the block offset once per loop instead of repeated multiplying
+            const int iBlockOffset = iBlock * ( iBlockSize + iNumBytesSeqNum );
+
             // extract sequence number of current received block (per definition
             // the sequence number is appended after the coded audio data)
-            const int iCurrentSequenceNumber = vecbyData[iBlock * ( iBlockSize + iNumBytesSeqNum ) + iBlockSize];
+            const int iCurrentSequenceNumber = vecbyData[iBlockOffset + iBlockSize];
 
             // calculate the sequence number difference and take care of wrap
             int iSeqNumDiff = iCurrentSequenceNumber - static_cast<int> ( iSequenceNumberAtGetPos );
@@ -243,9 +245,7 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
             if ( !bIsSimulation )
             {
                 // copy one block of data in buffer
-                std::copy ( vecbyData.begin() + iBlock * ( iBlockSize + iNumBytesSeqNum ),
-                            vecbyData.begin() + iBlock * ( iBlockSize + iNumBytesSeqNum ) + iBlockSize,
-                            vecvecMemory[iBlockPutPos].begin() );
+                std::copy ( vecbyData.begin() + iBlockOffset, vecbyData.begin() + iBlockOffset + iBlockSize, vecvecMemory[iBlockPutPos].begin() );
             }
 
             // valid packet added, set flag
@@ -264,16 +264,16 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
         // copy new data in internal buffer
         const int iNumBlocks = iInSize / iBlockSize;
 
-        // iBlock is a long to avoid overflowing a mulitplication later in the code
-        for ( long iBlock = 0; iBlock < iNumBlocks; iBlock++ )
+        for ( int iBlock = 0; iBlock < iNumBlocks; iBlock++ )
         {
             // for simultion buffer only update pointer, no data copying
             if ( !bIsSimulation )
             {
+                // calculate the block offset once per loop instead of repeated multiplying
+                const int iBlockOffset = iBlock * iBlockSize;
+
                 // copy one block of data in buffer
-                std::copy ( vecbyData.begin() + iBlock * iBlockSize,
-                            vecbyData.begin() + iBlock * iBlockSize + iBlockSize,
-                            vecvecMemory[iBlockPutPos].begin() );
+                std::copy ( vecbyData.begin() + iBlockOffset, vecbyData.begin() + iBlockOffset + iBlockSize, vecvecMemory[iBlockPutPos].begin() );
             }
 
             // set the put position one block further

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1041,7 +1041,7 @@ void CServer::DecodeReceiveData ( const int iChanCnt, const int iNumClients )
         // get current number of OPUS coded bytes
         const int iCeltNumCodedBytes = vecChannels[iCurChanID].GetCeltNumCodedBytes();
 
-        for ( size_t iB = 0; iB < (size_t) vecNumFrameSizeConvBlocks[iChanCnt]; iB++ )
+        for ( int iB = 0; iB < vecNumFrameSizeConvBlocks[iChanCnt]; iB++ )
         {
             // get data
             const EGetDataStat eGetStat = vecChannels[iCurChanID].GetData ( vecvecbyCodedData[iChanCnt], iCeltNumCodedBytes );
@@ -1081,10 +1081,12 @@ void CServer::DecodeReceiveData ( const int iChanCnt, const int iNumClients )
             // OPUS decode received data stream
             if ( CurOpusDecoder != nullptr )
             {
+                const int iOffset = iB * SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt];
+
                 iUnused = opus_custom_decode ( CurOpusDecoder,
                                                pCurCodedData,
                                                iCeltNumCodedBytes,
-                                               &vecvecsData[iChanCnt][iB * SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt]],
+                                               &vecvecsData[iChanCnt][iOffset],
                                                iClientFrameSizeSamples );
             }
         }
@@ -1354,10 +1356,12 @@ void CServer::MixEncodeTransmitData ( const int iChanCnt, const int iNumClients 
 opus_custom_encoder_ctl ( pCurOpusEncoder, OPUS_SET_BITRATE ( CalcBitRateBitsPerSecFromCodedBytes ( iCeltNumCodedBytes, iClientFrameSizeSamples ) ) );
             // clang-format on
 
-            for ( size_t iB = 0; iB < (size_t) vecNumFrameSizeConvBlocks[iChanCnt]; iB++ )
+            for ( int iB = 0; iB < vecNumFrameSizeConvBlocks[iChanCnt]; iB++ )
             {
+                const int iOffset = iB * SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt];
+
                 iUnused = opus_custom_encode ( pCurOpusEncoder,
-                                               &vecsSendData[iB * SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt]],
+                                               &vecsSendData[iOffset],
                                                iClientFrameSizeSamples,
                                                &vecvecbyCodedData[iChanCnt][0],
                                                iCeltNumCodedBytes );


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
Improve buffer offset calculation to avoid multiplication overflow warnings and improve efficiency

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
#2292 did not fix the CodeQL warnings, so this is an alternative and better approach.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready and should work.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
~Smoke test with a server or client.~ Client built on Pi works fine.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
