### PR TITLE
Server: Fix outdated comment about QThreadPool [trivial]

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -416,7 +416,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
 
     int iAvailableCores = QThread::idealThreadCount();
 
-    // setup QThreadPool if multithreading is active and possible
+    // setup CThreadPool if multithreading is active and possible
     if ( bUseMultithreading )
     {
         if ( iAvailableCores == 1 )


### PR DESCRIPTION
We don't use QThreadPool, but rather our own CThreadPool.

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->

CHANGELOG: SKIP

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Misleading comment.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Needs approvals which confirm that my understanding is correct that we don't use QThreadPool anymore.