### PR TITLE
Bugfix: Ensure proper IPv6 obfuscation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -72,6 +72,9 @@
 - Server: Improved the icon that is displayed in the Windows system tray for a server (#2231)
   (contributed by @henkdegroot)
 
+- Bugfix: IPv6 address formatting and obfuscation has been improved (#2343).
+  (contributed by @rdica, @hoffie, @softins)
+
 - Windows Installer: Updated NSIS to v3.08 (#2208).
   (contributed by @ann0see)
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -942,6 +942,27 @@ int CHostAddress::Compare ( const CHostAddress& other ) const
     return thisAddr < otherAddr ? -1 : thisAddr > otherAddr ? 1 : 0;
 }
 
+QString CHostAddress::toString ( const EStringMode eStringMode ) const
+{
+    QString strReturn = InetAddr.toString();
+
+    // special case: for local host address, we do not replace the last byte
+    if ( ( ( eStringMode == SM_IP_NO_LAST_BYTE ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) ) &&
+         ( InetAddr != QHostAddress ( QHostAddress::LocalHost ) ) )
+    {
+        // replace last byte by an "x"
+        strReturn = strReturn.section ( ".", 0, 2 ) + ".x";
+    }
+
+    if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
+    {
+        // add port number after a semicolon
+        strReturn += ":" + QString().setNum ( iPort );
+    }
+
+    return strReturn;
+}
+
 // Instrument picture data base ------------------------------------------------
 CVector<CInstPictures::CInstPictProps>& CInstPictures::GetTable ( const bool bReGenerateTable )
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -965,7 +965,7 @@ QString CHostAddress::toString ( const EStringMode eStringMode ) const
 
     if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
     {
-        // add port number after a semicolon
+        // add port number after a colon
         if ( strReturn.contains ( "." ) )
         {
             strReturn += ":" + QString().setNum ( iPort );

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -948,10 +948,19 @@ QString CHostAddress::toString ( const EStringMode eStringMode ) const
 
     // special case: for local host address, we do not replace the last byte
     if ( ( ( eStringMode == SM_IP_NO_LAST_BYTE ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) ) &&
-         ( InetAddr != QHostAddress ( QHostAddress::LocalHost ) ) )
+         ( InetAddr != QHostAddress ( QHostAddress::LocalHost ) ) && ( InetAddr != QHostAddress ( QHostAddress::LocalHostIPv6 ) ) )
     {
-        // replace last byte by an "x"
-        strReturn = strReturn.section ( ".", 0, 2 ) + ".x";
+        // replace last part by an "x"
+        if ( strReturn.contains ( "." ) )
+        {
+            // IPv4 or IPv4-mapped:
+            strReturn = strReturn.section ( ".", 0, -2 ) + ".x";
+        }
+        else
+        {
+            // IPv6
+            strReturn = strReturn.section ( ":", 0, -2 ) + ":x";
+        }
     }
 
     if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -966,7 +966,15 @@ QString CHostAddress::toString ( const EStringMode eStringMode ) const
     if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
     {
         // add port number after a semicolon
-        strReturn += ":" + QString().setNum ( iPort );
+        if ( strReturn.contains ( "." ) )
+        {
+            strReturn += ":" + QString().setNum ( iPort );
+        }
+        else
+        {
+            // enclose pure IPv6 address in [ ] before adding port, to avoid ambiguity
+            strReturn = "[" + strReturn + "]:" + QString().setNum ( iPort );
+        }
     }
 
     return strReturn;

--- a/src/util.h
+++ b/src/util.h
@@ -738,26 +738,7 @@ public:
 
     int Compare ( const CHostAddress& other ) const;
 
-    QString toString ( const EStringMode eStringMode = SM_IP_PORT ) const
-    {
-        QString strReturn = InetAddr.toString();
-
-        // special case: for local host address, we do not replace the last byte
-        if ( ( ( eStringMode == SM_IP_NO_LAST_BYTE ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) ) &&
-             ( InetAddr != QHostAddress ( QHostAddress::LocalHost ) ) )
-        {
-            // replace last byte by an "x"
-            strReturn = strReturn.section ( ".", 0, 2 ) + ".x";
-        }
-
-        if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
-        {
-            // add port number after a semicolon
-            strReturn += ":" + QString().setNum ( iPort );
-        }
-
-        return strReturn;
-    }
+    QString toString ( const EStringMode eStringMode = SM_IP_PORT ) const;
 
     QHostAddress InetAddr;
     quint16      iPort;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
- util: Move CHostAddress implementation from .h to .cpp
- util: Fix IPv6 obfuscation in CHostAddress::toString

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2342

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready, but needs testing.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- [x] Testing the logic (see below)
- [x] Testing IPv4 Recorder clients @rdica? :)
- [x] Testing IPv6 Recorder clients @rdica? :)
- [x] Decision if it should go into 3.8.2

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above

---
I've tested the logic like that:

```diff
diff --git a/src/main.cpp b/src/main.cpp
index e63300c6..566099af 100644
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,24 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 int main ( int argc, char** argv )
 {
 
+    QList<QString> tests;
+    tests << QString ( "1.2.3.4" );
+    tests << QString ( "::1" );
+    tests << QString ( "::ffff:1.2.3.4" );
+    tests << QString ( "abcd::1234" );
+    tests << QString ( "1111:2222:3333:4444:5555:6666:7777:8888" );
+    foreach ( auto test, tests )
+    {
+        qInfo() << test << "->" << ( CHostAddress ( QHostAddress ( test ), 9999 ) ).toString ( CHostAddress::SM_IP_NO_LAST_BYTE );
+    }
+
+    foreach ( auto test, tests )
+    {
+        qInfo() << test << "(+port) ->" << ( CHostAddress ( QHostAddress ( test ), 9999 ) ).toString ( CHostAddress::SM_IP_NO_LAST_BYTE_PORT );
+    }
+
+    exit ( 0 );
+
 #if defined( Q_OS_MACX )
     // Mnemonic keys are default disabled in Qt for MacOS. The following function enables them.
     // Qt will not show these with underline characters in the GUI on MacOS.

```

Result:
```
"1.2.3.4" -> "1.2.3.x"
"::1" -> "::1"
"::ffff:1.2.3.4" -> "::ffff:1.2.3.x"
"abcd::1234" -> "abcd::x"
"1111:2222:3333:4444:5555:6666:7777:8888" -> "1111:2222:3333:4444:5555:6666:7777:x"
"1.2.3.4" (+port) -> "1.2.3.x:9999"
"::1" (+port) -> "[::1]:9999"
"::ffff:1.2.3.4" (+port) -> "::ffff:1.2.3.x:9999"
"abcd::1234" (+port) -> "[abcd::x]:9999"
"1111:2222:3333:4444:5555:6666:7777:8888" (+port) -> "[1111:2222:3333:4444:5555:6666:7777:x]:9999"
```