### PR TITLE
Build: Drop qmake application bundle name

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -145,7 +145,6 @@ win32 {
     OBJECTIVE_SOURCES += mac/activity.mm
     CONFIG += x86
     QMAKE_TARGET_BUNDLE_PREFIX = io.jamulus
-    QMAKE_APPLICATION_BUNDLE_NAME. = $$TARGET
 
     OSX_ENTITLEMENTS.files = Jamulus.entitlements
     OSX_ENTITLEMENTS.path = Contents/Resources
@@ -201,7 +200,6 @@ win32 {
     HEADERS += ios/sound.h
     OBJECTIVE_SOURCES += ios/sound.mm
     QMAKE_TARGET_BUNDLE_PREFIX = io.jamulus
-    QMAKE_APPLICATION_BUNDLE_NAME. = $$TARGET
     LIBS += -framework AVFoundation \
         -framework AudioToolbox
 } else:android {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
Jamulus.pro sets `QMAKE_APPLICATION_BUNDLE_NAME.` (note the trailing dot). This sets the variable with exactly this name, but not the probably intended dot-less `QMAKE_APPLICATION_BUNDLE_NAME` .

As this can't have worked in the past, it's obviously not necessary. So instead of fixing the assignment, the line is dropped altogether.

The [docs](https://doc.qt.io/qt-5/qmake-variable-reference.html) suggest that QMAKE_APPLICATION_BUNDLE_NAME is used in the plist generation logic, but that the relevant place defaults to using TARGET, which we do set properly. This highlights that it should be ok to work without QMAKE_APPLICATION_BUNDLE_NAME.

CHANGELOG: Build: Removed broken QMAKE_APPLICATION_BUNDLE_NAME. logic.
(I'll probably merge this Changelog line with other autobuild improvements)

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Remove broken code.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready on CI green.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Reviews.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
