### PR TITLE
Autobuild: Don't run building ARM on non-releases

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -102,7 +102,8 @@ jobs:
             cmd3_postbuild:         ./.github/autobuild/linux_deb.sh get-artifacts
             run_codeql:             true
 
-          - config_name:            Linux .deb armhf (artifacts)
+          - config_name:            Linux .deb armhf (artifacts, release only)
+            if:                     contains(needs.create_release.outputs.publish_to_release, 'true')
             target_os:              linux
             building_on_os:         ubuntu-18.04
             cmd1_prebuild:          TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh setup

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -103,7 +103,7 @@ jobs:
             run_codeql:             true
 
           - config_name:            Linux .deb armhf (artifacts, release only)
-            if:                     contains(needs.create_release.outputs.publish_to_release, 'true')
+            if:                     needs.create_release.outputs.publish_to_release == 'true'
             target_os:              linux
             building_on_os:         ubuntu-18.04
             cmd1_prebuild:          TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh setup


### PR DESCRIPTION
**Short description of changes**
This prevents unneeded builds on ARM since the intel builds already 
check the same code. We still run this on betas and everything which creates a GitHub release.

CHANGELOG: SKIP

**Context: Fixes an issue?**
No, https://github.com/jamulussoftware/jamulus/discussions/2282#discussioncomment-2046262 is related

**Does this change need documentation? What needs to be documented and how?**
No.

**Status of this Pull Request**
Probably worth a discussion; however my standpoint is: We don't need to check building on ARM until we do beta releases. Also we could ensure that the workflow_dispatch event runs ARM builds (but that isn't implemented yet).

**What is missing until this pull request can be merged?**
Review.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
