### PR TITLE
Autobuild: Stop installing unneeded debian packages (Linux/Android)

### DIFF
--- a/autobuild/android/autobuild_apk_1_prepare.sh
+++ b/autobuild/android/autobuild_apk_1_prepare.sh
@@ -15,8 +15,8 @@ echo "::set-env name=DEBIAN_FRONTEND::${DEBIAN_FRONTEND}"
 
 sudo apt-get -qq update
 # Dependencies to create Android pkg
-sudo apt-get -qq -y install build-essential git zip unzip bzip2 p7zip-full wget curl chrpath libxkbcommon-x11-0 \
-    openjdk-8-jre openjdk-8-jdk openjdk-8-jdk-headless gradle
+sudo apt-get -qq --no-install-recommends -y install build-essential zip unzip bzip2 p7zip-full wget curl chrpath libxkbcommon-x11-0 \
+    openjdk-8-jre-headless openjdk-8-jdk-headless
 
 # Add Android tools and platform tools to PATH
 export ANDROID_HOME="/opt/android/android-sdk"

--- a/autobuild/linux/autobuild_deb_1_prepare.sh
+++ b/autobuild/linux/autobuild_deb_1_prepare.sh
@@ -13,4 +13,4 @@ echo "Update system..."
 sudo apt-get -qq update
 
 echo "Install dependencies..."
-sudo apt-get -qq -y install devscripts build-essential debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools
+sudo apt-get -qq --no-install-recommends -y install devscripts build-essential debhelper libjack-jackd2-dev qtbase5-dev qttools5-dev-tools


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
- Use `apt --no-install-recommends` avoid installation of unneeded packages.
- Android:
  - Drop `git` (Github's image already contains it)
  - Drop `gradle` (this is downloaded anyway)
  - Use headless JDK/JRE -- we don't start GUI apps during build

CHANGELOG: Autobuild: Improved build preparation performance.
(Changelog entry should probably be merged with other Autobuild-related entries later)

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Speed up build, save resources.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Reviews.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above