### PR TITLE
Autobuild: Fix broken .deb dependencies / Fix uninstallable 3.8.2 on Ubuntu 18.04

### DIFF
--- a/distributions/build-debian-package-auto.sh
+++ b/distributions/build-debian-package-auto.sh
@@ -21,6 +21,9 @@ do
 done
 echo
 
+echo "Copying modified control file for proper dependencies/maintainer logic"
+cp distributions/autobuilddeb/control debian/control
+
 echo "${VERSION} building..."
 
 sed -i "s/é&%JAMVERSION%&è/${VERSION}/g" debian/control


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- A short description of your changes which might go into the change log -->
The autobuild-produced Debian/Ubuntu packages use another `debian/control` file than manual builds. This is done by copying a special copy of the `control` file to the right place.

86807c1ab88ee10ab453371b45d3a4e8a45fd606 (squash of 3dadf23968ec58b22d1ff7b632f23732409bdfa7 and others) from #2138 mistakenly (I think?) removed this logic.

This results in broken dependencies (especially visible on Ubuntu 18.04) and wrong maintainer information:
```
root@71dafa5ca28f:/downloads# dpkg-deb --info jamulus_headless_3.8.1_ubuntu_amd64.deb | grep -P 'Depends|Maintainer'
 Maintainer: "corrados" <nomail@example.com>
 Depends: libqt5core5a (>= 5.5.0), libqt5network5 (>= 5.0.2), libqt5xml5 (>= 5.0.2)

root@71dafa5ca28f:/downloads# dpkg-deb --info jamulus_headless_3.8.2_ubuntu_amd64.deb | grep -P 'Depends|Maintainer'            
 Maintainer: "Marc Landolt jr" <debian@marclandolt.ch>
 Depends: libc6 (>= 2.27), libgcc-s1 (>= 3.0), libqt5core5a (>= 5.9.0~beta), libqt5network5 (>= 5.8.0), libqt5xml5 (>= 5.0.2), libstdc++6 (>= 7), adduser
```

We should also **decide what to do regarding 3.8.2**:
1. Take the new 3.8.2 .deb (app version remaining at 3.8.2) from this PR, remove the existing .deb from the release and upload the new one (maybe with a -1 suffix to make clear that the file has been updated)
1. Release 3.8.3 as a bug fix release. Downside: Will trigger irrelevant update notifications and confusion for non Ubuntu-18.04 users
1. Release 3.8.2.1. Downside: We've never tested this versioning scheme. I wouldn't do that.
1. Release 3.9.0nightly and point Ubuntu 18.04 users to this version (maybe add hint to the announcement)
1. Do nothing and state "3.8.2 is broken on Ubuntu 18.04; please use 3.8.1 and wait for the next release". Ubuntu 18.04 is really old, but still supported until 2023. People do use it as #2422 shows.

I'd tend towards option 1.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2422

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
Yes:
- [ ] Release body
- [ ] Github Announcement
- [ ] Facebook announcement

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Needs verification/testing.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Needs verification/testing.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
