### PR TITLE
Autobuild: Cleanup analyze_git_references.py

### DIFF
--- a/.github/actions_scripts/analyse_git_reference.py
+++ b/.github/actions_scripts/analyse_git_reference.py
@@ -1,112 +1,101 @@
 #!/usr/bin/python3
+# This script is trigged from the Github Autobuild workflow.
+# It analyzes Jamulus.pro and git push details (tag vs. branch, etc.) to decide
+#   - whether a release should be created,
+#   - whether it is a pre-release, and
+#   - what its title should be.
 
-#
-# on a triggered github workflow, this file does the decisions and variagles like
-#   - shall the build be released (otherwise just run builds to check if there are errors)
-#   - is it a prerelease
-#   - title, tag etc of release_tag
-#
-# see the last lines of the file to see what variables are set
-#
-
-
-import sys
 import os
 import re
 import subprocess
 
-# get the jamulus version from the .pro file
-def get_jamulus_version(repo_path_on_disk):
-    jamulus_version = ""
-    with open (repo_path_on_disk + '/Jamulus.pro','r') as f:
+REPO_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+
+
+def get_version_from_jamulus_pro():
+    with open(REPO_PATH + '/Jamulus.pro', 'r') as f:
         pro_content = f.read()
-    pro_content = pro_content.replace('\r','')
-    pro_lines = pro_content.split('\n')
-    for line in pro_lines:
-        line = line.strip()
-        VERSION_LINE_STARTSWITH = 'VERSION = '
-        if line.startswith(VERSION_LINE_STARTSWITH):
-            jamulus_version = line[len(VERSION_LINE_STARTSWITH):]
-            return jamulus_version
-    return "UNKNOWN_VERSION"
+    m = re.search(r'^VERSION\s*=\s*(\S+)$', pro_content, re.MULTILINE)
+    if not m:
+        raise Exception("Unable to determine Jamulus.pro VERSION")
+    return m.group(1)
+
 
 def get_git_hash():
-    return subprocess.check_output(['git', 'describe', '--match=xxxxxxxxxxxxxxxxxxxx', '--always', '--abbrev', '--dirty']).decode('ascii').strip()
-    #return subprocess.check_output(['git', 'rev-parse', 'HEAD'])
-    #return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
-
-if len(sys.argv) == 1:
-   pass
-else:
-    print('wrong number of arguments')
-    print('Number of arguments:', len(sys.argv), 'arguments.')
-    print('Argument List:', str(sys.argv))
-    raise Exception("wrong agruments")
-
-# derive workspace-path
-repo_path_on_disk = os.environ['GITHUB_WORKSPACE']
-
-# derive git related variables
-version_from_changelog = get_jamulus_version(repo_path_on_disk)
-if "dev" in version_from_changelog:
-    release_version_name = "{}-{}".format(version_from_changelog, get_git_hash())
-    print("building an intermediate version: ", release_version_name)
-else:
-    release_version_name = version_from_changelog
-    print("building a release version: ", release_version_name)
+    return subprocess.check_output([
+        'git',
+        'describe',
+        '--match=xxxxxxxxxxxxxxxxxxxx',
+        '--always',
+        '--abbrev',
+        '--dirty'
+    ]).decode('ascii').strip()
 
 
-fullref=os.environ['GITHUB_REF']
+def write_changelog(version):
+    changelog = subprocess.check_output([
+        'perl',
+        f'{REPO_PATH}/.github/actions_scripts/getChangelog.pl',
+        f'{REPO_PATH}/ChangeLog',
+        version,
+    ])
+    with open(f'{REPO_PATH}/autoLatestChangelog.md', 'wb') as f:
+        f.write(changelog)
+
+
+def get_release_version_name(jamulus_pro_version):
+    if "dev" in jamulus_pro_version:
+        name = "{}-{}".format(jamulus_pro_version, get_git_hash())
+        print("building an intermediate version: ", name)
+        return name
+
+    name = jamulus_pro_version
+    print("building a release version: ", name)
+    return name
+
+
+def set_github_variable(varname, varval):
+    print("{}='{}'".format(varname, varval))  # console output
+    print("::set-output name={}::{}".format(varname, varval))
+
+
+jamulus_pro_version = get_version_from_jamulus_pro()
+write_changelog(jamulus_pro_version)
+release_version_name = get_release_version_name(jamulus_pro_version)
+
+fullref = os.environ['GITHUB_REF']
 reflist = fullref.split("/", 2)
 pushed_name = reflist[2]
 
