### PR TITLE
Do not show ASIO related warning message if using JACK

### DIFF
--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -176,7 +176,7 @@ QString CSoundBase::SetDev ( const QString strDevName )
             }
             sErrorMessage += "</ul>";
 
-#ifdef _WIN32
+#if defined( _WIN32 ) && !defined( WITH_JACK )
             // to be able to access the ASIO driver setup for changing, e.g., the sample rate, we
             // offer the user under Windows that we open the driver setups of all registered
             // ASIO drivers


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Basically https://github.com/jamulussoftware/jamulus/pull/2168/commits/fd7bfe68af1f25a132da0bb2a9337a09d4dad155 split out as separate commit.

CHANGELOG: Windows: The JACK build now no longer gives an ASIO related warning message on an incompatible state

**Context: Fixes an issue?**
No.

**Does this change need documentation? What needs to be documented and how?**
No. Bug Fix

**Status of this Pull Request**
Not yet tested, just ported

**What is missing until this pull request can be merged?**
Testing and review.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
