### PR TITLE
Translations: Drop left-over .arg() in mac/sound.cpp

### DIFF
--- a/mac/sound.cpp
+++ b/mac/sound.cpp
@@ -461,8 +461,7 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
          ( !( CurDevStreamFormat.mFormatFlags & kAudioFormatFlagIsPacked ) ) )
     {
         return QString ( tr ( "The stream format on the current input device isn't "
-                              "compatible with this software. Please select another device." ) )
-            .arg ( APP_NAME );
+                              "compatible with this software. Please select another device." ) );
     }
 
     // check the output


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
`mac/sound.cpp` contains a `tr()` which doesn't use `%1`, but calls `.arg()`. This was probably introduced in 40d4b4774 (which was already part of 3.8.1).

This results in the following output:
```
QString::arg: Argument missing: The stream format on the current input device isn't compatible with this software. Please select another device., Jamulus 
```
Spotted by @melcon:
https://github.com/jamulussoftware/jamulus/pull/2358#discussion_r801049456

This PR removes the `.arg()` as no `%1` is used or needed.
Most translations do not contain `%1` either:
```
$ grep 'The stream format on the current input device' src/res/translation/*.ts -A1 | grep %1
src/res/translation/translation_pt_BR.ts-        <translation>O formato do fluxo no dispositivo de entrada atual não é compatível com %1. Selecione outro dispositivo.</translation>
```
pt_BR is handled here: #2358

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready