### PR TITLE
Autobuild: Use macOS 11 and explain Xcode version choice

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -125,6 +125,11 @@ jobs:
              cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh sign_if_possible"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"
              uses_codeql:           false
+             # Qt5's maximum supported Xcode version is 12.x (SDK 11).
+             # However, 12.5.1 triggers a Qt build warning about lack of support contrary to the docs.
+             # It also uses a newer macOS SDK which should not be an issue for older macOS versions, but we currently
+             # aim to err on the safe side and use 12.1.1 instead.
+             # https://xcodereleases.com/ https://doc.qt.io/qt-5/macos.html
              xcode_version:         12.1.1
 
            - config_name:           MacOS Legacy (artifacts)
@@ -134,7 +139,7 @@ jobs:
              cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh do_not_sign"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh legacy"
              uses_codeql:           false
-             # For Qt5 on Mac, we need to ensure SDK 10.15 is used, and not SDK 11.x.
+             # For Qt5 on Mac (Legacy), we need to ensure SDK 10.15 is used, and not SDK 11.x.
              # Xcode 12.1 is the most-recent release which still ships SDK 10.15:
              # https://developer.apple.com/support/xcode/
              # Xcode 12.1.1 is the most-recent 12.1.x release:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -111,7 +111,7 @@ jobs:
 
            - config_name:           MacOS (codeQL)
              target_os:             macos
-             building_on_os:        macos-10.15
+             building_on_os:        macos-11
              cmd1_prebuild:         "./autobuild/mac/codeQL/autobuild_mac_1_prepare.sh 5.15.2"
              cmd2_build:            "./autobuild/mac/codeQL/autobuild_mac_2_build.sh"
              cmd3_postbuild:        false
@@ -120,8 +120,7 @@ jobs:
 
            - config_name:           MacOS (artifacts)
              target_os:             macos
-             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?)
-             building_on_os:        macos-10.15
+             building_on_os:        macos-11
              cmd1_prebuild:         "./autobuild/mac/artifacts/autobuild_mac_1_prepare.sh 5.15.2"
              cmd2_build:            "./autobuild/mac/artifacts/autobuild_mac_2_build.sh sign_if_possible"
              cmd3_postbuild:        "./autobuild/mac/artifacts/autobuild_mac_3_copy_files.sh"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
- Autobuild: Build on macOS 11
  We previously couldn't run on macOS 11 as dmgbuild did not support it.
  Now that we are using create-dmg, this blocker is gone.

- Autobuild: Explain Xcode version choice

CHANGELOG: Autobuild: Updated build environments to macOS 11 and improved explanation about Xcode version choice.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
No, just trying hard to use the most-supported environments.
Related: #2357

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- Mac test run (@softins)?
- Approvals

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
