### PR TITLE
Fix accelerator key clashes

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1216,7 +1216,7 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
         lbrInputLevelR->setEnabled ( true );
 
         // change connect button text to "disconnect"
-        butConnect->setText ( tr ( "D&isconnect" ) );
+        butConnect->setText ( tr ( "&Disconnect" ) );
 
         // set server name in audio mixer group box title
         MainMixerBoard->SetServerName ( strMixerBoardLabel );

--- a/src/res/translation/translation_de_DE.ts
+++ b/src/res/translation/translation_de_DE.ts
@@ -1157,7 +1157,7 @@ Wir haben Deinen Kanal stummgeschaltet und die Funktion &apos;Stummschalten&apos
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>&amp;Trennen</translation>
     </message>
 </context>

--- a/src/res/translation/translation_es_ES.ts
+++ b/src/res/translation/translation_es_ES.ts
@@ -575,7 +575,7 @@
     <message>
         <location filename="../../chatdlg.cpp" line="58"/>
         <source>&amp;Edit</source>
-        <translation>&amp;Editar</translation>
+        <translation>E&amp;ditar</translation>
     </message>
     <message>
         <location filename="../../chatdlg.cpp" line="60"/>
@@ -1036,7 +1036,7 @@
     <message>
         <location filename="../../clientdlg.cpp" line="290"/>
         <source>&amp;Load Mixer Channels Setup...</source>
-        <translation>&amp;Cargar Configuración Canales Mezclador...</translation>
+        <translation>C&amp;argar Configuración Canales Mezclador...</translation>
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="292"/>
@@ -1177,7 +1177,7 @@ Hemos silenciado tu canal y activado &apos;Silenciarme Yo&apos;. Por favor resue
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>&amp;Desconectar</translation>
     </message>
 </context>

--- a/src/res/translation/translation_fr_FR.ts
+++ b/src/res/translation/translation_fr_FR.ts
@@ -738,7 +738,7 @@
     <message>
         <location filename="../../clientdlg.cpp" line="376"/>
         <source>C&amp;hat...</source>
-        <translation>&amp;Tchate...</translation>
+        <translation>Tc&amp;hate...</translation>
     </message>
     <message>
         <source>&amp;Settings...</source>
@@ -985,7 +985,7 @@ Nous avons coupé votre canal et activé &quot;Me silencer&quot;. Veuillez d&apo
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>&amp;Déconnecter</translation>
     </message>
 </context>

--- a/src/res/translation/translation_it_IT.ts
+++ b/src/res/translation/translation_it_IT.ts
@@ -1158,8 +1158,8 @@ E&apos; stato disattivato l&apos;audio del tuo canale ed inserito il &quot;Disat
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
-        <translation>D&amp;isconnetti</translation>
+        <source>&amp;Disconnect</source>
+        <translation>Disco&amp;nnetti</translation>
     </message>
 </context>
 <context>

--- a/src/res/translation/translation_nl_NL.ts
+++ b/src/res/translation/translation_nl_NL.ts
@@ -1145,7 +1145,7 @@ We hebben uw kanaal gedempt en &apos;Demp mijzelf&apos; geactiveerd. Los eerst h
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>&amp;Afmelden</translation>
     </message>
 </context>

--- a/src/res/translation/translation_pl_PL.ts
+++ b/src/res/translation/translation_pl_PL.ts
@@ -928,7 +928,7 @@ Twój kanał został wyciszony i włączono „Wycisz mnie”. Napraw przyczynę
     <message>
         <location filename="../../clientdlg.cpp" line="387"/>
         <source>Sett&amp;ings</source>
-        <translation>&amp;Ustawienia</translation>
+        <translation>Ustaw&amp;ienia</translation>
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="391"/>
@@ -989,7 +989,7 @@ Twój kanał został wyciszony i włączono „Wycisz mnie”. Napraw przyczynę
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>&amp;Rozłącz</translation>
     </message>
 </context>
@@ -1038,7 +1038,7 @@ Twój kanał został wyciszony i włączono „Wycisz mnie”. Napraw przyczynę
     <message>
         <location filename="../../clientdlgbase.ui" line="498"/>
         <source>&amp;Mute Myself</source>