-
-# run Changelog-script
-os.system('perl "{}"/.github/actions_scripts/getChangelog.pl "{}"/ChangeLog "{}" > "{}"/autoLatestChangelog.md'.format(
-    os.environ['GITHUB_WORKSPACE'],
-    os.environ['GITHUB_WORKSPACE'],
-    version_from_changelog,
-    os.environ['GITHUB_WORKSPACE']
-))
-
-# decisions about release, prerelease, title and tag
+# decisions about release, prerelease, title and tag:
+publish_to_release = False
+is_prerelease = True
 if fullref.startswith("refs/tags/"):
     print('this reference is a Tag')
-    release_tag = pushed_name # tag already exists
-    release_title="Release {}  ({})".format(release_version_name, pushed_name)
+    release_tag = pushed_name  # tag already exists
+    release_title = "Release {}  ({})".format(release_version_name, pushed_name)
 
     if pushed_name.startswith("r"):
+        publish_to_release = True
         if re.match(r'^r\d+_\d+_\d+$', pushed_name):
             print('this reference is a Release-Tag')
-            publish_to_release = True
             is_prerelease = False
         else:
             print('this reference is a Non-Release-Tag')
-            publish_to_release = True
-            is_prerelease = True
     else:
         print('this reference is a Non-Release-Tag')
-        publish_to_release = False
-        is_prerelease = True # just in case
+
 elif fullref.startswith("refs/heads/"):
     print('this reference is a Head/Branch')
-    publish_to_release = False
-    is_prerelease = True
-    release_title='Pre-Release of "{}"'.format(pushed_name)
-    release_tag = "releasetag/"+pushed_name #better not use pure pushed name, creates a tag with the name of the branch, leads to ambiguous references => can not push to this branch easily
+    release_title = 'Pre-Release of "{}"'.format(pushed_name)
+    release_tag = "releasetag/" + pushed_name  # better not use pure pushed name, creates a tag with the name of the branch, leads to ambiguous references => can not push to this branch easily
+
 else:
     print('unknown git-reference type: ' + fullref)
-    publish_to_release = False
-    is_prerelease = True
-    release_title='Pre-Release of "{}"'.format(pushed_name)
-    release_tag = "releasetag/"+pushed_name #avoid ambiguity in references in all cases
+    release_title = 'Pre-Release of "{}"'.format(pushed_name)
+    release_tag = "releasetag/" + pushed_name  # avoid ambiguity in references in all cases
 
-#helper function: set github variable and print it to console
-def set_github_variable(varname, varval):
-    print("{}='{}'".format(varname, varval)) #console output
-    print("::set-output name={}::{}".format(varname, varval))
-
-#set github-available variables
+# set github-available variables
 set_github_variable("PUBLISH_TO_RELEASE", str(publish_to_release).lower())
 set_github_variable("IS_PRERELEASE", str(is_prerelease).lower())
 set_github_variable("RELEASE_TITLE", release_title)

--- a/.github/actions_scripts/analyse_git_reference.py
+++ b/.github/actions_scripts/analyse_git_reference.py
@@ -80,6 +80,8 @@ if publish_to_release:
     release_tag = reflist[2]
     release_title = f"Release {release_version_name}  ({release_tag})"
     is_prerelease = not re.match(r'^r\d+_\d+_\d+$', release_tag)
+    if not is_prerelease and release_version_name != release_tag[1:].replace('_', '.'):
+        raise Exception(f"non-pre-release tag {release_tag} doesn't match Jamulus.pro VERSION = {release_version_name}")
 
     # Those variables are only used when a release is created at all:
     set_github_variable("IS_PRERELEASE", str(is_prerelease).lower())

--- a/.github/actions_scripts/analyse_git_reference.py
+++ b/.github/actions_scripts/analyse_git_reference.py
@@ -64,7 +64,7 @@ write_changelog(jamulus_pro_version)
 release_version_name = get_release_version_name(jamulus_pro_version)
 
 fullref = os.environ['GITHUB_REF']
-publish_to_release = fullref.startswith('refs/tags/r')
+publish_to_release = bool(re.match(r'^refs/tags/r\d+_\d+_\d+\S*$', fullref))
 
 # RELEASE_VERSION_NAME is required for all builds including branch pushes
 # and PRs:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -39,10 +39,7 @@ jobs:
      outputs:
       publish_to_release:           ${{ steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE }}
       upload_url:                   ${{ steps.create_release_step.outputs.upload_url }}
-      version:                      ${{ steps.jamulus-build-vars.outputs.JAMULUS_VERSION }}
       version_name:                 ${{ steps.jamulus-build-vars.outputs.RELEASE_VERSION_NAME }}
