### PR TITLE
Add debian folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ Debug-iphoneos/
 Jamulus.xcodeproj
 jamulus_plugin_import.cpp
 autoLatestChangelog.md
+debian/


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
Until now a debian folder might have been commited to git.

I remember thinking of this some time ago where it didn't work as expected. However now I can verify that the debian/ folder is no longer added to git. I hope it doesn't have any side-effects I can't remember.

CHANGELOG: Internal: Add debian/ folder to .gitignore file to ensure build files are not added to git

**Context: Fixes an issue?**
Often while developing locally, I had to manually choose the files & changes I made. Now a git add . should be enough

**Does this change need documentation? What needs to be documented and how?**
No.

**Status of this Pull Request**
Works locally, should have another review

**What is missing until this pull request can be merged?**
Review

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