-        <translation>&amp;Wycisz mnie</translation>
+        <translation>Wycisz &amp;Mnie</translation>
     </message>
     <message>
         <location filename="../../clientdlgbase.ui" line="505"/>

--- a/src/res/translation/translation_pt_BR.ts
+++ b/src/res/translation/translation_pt_BR.ts
@@ -585,7 +585,7 @@
     <message>
         <location filename="../../chatdlg.cpp" line="58"/>
         <source>&amp;Edit</source>
-        <translation>&amp;Editar</translation>
+        <translation>E&amp;ditar</translation>
     </message>
     <message>
         <location filename="../../chatdlg.cpp" line="60"/>
@@ -1176,9 +1176,8 @@ Silenciamos seu canal e ativamos &apos;Silenciar-me&apos;. Resolva o problema de
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
-        <translatorcomment>Opted by Desligar instead of Desconectar to keep same keyboard shortcut</translatorcomment>
-        <translation>Desl&amp;igar</translation>
+        <source>&amp;Disconnect</source>
+        <translation>&amp;Desconectar</translation>
     </message>
 </context>
 <context>

--- a/src/res/translation/translation_pt_PT.ts
+++ b/src/res/translation/translation_pt_PT.ts
@@ -1169,8 +1169,8 @@ O seu canal foi silenciado e foi activada a função &apos;Silenciar-me&apos;. P
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
-        <translation>Desl&amp;igar</translation>
+        <source>&amp;Disconnect</source>
+        <translation>&amp;Desligar</translation>
     </message>
 </context>
 <context>

--- a/src/res/translation/translation_sk_SK.ts
+++ b/src/res/translation/translation_sk_SK.ts
@@ -981,7 +981,7 @@ Stíšili sme váš kanál a aktivovali nastavenia &apos;Stíšiť ma&apos;. Pro
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>O&amp;dpojiť</translation>
     </message>
 </context>

--- a/src/res/translation/translation_sv_SE.ts
+++ b/src/res/translation/translation_sv_SE.ts
@@ -901,7 +901,7 @@ Vi stängde av din kanal och aktiverade &apos;Tysta mig själv&apos;. Vänligen 
     <message>
         <location filename="../../clientdlg.cpp" line="296"/>
         <source>E&amp;xit</source>
-        <translation>&amp;Avsluta</translation>
+        <translation>A&amp;vsluta</translation>
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="160"/>
@@ -936,7 +936,7 @@ Vi stängde av din kanal och aktiverade &apos;Tysta mig själv&apos;. Vänligen 
     <message>
         <location filename="../../clientdlg.cpp" line="315"/>
         <source>O&amp;wn Fader First</source>
-        <translation type="unfinished">E&amp;gen fader först</translation>
+        <translation type="unfinished">&amp;Egen fader först</translation>
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="387"/>
@@ -1011,7 +1011,7 @@ Vi stängde av din kanal och aktiverade &apos;Tysta mig själv&apos;. Vänligen 
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>Koppla &amp;ner</translation>
     </message>
 </context>
@@ -1065,7 +1065,7 @@ Vi stängde av din kanal och aktiverade &apos;Tysta mig själv&apos;. Vänligen 
     <message>
         <location filename="../../clientdlgbase.ui" line="505"/>
         <source>&amp;Settings</source>
-        <translation>&amp;Inställningar</translation>
+        <translation>In&amp;ställningar</translation>
     </message>
     <message>
         <location filename="../../clientdlgbase.ui" line="512"/>

--- a/src/res/translation/translation_zh_CN.ts
+++ b/src/res/translation/translation_zh_CN.ts
@@ -930,7 +930,7 @@ We muted your channel and activated &apos;Mute Myself&apos;. Please solve the fe
     </message>
     <message>
         <location filename="../../clientdlg.cpp" line="1219"/>
-        <source>D&amp;isconnect</source>
+        <source>&amp;Disconnect</source>
         <translation>断开连接(&amp;D)</translation>
     </message>
 </context>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
Corrected accelerator key clashes in English and several other languages.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Part of release process

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
Probably not. Accelerator keys vary between languages and are shown in the GUI

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for review

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
~Sanity test on my system~ DONE

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