-      x_github_workspace:           ${{ steps.jamulus-build-vars.outputs.X_GITHUB_WORKSPACE }} #needed, because matrix can not directly access ${{ github.workspace }} aparrently
-
 
      steps:
          # Checkout code


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
This PR refactors `.github/actions_scripts/analyze_git_references.py`. It drops unused variables and logic, it replaces comments by (hopefully) well-named functions and fixes multiple coding style issues. It also adds a check to fail if we push release tags without proper `Jamulus.pro` `VERSION`.

Most of the changes are internal to the script and are not supposed to show a change in behavior from the outside.
Some of the changes do have an effect on the output though, which can be seen in the following output variable cleanups:

- The following variable is not referenced in the Autobuild workflow at all and can therefore be safely dropped from the script output: `PUSHED_NAME`

- The following variables are referenced in the Autobuild workflow and are declared as outputs, but those outputs are not referred to anywhere. Therefore, they can safely be dropped:
  - `PUSHED_NAME`
  - `X_GITHUB_WORKSPACE`

- The following variables are only relevant for releases (`PUBLISH_TO_RELEASE=true`). Therefore, we only need to calculate their value for actual releases:
  - `RELEASE_TITLE`
  - `RELEASE_TAG`
  - `IS_PRERELEASE`

As I suspect this PR diff is rather hard to read, I'm providing output diffs (before/after this PR, last updated 2022-03-09 11:40 CEST) for the most relevant scenarios as proof that those cases still look sane:

*Simulated push to a branch:* 
```diff
$ git status
On branch master
$ export GITHUB_WORKSPACE=. GITHUB_REF=refs/heads/somebranch; diff -u <(./.github/actions_scripts/analyse_git_reference.py | grep ::set | sort ) <(./.github/actions_scripts/analyse_git_reference_new.py | grep ::set | sort ) | grep ::set
-::set-output name=IS_PRERELEASE::true
-::set-output name=JAMULUS_VERSION::3.8.2dev-f5434765
 ::set-output name=PUBLISH_TO_RELEASE::false
-::set-output name=PUSHED_NAME::somebranch
-::set-output name=RELEASE_TAG::releasetag/somebranch
-::set-output name=RELEASE_TITLE::Pre-Release of "somebranch"
 ::set-output name=RELEASE_VERSION_NAME::3.8.2dev-f5434765
-::set-output name=X_GITHUB_WORKSPACE::.
```

*Simulated push to a release tag:*
```diff
$ git co r3_8_2
HEAD is now at 36cb9002 Update to version 3.8.2 for release
$ git status
HEAD detached at r3_8_2
$ export GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_8_2; diff -u <(./.github/actions_scripts/analyse_git_reference.py | grep ::set | sort ) <(./.github/actions_scripts/analyse_git_reference_new.py | grep ::set | sort ) | grep ::set
 ::set-output name=IS_PRERELEASE::false
-::set-output name=JAMULUS_VERSION::3.8.2
 ::set-output name=PUBLISH_TO_RELEASE::true
-::set-output name=PUSHED_NAME::r3_8_2
 ::set-output name=RELEASE_TAG::r3_8_2
 ::set-output name=RELEASE_TITLE::Release 3.8.2  (r3_8_2)
 ::set-output name=RELEASE_VERSION_NAME::3.8.2
-::set-output name=X_GITHUB_WORKSPACE::.
```

*Simulated push to a pre-release tag:*
```diff
$ git co r3_8_2rc1
HEAD is now at c4450193 Update version to 3.8.2rc1
$ git status
HEAD detached at r3_8_2rc1
$ export GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_8_2rc1; diff -u <(./.github/actions_scripts/analyse_git_reference.py | grep ::set | sort ) <(./.github/actions_scripts/analyse_git_reference_new.py | grep ::set | sort ) | grep ::set
 ::set-output name=IS_PRERELEASE::true
-::set-output name=JAMULUS_VERSION::3.8.2rc1
 ::set-output name=PUBLISH_TO_RELEASE::true
-::set-output name=PUSHED_NAME::r3_8_2rc1
 ::set-output name=RELEASE_TAG::r3_8_2rc1
 ::set-output name=RELEASE_TITLE::Release 3.8.2rc1  (r3_8_2rc1)
 ::set-output name=RELEASE_VERSION_NAME::3.8.2rc1
-::set-output name=X_GITHUB_WORKSPACE::.
```

