### PR TITLE
Autobuild: Use Qt6 for Windows 64bit

### DIFF
--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -20,7 +20,7 @@ $DownloadCacheDir = 'C:\AutobuildCache'
 # The following version pinnings are semi-automatically checked for
 # updates. Verify .github/workflows/bump-dependencies.yaml when changing those manually:
 $Qt32Version = "5.15.2"
-$Qt64Version = "5.15.2"
+$Qt64Version = "6.4.3"
 $AqtinstallVersion = "3.1.5"
 $JackVersion = "1.9.22"
 $Msvc32Version = "win32_msvc2019"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
This PR switches the Autobuilds (and therefore: the releases!) to use Qt 6 for Windows 64bit builds.
The PR depends on the already merged PRs #2299 (initial Qt6 code compatibility) and #2328 (build logic Qt6 compatibility)
It only contains three small additional commits:
- Autobuild: Windows: Build with Qt 6.~3.1~5.0 on 64bit
  32bit builds remain on 5.15.2, as Qt6 is not available there.

Code-wise this is the smaller change. Change-wise it is the more relevant, more invasive one.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
See #2299

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
CHANGELOG: Build: Windows 64bit releases use Qt 6.5.0 now.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for testing

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- [x] Wait for merge of #2299 (Build would fail otherwise)
- [x] Wait for merge of #2328 (Merge will conflict otherwise)
- [x] Testing of all officially supported and affected release artifacts on relevant platforms (via beta/rc)
  - [ ] Windows 10
  - [x] Windows 11
  - [x] Mac
- [x] Check if Qt6 drops support for any older platform versions (docs: [Qt5](https://doc.qt.io/qt-5/supported-platforms.html), [Qt6](https://doc.qt.io/qt-6/supported-platforms.html))
  - [x] Qt6 no longer officially supports Windows 7 and 8.1 (see comments)
  - [x] Qt6 no longer supports macOS versions on or before 10.13. I guess that's OK because we still have the legacy build for those users? (@softins: "So if we build with Qt6, High Sierra users on 10.13 would need to start using the legacy build.")

I'm hoping to merge this for 3.9.0, but if any critical issues are found or if there's too little testing, we should postpone it.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
