### PR TITLE
JSON-RPC: Add server directory name (issue #2467)

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -65,7 +65,7 @@ Parameters:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| params | object | No parameters (empty object). |
+| params.secret | string | The preshared secret key. |
 
 Results:
 
@@ -276,6 +276,7 @@ Results:
 | result.city | string | The server city. |
 | result.countryId | number | The server country ID (see QLocale::Country). |
 | result.welcomeMessage | string | The server welcome message. |
+| result.directoryServer | string | The directory server to which this server requested registration, or blank if none. |
 | result.registrationStatus | string | The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus). |
 
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -226,7 +226,7 @@ void CRpcServer::ProcessMessage ( QTcpSocket* pSocket, QJsonObject message, QJso
     {
         /// @rpc_method jamulus/apiAuth
         /// @brief Authenticates the connection which is a requirement for calling further methods.
-        /// @param {object} params - No parameters (empty object).
+        /// @param {string} params.secret - The preshared secret key.
         /// @result {string} result - "ok" on success
         HandleApiAuth ( pSocket, params, response );
         return;

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -106,13 +106,20 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
     /// @result {string} result.city - The server city.
     /// @result {number} result.countryId - The server country ID (see QLocale::Country).
     /// @result {string} result.welcomeMessage - The server welcome message.
+    /// @result {string} result.directoryServer - The directory server to which this server requested registration, or blank if none.
     /// @result {string} result.registrationStatus - The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus).
     pRpcServer->HandleMethod ( "jamulusserver/getServerProfile", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        QString dsName = "";
+
+        if ( AT_NONE != pServer->GetDirectoryType() )
+            dsName = NetworkUtil::GetDirectoryAddress ( pServer->GetDirectoryType(), pServer->GetDirectoryAddress() );
+
         QJsonObject result{
             { "name", pServer->GetServerName() },
             { "city", pServer->GetServerCity() },
             { "countryId", pServer->GetServerCountry() },
             { "welcomeMessage", pServer->GetWelcomeMessage() },
+            { "directoryServer", dsName },
             { "registrationStatus", SerializeRegistrationStatus ( pServer->GetSvrRegStatus() ) },
         };
         response["result"] = result;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Addresses directory server name in issue #2467 and fixes minor doc issue.  Regenerated JSON-RPC doc using tools python script.

CHANGELOG: Extended JSON-RPC jamulusserver/getServerProfile method to include directoryServer name for registration requests.

**Context: Fixes an issue?**

Fixes: #2467 


**Does this change need documentation? What needs to be documented and how?**

Auto-documented using python doc tool for JSON-RPC.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Tested on Linux only.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [X] I tested my code and it does what I want
- [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [X] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [X] I've filled all the content above
