### PR TITLE
Build: Use jom to parallelize Windows builds

### DIFF
--- a/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
+++ b/autobuild/windows/autobuild_windowsinstaller_1_prepare.ps1
@@ -46,6 +46,7 @@ $AqtinstallVersion = "2.0.5"
 $JackVersion = "1.9.17"
 $Msvc32Version = "win32_msvc2019"
 $Msvc64Version = "win64_msvc2019_64"
+$JomVersion = "1.1.2"
 
 if ( Test-Path -Path $QtDir )
 {
@@ -68,6 +69,9 @@ else
     Install-Qt ${Qt32Version} ${Msvc32Version} ${QtDir}
 }
 
+choco config set cacheLocation $ChocoCacheDir
+choco install --no-progress -y jom --version "${JomVersion}"
+
 
 #################################
 ###  ONLY ADD JACK IF NEEDED  ###
@@ -75,8 +79,6 @@ else
 
 if ($BuildOption -Eq "jackonwindows")
 {
-    choco config set cacheLocation $ChocoCacheDir
-
     echo "Install JACK2 64-bit..."
     # Install JACK2 64-bit
     choco install --no-progress -y jack --version "${JackVersion}"

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -234,7 +234,16 @@ Function Build-App
         "-o", "$BuildPath\Makefile")
 
     Set-Location -Path $BuildPath
-    Invoke-Native-Command -Command "nmake" -Arguments ("$BuildConfig")
+    if (Get-Command "jom.exe" -ErrorAction SilentlyContinue)
+    {
+        echo "Building with jom /J ${Env:NUMBER_OF_PROCESSORS}"
+        Invoke-Native-Command -Command "jom" -Arguments ("/J", "${Env:NUMBER_OF_PROCESSORS}", "$BuildConfig")
+    }
+    else
+    {
+        echo "Building with nmake (install Qt jom if you want parallel builds)"
+        Invoke-Native-Command -Command "nmake" -Arguments ("$BuildConfig")
+    }
     Invoke-Native-Command -Command "$Env:QtWinDeployPath" `
         -Arguments ("--$BuildConfig", "--compiler-runtime", "--dir=$DeployPath\$BuildArch",
         "$BuildPath\$BuildConfig\$AppName.exe")


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
This PR installs [Qt jom](https://wiki.qt.io/Jom) via `choco` and uses it in place of `nmake`. `jom` supports parallel builds and this PR enables them.

CHANGELOG: Internal: Speed up build process by using jom with parallelization instead of nmake in autobuilds.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Performance

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
- [x] Windows build times are down from [8m52s](https://github.com/jamulussoftware/jamulus/runs/5366322321?check_suite_focus=true) on master to [6m16s](https://github.com/hoffie/jamulus/runs/5383808077?check_suite_focus=true) in this build [[5m54s in the most recent run]](https://github.com/jamulussoftware/jamulus/runs/5387615640?check_suite_focus=true) (only compared JACK, but ASIO should be similar)

Note: Build times do vary so take these numbers with a grain of salt.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
CI/Reviews

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
