### PR TITLE
Build: Parallelize compilation on Android, Mac (CodeQL) and Debian

### DIFF
--- a/autobuild/android/autobuild_apk_2_build.sh
+++ b/autobuild/android/autobuild_apk_2_build.sh
@@ -20,7 +20,7 @@ echo .
 echo .
 echo .
 echo .
-/opt/android/android-ndk/prebuilt/linux-x86_64/bin/make
+/opt/android/android-ndk/prebuilt/linux-x86_64/bin/make -j "$(nproc)"
 echo .
 echo .
 echo .

--- a/autobuild/mac/codeQL/autobuild_mac_2_build.sh
+++ b/autobuild/mac/codeQL/autobuild_mac_2_build.sh
@@ -20,7 +20,7 @@ echo "Building... qmake"
 qmake
 
 echo "Building... make"
-make
+make -j "$(sysctl -n hw.ncpu)"
 
 
 echo "Done"

--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -11,8 +11,8 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	cd src/res/translation && lrelease *.ts
-	cd build-gui && make
-	cd build-nox && make
+	cd build-gui && make -j "$$(nproc)"
+	cd build-nox && make -j "$$(nproc)"
 
 override_dh_auto_install:
 	cd build-nox && make install INSTALL_ROOT=../debian/tmp


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
This PR modifies the `make` calls to use a `-jN` paramter to parallelize builds.
- Mac already used this.
- Windows' nmake doesn't support `-j`, but I'll try to do something similar using `jom`.
- This PR adds
  - Android
  - Debian
  - Mac (CodeQL)

CHANGELOG: Internal: Speed up build process by using parallelization.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Performance

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.
- [x] Linux build times are down from [8m22s](https://github.com/jamulussoftware/jamulus/runs/5366322032?check_suite_focus=true) on master to [5m5s](https://github.com/hoffie/jamulus/runs/5383531494?check_suite_focus=true) in this build
- [x] Mac codeQL build times are down from [10m13s](https://github.com/jamulussoftware/jamulus/runs/5366322090?check_suite_focus=true) on master to [8m6s] in this build
- [ ] Android build times are down from [32m28s](https://github.com/jamulussoftware/jamulus/runs/5366321973?check_suite_focus=true) on master to [???](https://github.com/hoffie/jamulus/runs/5383531308?check_suite_focus=true) in this build

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Reviews.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
