### PR TITLE
Add MIDI control option for Mute Myself function

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -164,6 +164,8 @@ CClient::CClient ( const quint16  iPortNumber,
 
     QObject::connect ( &Sound, &CSound::ControllerInFaderIsMute, this, &CClient::OnControllerInFaderIsMute );
 
+    QObject::connect ( &Sound, &CSound::ControllerInMuteMyself, this, &CClient::OnControllerInMuteMyself );
+
     QObject::connect ( &Socket, &CHighPrioSocket::InvalidPacketReceived, this, &CClient::OnInvalidPacketReceived );
 
     QObject::connect ( pSignalHandler, &CSignalHandler::HandledSignal, this, &CClient::OnHandledSignal );
@@ -702,6 +704,17 @@ void CClient::OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute )
 #endif
 
     emit ControllerInFaderIsMute ( iChannelIdx, bIsMute );
+}
+
+void CClient::OnControllerInMuteMyself ( bool bMute )
+{
+    // in case of a headless client the buttons are not displayed so we need
+    // to send the controller information directly to the server
+#ifdef HEADLESS
+    // FIXME: no idea what to do here.
+#endif
+
+    emit ControllerInMuteMyself ( bMute );
 }
 
 void CClient::OnClientIDReceived ( int iChanID )

--- a/src/client.h
+++ b/src/client.h
@@ -393,6 +393,7 @@ protected slots:
     void OnControllerInPanValue ( int iChannelIdx, int iValue );
     void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
+    void OnControllerInMuteMyself ( bool bMute );
     void OnClientIDReceived ( int iChanID );
 
 signals:
@@ -423,4 +424,5 @@ signals:
     void ControllerInPanValue ( int iChannelIdx, int iValue );
     void ControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void ControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
+    void ControllerInMuteMyself ( bool bMute );
 };

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -507,6 +507,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     QObject::connect ( pClient, &CClient::ControllerInFaderIsMute, this, &CClientDlg::OnControllerInFaderIsMute );
 
+    QObject::connect ( pClient, &CClient::ControllerInMuteMyself, this, &CClientDlg::OnControllerInMuteMyself );
+
     QObject::connect ( pClient, &CClient::CLChannelLevelListReceived, this, &CClientDlg::OnCLChannelLevelListReceived );
 
     QObject::connect ( pClient, &CClient::VersionAndOSReceived, this, &CClientDlg::OnVersionAndOSReceived );

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -147,6 +147,8 @@ public slots:
 
     void OnControllerInFaderIsMute ( const int iChannelIdx, const bool bIsMute ) { MainMixerBoard->SetFaderIsMute ( iChannelIdx, bIsMute ); }
 
+    void OnControllerInMuteMyself ( const bool bMute ) { chbLocalMute->setChecked ( bMute ); }
+
     void OnVersionAndOSReceived ( COSUtil::EOpSystemType, QString strVersion );
 
     void OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType, QString strVersion );

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -28,11 +28,12 @@
 // a single character to an EMidiCtlType
 char const sMidiCtlChar[] = {
     // Has to follow order of EMidiCtlType
-    /* [EMidiCtlType::Fader] = */ 'f',
-    /* [EMidiCtlType::Pan]   = */ 'p',
-    /* [EMidiCtlType::Solo]  = */ 's',
-    /* [EMidiCtlType::Mute]  = */ 'm',
-    /* [EMidiCtlType::None]  = */ '\0' };
+    /* [EMidiCtlType::Fader]       = */ 'f',
+    /* [EMidiCtlType::Pan]         = */ 'p',
+    /* [EMidiCtlType::Solo]        = */ 's',
+    /* [EMidiCtlType::Mute]        = */ 'm',
+    /* [EMidiCtlType::MuteMyself]  = */ 'o',
+    /* [EMidiCtlType::None]        = */ '\0' };
 
 /* Implementation *************************************************************/
 CSoundBase::CSoundBase ( const QString& strNewSystemDriverTechniqueName,
@@ -390,6 +391,12 @@ void CSoundBase::ParseMIDIMessage ( const CVector<uint8_t>& vMIDIPaketBytes )
                         {
                             // We depend on toggles reflecting the desired state
                             emit ControllerInFaderIsMute ( cCtrl.iChannel, iValue >= 0x40 );
+                        }
+                        break;
+                        case MuteMyself:
+                        {
+                            // We depend on toggles reflecting the desired state to Mute Myself
+                            emit ControllerInMuteMyself ( iValue >= 0x40 );
                         }
                         break;
                         default:

--- a/src/soundbase.h
+++ b/src/soundbase.h
@@ -48,6 +48,7 @@ enum EMidiCtlType
     Pan,
     Solo,
     Mute,
+    MuteMyself,
     None
 };
 
@@ -171,4 +172,5 @@ signals:
     void ControllerInPanValue ( int iChannelIdx, int iValue );
     void ControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void ControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
+    void ControllerInMuteMyself ( bool bMute );
 };


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
This change add an option to allow the Mute Myself checkbox to be controlled via MIDI. The character to use in the --ctrlmidich option for this is: o. Followed by the CC#. For instance use: o87 to enable/disable the Mute Myself using CC# 87.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
New feature/option discussed in #2322 

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
Letter o (for own) needs to be added to the --ctrlmidich option details.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for review

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Tested on Windows and Linux using JACK.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
