### PR TITLE
tools/generate_json_rpc_docs.py: Fix minor coding style issues

### DIFF
--- a/tools/generate_json_rpc_docs.py
+++ b/tools/generate_json_rpc_docs.py
@@ -19,6 +19,7 @@ source_files = [
 
 repo_root = os.path.join(os.path.dirname(__file__), '..')
 
+
 class DocumentationItem:
     """
     Represents a documentation item. In the source code they look like this:
@@ -26,11 +27,17 @@ class DocumentationItem:
         /// @rpc_notification jamulusclient/channelLevelListReceived
         /// @brief Emitted when the channel level list is received.
         /// @param {array} params.channelLevelList - The channel level list.
-        ///  Each item corresponds to the respective client retrieved from the jamulusclient/clientListReceived notification.
-        /// @param {number} params.channelLevelList[*] - The channel level, an integer between 0 and 9.
+        ///  Each item corresponds to the respective client retrieved from the
+        ///  jamulusclient/clientListReceived notification.
+        /// @param {number} params.channelLevelList[*] - The channel level,
+        ///  an integer between 0 and 9.
     """
 
     def __init__(self, name, type_):
+        """
+        @param name: str
+        @param type: str
+        """
         self.name = name
         self.type = type_
         self.brief = DocumentationText()
@@ -38,6 +45,9 @@ class DocumentationItem:
         self.results = []
 
     def handle_tag(self, tag_name):
+        """
+        @param tag_name: str, brief|param|result
+        """
         if tag_name == "brief":
             self.current_tag = self.brief
         elif tag_name == "param":
@@ -50,12 +60,21 @@ class DocumentationItem:
             raise Exception("Unknown tag: " + tag_name)
 
     def handle_text(self, text):
+        """
+        @param text: str
+        """
         self.current_tag.add_text(text)
 
     def sort_key(self):
+        """
+        @return str
+        """
         return self.type + ": " + self.name
 
     def to_markdown(self):
+        """
+        @return: Markdown-formatted str with name, brief, params and results
+        """
         output = []
         output.append("### " + self.name)
         output.append("")
@@ -83,12 +102,19 @@ class DocumentationText:
     """
 
     def __init__(self):
+        """Constructor"""
         self.parts = []
 
     def add_text(self, text):
+        """
+        @param text: str
+        """
         self.parts.append(text)
 
     def __str__(self):
+        """
+        @return: Space-delimited list of previously added parts
+        """
         return " ".join(self.parts)
 
 
@@ -98,16 +124,23 @@ class DocumentationTable:
     """
 
     def __init__(self, tags):
+        """
+        @param tags: iterable
+        """
         self.tags = tags
 
     def to_markdown(self):
+        """
+        @return: str containing the Markdown table
+        """
         output = []
         output.append("| Name | Type | Description |")
         output.append("| --- | --- | --- |")
+        tag_re = re.compile(r"^\{(\w+)\}\s+([\S]+)\s+-\s+(.*)$", re.DOTALL)
         for tag in self.tags:
             text = str(tag)
             # Parse tag in form of "{type} name - description"
-            match = re.match(r"^\{(\w+)\}\s+([\S]+)\s+-\s+(.*)$", text, re.DOTALL)
+            match = tag_re.match(text)
             if match:
                 type_ = match.group(1)
                 name = match.group(2)

--- a/tools/generate_json_rpc_docs.py
+++ b/tools/generate_json_rpc_docs.py
@@ -30,9 +30,9 @@ class DocumentationItem:
         /// @param {number} params.channelLevelList[*] - The channel level, an integer between 0 and 9.
     """
 
-    def __init__(self, name, type):
+    def __init__(self, name, type_):
         self.name = name
-        self.type = type
+        self.type = type_
         self.brief = DocumentationText()
         self.params = []
         self.results = []
@@ -109,10 +109,10 @@ class DocumentationTable:
             # Parse tag in form of "{type} name - description"
             match = re.match(r"^\{(\w+)\}\s+([\S]+)\s+-\s+(.*)$", text, re.DOTALL)
             if match:
-                type = match.group(1)
+                type_ = match.group(1)
                 name = match.group(2)
                 description = re.sub(r"^\s+", " ", match.group(3)).strip()
-                output.append("| " + name + " | " + type + " | " + description + " |")
+                output.append(f"| {name} | {type_} | {description} |")
         return "\n".join(output)
 
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill the following to make the review process straight forward -->

**Short description of changes**
<!-- Explain what your PR does -->
- tools/generate_json_rpc_docs: Avoid re-use of built-in 'type'
- tools/generate_json_rpc_docs: Fix flake8 warnings
  Mainly docstrings and line length.

(Note: flakes8 still complains about the line length of the included markdown text. I'd keep it as-is though).
CHANGELOG: SKIP

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
<img src="https://user-images.githubusercontent.com/20726856/157529286-7958fc5b-20f4-4b88-abb3-b1f04c340eb5.png" width="800">

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
