### PR TITLE
Remove Ubuntu from artifact name

### DIFF
--- a/autobuild/linux/autobuild_deb_3_copy_files.sh
+++ b/autobuild/linux/autobuild_deb_3_copy_files.sh
@@ -44,14 +44,14 @@ echo ""
 #move/rename headless first, so wildcard pattern matches only one file each
 echo ""
 echo ""
-artifact_deploy_filename_1=jamulus_headless_${jamulus_buildversionstring}_ubuntu_amd64.deb
+artifact_deploy_filename_1=jamulus_headless_${jamulus_buildversionstring}_amd64.deb
 echo "Move/Rename the built file to deploy/${artifact_deploy_filename_1}"
 mv "${THIS_JAMULUS_PROJECT_PATH}"/../jamulus-headless*_amd64.deb "${THIS_JAMULUS_PROJECT_PATH}"/deploy/"${artifact_deploy_filename_1}"
 
 #move/rename normal second
 echo ""
 echo ""
-artifact_deploy_filename_2=jamulus_${jamulus_buildversionstring}_ubuntu_amd64.deb
+artifact_deploy_filename_2=jamulus_${jamulus_buildversionstring}_amd64.deb
 echo "Move/Rename the built file to deploy/${artifact_deploy_filename_2}"
 mv "${THIS_JAMULUS_PROJECT_PATH}"/../jamulus*_amd64.deb "${THIS_JAMULUS_PROJECT_PATH}"/deploy/"${artifact_deploy_filename_2}"
 


### PR DESCRIPTION
Fixes: https://github.com/jamulussoftware/jamulus/issues/2429

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
Removes "ubuntu" from the artifact name.

CHANGELOG: Remove confusing _ubuntu suffix from .deb files to avoid users thinking that the artifacts are only compatible with Ubuntu linux.

**Context: Fixes an issue?**
Partly fixes: #2429 

**Does this change need documentation? What needs to be documented and how?**
Yes. We need to update the installation links on the website.

**Status of this Pull Request**
Draft. 

**What is missing until this pull request can be merged?**
Needs resolving of #2429 first.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
