### PR TITLE
Add fallback for Qt downloads

### DIFF
--- a/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
@@ -15,6 +15,25 @@ param(
 # Fail early on all errors
 $ErrorActionPreference = "Stop"
 
+Function Install-Qt {
+    param(
+        [string] $QtVersion,
+        [string] $QtArch,
+        [string] $InstallDir
+    )
+    $Args = ("--outputdir", "$InstallDir", "windows", "desktop", "$QtVersion", "$QtArch")
+    aqt install-qt @Args
+    if ( !$? )
+    {
+        echo "WARNING: Qt installation via first aqt run failed, re-starting with different base URL."
+        aqt install-qt @Args -b https://mirrors.ocf.berkeley.edu/qt/
+        if ( !$? )
+        {
+            throw "Qt installation with args @Arguments failed with exit code $LastExitCode"
+        }
+    }
+}
+
 ###################
 ###  PROCEDURE  ###
 ###################
@@ -25,7 +44,8 @@ $Qt32Version = "5.15.2"
 $Qt64Version = "5.15.2"
 $AqtinstallVersion = "2.0.5"
 $JackVersion = "1.9.17"
-$MsvcVersion = "2019"
+$Msvc32Version = "win32_msvc2019"
+$Msvc64Version = "win64_msvc2019_64"
 
 if ( Test-Path -Path $QtDir )
 {
@@ -42,20 +62,10 @@ else
     }
 
     echo "Get Qt 64 bit..."
-    # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
-    aqt install-qt --outputdir "${QtDir}" windows desktop "${Qt64Version}" "win64_msvc${MsvcVersion}_64"
-    if ( !$? )
-    {
-        throw "64bit Qt installation failed with exit code $LastExitCode"
-    }
+    Install-Qt ${Qt64Version} ${Msvc64Version} ${QtDir}
 
     echo "Get Qt 32 bit..."
-    # intermediate solution if the main server is down: append e.g. " -b https://mirrors.ocf.berkeley.edu/qt/" to the "aqt"-line below
-    aqt install-qt --outputdir "${QtDir}" windows desktop "${Qt32Version}" "win32_msvc${MsvcVersion}"
-    if ( !$? )
-    {
-            throw "32bit Qt installation failed with exit code $LastExitCode"
-    }
+    Install-Qt ${Qt32Version} ${Msvc32Version} ${QtDir}
 }
 
 


### PR DESCRIPTION
Adds a fallback mirror for Qt on failure. Proposed by @dtinth

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
Changes the Qt mirror on error. 

**Context: Fixes an issue?**
Autobuild currently fails quite often

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No
**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
Waiting on Review

**What is missing until this pull request can be merged?**
Review

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