*Simulated push to a nightly tag:*
```diff
$ git co r3_7_0devNightly1
HEAD is now at cae8d2d6 Prerelease r3_7_0devNightly1
$ git status
HEAD detached at r3_7_0devNightly1
$ export GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/r3_7_0devNightly1; diff -u <(./.github/actions_scripts/analyse_git_reference.py | grep ::set | sort ) <(./.github/actions_scripts/analyse_git_reference_new.py | grep ::set | sort ) | grep ::set
 ::set-output name=IS_PRERELEASE::true
-::set-output name=JAMULUS_VERSION::3.7.0devNightly1-cae8d2d6
 ::set-output name=PUBLISH_TO_RELEASE::true
-::set-output name=PUSHED_NAME::r3_7_0devNightly1
 ::set-output name=RELEASE_TAG::r3_7_0devNightly1
 ::set-output name=RELEASE_TITLE::Release 3.7.0devNightly1-cae8d2d6  (r3_7_0devNightly1)
 ::set-output name=RELEASE_VERSION_NAME::3.7.0devNightly1-cae8d2d6
-::set-output name=X_GITHUB_WORKSPACE::.
```

**Note:** Releases which use other separators than `_` will no longer be considered releases. This affects some nightly versions (`r3.8.0devNightly1`) which have been tagged differently than previously (`r3_7_0devNightly1`). I'd like to keep it like that as we should be consistent in our tags (although I'm not opposed to switching from rA_B_C to the more common vA.B.C, but that's out-of-scope for this PR.)

*Simulated push to a non-version tag starting with r (is this case relevant?):*
```diff
$ export GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/rnon-release-tag-starting-with-r; diff -u <(./.github/actions_scripts/analyse_git_reference.py | grep ::set | sort ) <(./.github/actions_scripts/analyse_git_reference_new.py | grep ::set | sort ) | grep ::set
-::set-output name=IS_PRERELEASE::true
-::set-output name=JAMULUS_VERSION::3.8.2dev-f5434765
-::set-output name=PUBLISH_TO_RELEASE::true
-::set-output name=PUSHED_NAME::rnon-release-tag-starting-with-r
-::set-output name=RELEASE_TAG::rnon-release-tag-starting-with-r
-::set-output name=RELEASE_TITLE::Release 3.8.2dev-f5434765  (rnon-release-tag-starting-with-r)
+::set-output name=PUBLISH_TO_RELEASE::false
 ::set-output name=RELEASE_VERSION_NAME::3.8.2dev-f5434765
-::set-output name=X_GITHUB_WORKSPACE::.
```

*Simulated push to a non-version tag not starting with r:*
```diff
$ export GITHUB_WORKSPACE=. GITHUB_REF=refs/tags/non-release-tag; diff -u <(./.github/actions_scripts/analyse_git_reference.py | grep ::set | sort ) <(./.github/actions_scripts/analyse_git_reference_new.py | grep ::set | sort ) | grep ::set
-::set-output name=IS_PRERELEASE::true
-::set-output name=JAMULUS_VERSION::3.8.2dev-f5434765
 ::set-output name=PUBLISH_TO_RELEASE::false
-::set-output name=PUSHED_NAME::non-release-tag
-::set-output name=RELEASE_TAG::non-release-tag
-::set-output name=RELEASE_TITLE::Release 3.8.2dev-f5434765  (non-release-tag)
 ::set-output name=RELEASE_VERSION_NAME::3.8.2dev-f5434765
-::set-output name=X_GITHUB_WORKSPACE::.
```


CHANGELOG: Autobuild: Improved analyze_git_references.py script
(I'll likely merge all my Autobuild refactoring-related Changelog entries in the end)

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Improves readability/maintenance.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for review.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
I'm still planning the following tests on my fork:
- [x] Push a release tag (check release/changelog): [Artifact names are correct](https://github.com/hoffie/jamulus/runs/5460766607?check_suite_focus=true#step:3:4), [Artifact names are connect](https://github.com/hoffie/jamulus/actions/runs/1950050554)
- [x] Push a pre-release tag (check release/changelog): [Variables are correct](https://github.com/hoffie/jamulus/runs/5460796561?check_suite_focus=true#step:3:4), [Artifacts still building](https://github.com/hoffie/jamulus/actions/runs/1950062857)
- [x] Push to a branch: [Variables are correct](https://github.com/hoffie/jamulus/runs/5457570123?check_suite_focus=true#step:3:4) [Artifacts names are correct](https://github.com/hoffie/jamulus/actions/runs/1948744252)
- [x] A PR (this very PR should suffice for this test): [Variables are correct](https://github.com/jamulussoftware/jamulus/runs/5457622201?check_suite_focus=true#step:3:4), [Artifact names are correct](https://github.com/jamulussoftware/jamulus/actions/runs/1948763742)

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
