### PR TITLE
Make server GUI default to "None" directory if not set.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -840,11 +840,10 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
     else
     {
         // clang-format off
-// TODO compatibility to old version < ?????
-// only the case that manual was set in old ini must be considered
-if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) && !bValue )
+// TODO compatibility to old version < 3.4.7
+if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
 {
-    directoryType = AT_CUSTOM;
+    directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
 }
 else
             // clang-format on
@@ -867,6 +866,15 @@ else
         {
             directoryType = static_cast<EDirectoryType> ( iValue );
         }
+
+        // clang-format off
+// TODO compatibility to old version < 3.9.0
+// override type to AT_NONE if servlistenabled exists and is false
+if (  GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
+{
+    directoryType = AT_NONE;
+}
+        // clang-format on
     }
 
     pServer->SetDirectoryType ( directoryType );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -829,11 +829,10 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
 
     // directory type
     // CServerListManager defaults to AT_NONE
-    // Server GUI also defaults to AT_NONE (previously AT_DEFAULT, when registration was controlled by a checkbox)
     // Because type could be AT_CUSTOM, it has to be set after the address to avoid multiple registrations
     EDirectoryType directoryType = AT_NONE;
 
-    // if command line is set, use it
+    // if a command line Directory server address is set, set the Directory Type (genre) to AT_CUSTOM so it's used
     if ( CommandLineOptions.contains ( "--centralserver" ) || CommandLineOptions.contains ( "--directoryserver" ) )
     {
         directoryType = AT_CUSTOM;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -829,9 +829,9 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
 
     // directory type
     // CServerListManager defaults to AT_NONE
-    // Server GUI defaults to AT_DEFAULT
+    // Server GUI also defaults to AT_NONE (previously AT_DEFAULT, when registration was controlled by a checkbox)
     // Because type could be AT_CUSTOM, it has to be set after the address to avoid multiple registrations
-    EDirectoryType directoryType = AT_DEFAULT;
+    EDirectoryType directoryType = AT_NONE;
 
     // if command line is set, use it
     if ( CommandLineOptions.contains ( "--centralserver" ) || CommandLineOptions.contains ( "--directoryserver" ) )
@@ -840,15 +840,6 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
     }
     else
     {
-        // clang-format off
-// TODO compatibility to old version < 3.8.2
-// if "servlistenabled" exists and is false, set directory type to AT_NONE
-if ( GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
-{
-    directoryType = AT_NONE;
-}
-        // clang-format on
-
         // clang-format off
 // TODO compatibility to old version < ?????
 // only the case that manual was set in old ini must be considered


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
If the directory is not set in the ini file or the command line, the server should not automatically register to All Genres 1. It should default to not registering until the user actually chooses a directory.
This PR sets the default for the GUI accordingly.

CHANGELOG: Server: Set default directory to "None" when not set in ini file or command line.
<!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast -->

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2441 

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
Probably not.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Tested and ready

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
