### PR TITLE
Do not run CI on documentation changes

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -27,9 +27,27 @@ on:
       # CodeQL requires every branch from on.pull_request to be part of on.push as well in order to run comparisons.
       # We also need master here to trigger builds on PR merge to master and manual pushes (e.g. as part of the release process):
       - "master"
+    paths-ignore:
+      - '**README.md'
+      - 'docs/**'
+      - 'SECURITY.md'
+      - 'COMPILING.md'
+      - 'COPYING'
+      - 'APPLEAPPSTORE.LICENCE.WAIVER'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/pull_request_template.md'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**README.md'
+      - 'docs/**'
+      - 'SECURITY.md'
+      - 'COMPILING.md'
+      - 'COPYING'
+      - 'APPLEAPPSTORE.LICENCE.WAIVER'
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/pull_request_template.md'
 
 name:                               Auto-Build
 jobs:


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Stops running the CI if the documentation changes. There is no need of running the CI on non source files. New version of #1921 I think this is a quick fix (and can be update ofc.)

CHANGELOG: Stop running Autobuild if only documentation is updated to avoid wasting computation time.

**Context: Fixes an issue?**
No. Related to https://github.com/jamulussoftware/jamulus/discussions/2282#discussioncomment-2046262

**Does this change need documentation? What needs to be documented and how?**
No

**Status of this Pull Request**
Ready for review

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want (https://github.com/ann0see/jamulus/actions/runs/2013115499 and https://github.com/ann0see/jamulus/commits/autobuild/noRunDocs are small tests)
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
