### PR TITLE
Autobuild: Fail if build artifact_1 is missing

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -233,7 +233,8 @@ jobs:
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
 
       - name:                       Upload Artifact 1 to Job
-        if:                         steps.step_cmd3_postbuild.outputs.artifact_1
+        # Every build job has at least one artifact. Therefore, no `if` here.
+        # If the artifact is missing, this should fail.
         uses:                       actions/upload-artifact@v2
         with:
           name:                     ${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
@@ -252,7 +253,6 @@ jobs:
 
       - name:                       Notarize macOS Release Build
         if:                         >-
-                                    steps.step_cmd3_postbuild.outputs.artifact_1 != '' &&
                                     steps.step_build.outputs.macos_signed == 'true' &&
                                     contains(needs.create_release.outputs.publish_to_release, 'true')
         id:                         notarize-macOS-app
@@ -265,7 +265,6 @@ jobs:
 
       - name:                       Staple macOS Release Build
         if:                         >-
-                                    steps.step_cmd3_postbuild.outputs.artifact_1 != '' &&
                                     steps.step_build.outputs.macos_signed == 'true' &&
                                     contains(needs.create_release.outputs.publish_to_release, 'true')
         id:                         staple-macOS-app
@@ -274,9 +273,9 @@ jobs:
           product-path:             deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
 
       - name:                       Upload Artifact 1 to Release
-        if:                         >-
-                                    steps.step_cmd3_postbuild.outputs.artifact_1 != '' &&
-                                    contains(needs.create_release.outputs.publish_to_release, 'true')
+        # Every build job has at least one artifact. Therefore, no `if artifact_1` condition here.
+        # If the artifact is missing, this should fail.
+        if:                         contains(needs.create_release.outputs.publish_to_release, 'true')
         id:                         upload-release-asset1
         uses:                       actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
Previously, the job and release upload actions simply chose not to run when there's no artifact_1. However, all jobs should have at least one artifact, so this commit makes those steps fail in order to make potential errors visible instead of failing silently (all green, but missing artifact in job or release).

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!-- Explain what your PR does -->

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast -->

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2500.

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
- [x] CI on this PR needs to stay green (8marking as checked as it finished on my branch already](https://github.com/hoffie/jamulus/actions/runs/1975884991))
- [x] CI on a tree with empty cmd3 output should fail ([see this test run](https://github.com/hoffie/jamulus/actions/runs/1975895187))

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
