### PR TITLE
Build: Generate qm files and embedded resource during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Jamulus.xcodeproj
 jamulus_plugin_import.cpp
 .github_release_changelog.md
 /debian/
+src/res/qmake_qmake_qm_files.qrc
+src/res/qrc_qmake_qmake_qm_files.cpp
+src/res/translation/*.qm

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -22,7 +22,7 @@ contains(VERSION, .*dev.*) {
 
 CONFIG += qt \
     thread \
-    lrelease
+    lrelease embed_translations
 
 QT += network \
     xml \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -707,19 +707,6 @@ DISTFILES += ChangeLog \
     src/res/io.jamulus.jamulus.png \
     src/res/io.jamulus.jamulus.svg \
     src/res/io.jamulus.jamulusserver.svg \
-    src/translation/translation_de_DE.qm \
-    src/translation/translation_fr_FR.qm \
-    src/translation/translation_ko_KR.qm \
-    src/translation/translation_pt_PT.qm \
-    src/translation/translation_pt_BR.qm \
-    src/translation/translation_es_ES.qm \
-    src/translation/translation_nb_NO.qm \
-    src/translation/translation_nl_NL.qm \
-    src/translation/translation_pl_PL.qm \
-    src/translation/translation_it_IT.qm \
-    src/translation/translation_sv_SE.qm \
-    src/translation/translation_sk_SK.qm \
-    src/translation/translation_zh_CN.qm \
     src/res/CLEDBlack.png \
     src/res/CLEDBlackSmall.png \
     src/res/CLEDDisabledSmall.png \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1171,7 +1171,7 @@ QMAKE_EXTRA_TARGETS += clang_format
 
 equals(QT_MAJOR_VERSION, 5) {
     lessThan(QT_MINOR_VERSION, 12) {
-        message(Using extra lrelease rules for old Qt5)
+        message(Using extra lrelease rules for old Qt5 *** IGNORE the RCC errors below ***)
 
         qtPrepareTool(QMAKE_LRELEASE, lrelease)
 
@@ -1197,6 +1197,11 @@ equals(QT_MAJOR_VERSION, 5) {
             qmake_qm_files.base = $$OUT_PWD/$$LRELEASE_DIR
             qmake_qm_files.prefix = $$QM_FILES_RESOURCE_PREFIX
             RESOURCES += qmake_qm_files
+
+            # This is a hack because old rcc does not output dependencies that do not yet exist.
+            # This adds the QM files as explicit dependencies of all resource files, but that
+            # does not matter - it still ensures the qm files get built on the fly.
+            rcc.depends += $$QM_FILES
         } else {
             !isEmpty(QM_FILES_INSTALL_PATH) {
                 qm_files.files = $$QM_FILES

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,44 +1,4 @@
 <RCC>
-    <qresource prefix="/translations">
-        <file alias="translation_de">translation/translation_de_DE.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_fr">translation/translation_fr_FR.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_pt_PT">translation/translation_pt_PT.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_pt">translation/translation_pt_BR.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_es">translation/translation_es_ES.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_nb_NO">translation/translation_nb_NO.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_nl">translation/translation_nl_NL.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_it">translation/translation_it_IT.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_pl">translation/translation_pl_PL.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_sk">translation/translation_sk_SK.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_sv">translation/translation_sv_SE.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_zh_CN">translation/translation_zh_CN.qm</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="translation_ko_KR">translation/translation_ko_KR.qm</file>
-    </qresource>
-
     <qresource prefix="/png/LEDs">
         <file>res/CLEDDisabled.png</file>
         <file>res/CLEDGrey.png</file>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1593,8 +1593,9 @@ QMap<QString, QString> CLocale::GetAvailableTranslations()
         // get alias of translation file
         const QString strCurFileName = DirIter.next();
 
-        // extract only language code (must be at the end, separated with a "_")
-        const QString strLoc = strCurFileName.right ( strCurFileName.length() - strCurFileName.indexOf ( "_" ) - 1 );
+        // extract only language code xx_XX from translation_xx_XX.qm
+        const int     lang   = strCurFileName.indexOf ( "_" ) + 1;
+        const QString strLoc = strCurFileName.mid ( lang, strCurFileName.indexOf ( "." ) - lang );
 
         TranslMap[strLoc] = strCurFileName;
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1583,7 +1583,7 @@ QString CLocale::GetCountryFlagIconsResourceReference ( const QLocale::Country e
 QMap<QString, QString> CLocale::GetAvailableTranslations()
 {
     QMap<QString, QString> TranslMap;
-    QDirIterator           DirIter ( ":/translations" );
+    QDirIterator           DirIter ( ":/i18n" );
 
     // add english language (default which is in the actual source code)
     TranslMap["en"] = ""; // empty file name means that the translation load fails and we get the default english language


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
Generate the translation qm files during build and remove them from github.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
The qm files are binary dependants of the ts text files. Historically they have been generated manually
and stored in github. Qt versions from 5.12 include qmake rules for generating and embedding them.

This revisits previous closed PR #1303

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Working with Qt >= 5.12. ~If we need to keep supporting older Qt, we will need a compatible
set of fallback rules.~ Fallback rules added.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
~Support for Qt < 5.12, or a decision to stop supporting those versions.~
Checking that all artifacts build and run correctly, particularly Mac Legacy.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
