### PR TITLE
Audiomixerboard: Auto-reduce size when switching between meter styles

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,8 @@
 
 ### 3.8.2beta1dev <- NOTE: the release version number will be 3.8.2 ###
 
-- Client: Added selection option for level meter style (#1688).
-  (contributed by @henkdegroot)
+- Client: Added selection option for level meter style (#1688, #2352).
+  (contributed by @henkdegroot, @hoffie, @pgScorpio)
 
 - Client: On Windows, if no driver found while installing, the "Run Jamulus"
   option will not be checked (#2103).

--- a/src/levelmeter.cpp
+++ b/src/levelmeter.cpp
@@ -61,9 +61,9 @@ CLevelMeter::CLevelMeter ( QWidget* parent ) : QWidget ( parent ), eLevelMeterTy
     pBarMeter->setFormat ( "" );                        // suppress percent numbers
 
     // setup stacked layout for meter type switching mechanism
-    pStackedLayout = new QStackedLayout ( this );
-    pStackedLayout->addWidget ( pLEDMeter );
-    pStackedLayout->addWidget ( pBarMeter );
+    pMinStackedLayout = new CMinimumStackedLayout ( this );
+    pMinStackedLayout->addWidget ( pLEDMeter );
+    pMinStackedLayout->addWidget ( pBarMeter );
 
     // according to QScrollArea description: "When using a scroll area to display the
     // contents of a custom widget, it is important to ensure that the size hint of
@@ -103,7 +103,7 @@ void CLevelMeter::SetLevelMeterType ( const ELevelMeterType eNType )
         {
             vecpLEDs[iLEDIdx]->SetColor ( cLED::RL_BLACK );
         }
-        pStackedLayout->setCurrentIndex ( 0 );
+        pMinStackedLayout->setCurrentIndex ( 0 );
         break;
 
     case MT_SLIM_LED:
@@ -112,7 +112,7 @@ void CLevelMeter::SetLevelMeterType ( const ELevelMeterType eNType )
         {
             vecpLEDs[iLEDIdx]->SetColor ( cLED::RL_SLIM_BLACK );
         }
-        pStackedLayout->setCurrentIndex ( 0 );
+        pMinStackedLayout->setCurrentIndex ( 0 );
         break;
 
     case MT_SMALL_LED:
@@ -121,21 +121,12 @@ void CLevelMeter::SetLevelMeterType ( const ELevelMeterType eNType )
         {
             vecpLEDs[iLEDIdx]->SetColor ( cLED::RL_SMALL_BLACK );
         }
-        pStackedLayout->setCurrentIndex ( 0 );
+        pMinStackedLayout->setCurrentIndex ( 0 );
         break;
 
     case MT_BAR:
-        pStackedLayout->setCurrentIndex ( 1 );
-        break;
-
     case MT_SLIM_BAR:
-        // set all LEDs to disabled, otherwise we would not get our desired small width
-        for ( int iLEDIdx = 0; iLEDIdx < NUM_LEDS_INCL_CLIP_LED; iLEDIdx++ )
-        {
-            vecpLEDs[iLEDIdx]->SetColor ( cLED::RL_DISABLED );
-        }
-
-        pStackedLayout->setCurrentIndex ( 1 );
+        pMinStackedLayout->setCurrentIndex ( 1 );
         break;
     }
 

--- a/src/levelmeter.h
+++ b/src/levelmeter.h
@@ -29,7 +29,6 @@
 #include <QTimer>
 #include <QLayout>
 #include <QProgressBar>
-#include <QStackedLayout>
 #include "util.h"
 #include "global.h"
 
@@ -107,10 +106,10 @@ protected:
 
     void SetBarMeterStyleAndClipStatus ( const ELevelMeterType eNType, const bool bIsClip );
 
-    QStackedLayout* pStackedLayout;
-    ELevelMeterType eLevelMeterType;
-    CVector<cLED*>  vecpLEDs;
-    QProgressBar*   pBarMeter;
+    CMinimumStackedLayout* pMinStackedLayout;
+    ELevelMeterType        eLevelMeterType;
+    CVector<cLED*>         vecpLEDs;
+    QProgressBar*          pBarMeter;
 
     QTimer TimerClip;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -680,6 +680,16 @@ QString TruncateString ( QString str, int position )
     }
     return str.left ( position );
 }
+
+QSize CMinimumStackedLayout::sizeHint() const
+{
+    // always use the size of the currently visible widget:
+    if ( currentWidget() )
+    {
+        return currentWidget()->sizeHint();
+    }
+    return QStackedLayout::sizeHint();
+}
 #endif
 
 /******************************************************************************\

--- a/src/util.h
+++ b/src/util.h
@@ -41,6 +41,7 @@
 #    include <QDesktopServices>
 #    include <QKeyEvent>
 #    include <QTextBoundaryFinder>
+#    include <QStackedLayout>
 #    include "ui_aboutdlgbase.h"
 #endif
 #include <QFile>
@@ -444,6 +445,15 @@ public slots:
 
 signals:
     void LanguageChanged ( QString strLanguage );
+};
+
+// StackedLayout which auto-reduces to the size of the currently visible widget
+class CMinimumStackedLayout : public QStackedLayout
+{
+    Q_OBJECT
+public:
+    CMinimumStackedLayout ( QWidget* parent = nullptr ) : QStackedLayout ( parent ) {}
+    virtual QSize sizeHint() const override;
 };
 #endif
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
There are two different base meter styles (LED vs. bars) with multiple variants each (regular, slim, round). The base meter styles are implmeneted as widgets and are always part of a `QStackedLayout`. The selected meter style is shown via `setCurrentWidget()`. This hides the inactive widget, but the inactive widget is still there and is part of `QStackedLayout`'s size calculations which always uses the maximum size over all widgets, not just the currently visible one.

This leads to problems when the currently visible meter widget is narrower than the hidden counterpart. In that case, the `QStackedLayout` is wider than expected.

Technically, the following transitions show this issue:
- Select Bar, then Small LEDs (or start with Small LEDs), or
- Select LEDs, then Narrow Bar (or start with Narrow Bar)

However, the latter case already had a workaround (choosing Narrow Bar [silently adjusted details of the LED meter as well](https://github.com/jamulussoftware/jamulus/blob/ebb1e9f278e6ba08cd717fdd2ae3692aeeb327d3/src/levelmeter.cpp#L132-L136)).

The proper fix is using a subclass of QStackedLayout which calculates its sizeHint solely based on the currently visible widget.
This fixes the Bar->Small LEDs transition and makes the LEDs->Narrow Bar workaround redundant, which has therefore been removed.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2351
Initially reported here: https://github.com/jamulussoftware/jamulus/pull/1688#issuecomment-1030714460

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No ChangeLog entry as the bug was not part of a release. The PR adds itself to the existing ChangeLog entry.
CHANGELOG:SKIP

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for testing/review

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- [ ] Confirm that it fixes the bug (@pgScorpio)
- [ ] Confirm correctness with someone familiar with the initial PR (@henkdegroot?)

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
