### PR TITLE
Add rate-limiting for channel gain change messages

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -173,6 +173,11 @@ CClient::CClient ( const quint16  iPortNumber,
     // start timer so that elapsed time works
     PreciseTime.start();
 
+    // set gain delay timer to single-shot and connect handler function
+    TimerGain.setSingleShot ( true );
+
+    QObject::connect ( &TimerGain, &QTimer::timeout, this, &CClient::OnTimerRemoteChanGain );
+
     // start the socket (it is important to start the socket after all
     // initializations and connections)
     Socket.Start();
@@ -335,15 +340,85 @@ void CClient::SetDoAutoSockBufSize ( const bool bValue )
     CreateServerJitterBufferMessage();
 }
 
+// In order not to flood the server with gain change messages, particularly when using
+// a MIDI controller, a timer is used to limit the rate at which such messages are generated.
+// This avoids a potential long backlog of messages, since each must be ACKed before the next
+// can be sent, and this ACK is subject to the latency of the server connection.
+//
+// When the first gain change message is requested after an idle period (i.e. the timer is not
+// running), it will be sent immediately, and a 300ms timer started.
+//
+// If a gain change message is requested while the timer is still running, the new gain is not sent,
+// but just stored in newGain[iId], and the minGainId and maxGainId updated to note the range of
+// IDs that must be checked when the time expires (this will usually be a single channel
+// unless channel grouping is being used). This avoids having to check all possible channels.
+//
+// When the timer fires, the channels minGainId <= iId < maxGainId are checked by comparing
+// the last sent value in oldGain[iId] with any pending value in newGain[iId], and if they differ,
+// the new value is sent, updating oldGain[iId] with the sent value. If any new values are
+// sent, the timer is restarted so that further immediate updates will be pended.
+
 void CClient::SetRemoteChanGain ( const int iId, const float fGain, const bool bIsMyOwnFader )
 {
+    QMutexLocker locker ( &MutexGain );
+
     // if this gain is for my own channel, apply the value for the Mute Myself function
     if ( bIsMyOwnFader )
     {
         fMuteOutStreamGain = fGain;
     }
 
+    if ( TimerGain.isActive() )
+    {
+        // just update the new value for sending later;
+        // will compare with oldGain[iId] when the timer fires
+        newGain[iId] = fGain;
+
+        // update range of channel IDs to check in the timer
+        if ( iId < minGainId )
+            minGainId = iId; // first value to check
+        if ( iId >= maxGainId )
+            maxGainId = iId + 1; // first value NOT to check
+
+        return;
+    }
+
+    // here the timer was not active:
+    // send the actual gain and reset the range of channel IDs to empty
+    oldGain[iId] = newGain[iId] = fGain;
     Channel.SetRemoteChanGain ( iId, fGain );
+
+    maxGainId = 0;
+    minGainId = MAX_NUM_CHANNELS;
+
+    // start timer to delay sending further updates
+    TimerGain.start ( GAIN_DELAY_PERIOD_MS );
+}
+
+void CClient::OnTimerRemoteChanGain()
+{
+    QMutexLocker locker ( &MutexGain );
+    bool         bSent = false;
+
+    for ( int iId = minGainId; iId < maxGainId; iId++ )
+    {
+        if ( newGain[iId] != oldGain[iId] )
+        {
+            // send new gain and record as old gain
+            float fGain = oldGain[iId] = newGain[iId];
+            Channel.SetRemoteChanGain ( iId, fGain );
+            bSent = true;
+        }
+    }
+
+    // if a new gain has been sent, reset the range of channel IDs to empty and start timer
+    if ( bSent )
+    {
+        maxGainId = 0;
+        minGainId = MAX_NUM_CHANNELS;
+
+        TimerGain.start ( GAIN_DELAY_PERIOD_MS );
+    }
 }
 
 bool CClient::SetServerAddr ( QString strNAddr )

--- a/src/client.h
+++ b/src/client.h
@@ -73,6 +73,9 @@
 // audio reverberation range
 #define AUD_REVERB_MAX 100
 
+// delay period between successive gain updates (ms)
+#define GAIN_DELAY_PERIOD_MS 300
+
 // OPUS number of coded bytes per audio packet
 // TODO we have to use new numbers for OPUS to avoid that old CELT packets
 // are used in the OPUS decoder (which gives a bad noise output signal).
@@ -237,6 +240,8 @@ public:
 
     void SetRemoteChanGain ( const int iId, const float fGain, const bool bIsMyOwnFader );
 
+    void OnTimerRemoteChanGain();
+
     void SetRemoteChanPan ( const int iId, const float fPan ) { Channel.SetRemoteChanPan ( iId, fPan ); }
 
     void SetInputBoost ( const int iNewBoost ) { iInputBoost = iNewBoost; }
@@ -353,6 +358,14 @@ protected:
 
     // for ping measurement
     QElapsedTimer PreciseTime;
+
+    // for gain rate limiting
+    QMutex MutexGain;
+    QTimer TimerGain;
+    int    minGainId;
+    int    maxGainId;
+    float  oldGain[MAX_NUM_CHANNELS];
+    float  newGain[MAX_NUM_CHANNELS];
 
     CSignalHandler* pSignalHandler;
 

--- a/src/client.h
+++ b/src/client.h
@@ -73,8 +73,9 @@
 // audio reverberation range
 #define AUD_REVERB_MAX 100
 
-// delay period between successive gain updates (ms)
-#define GAIN_DELAY_PERIOD_MS 300
+// default delay period between successive gain updates (ms)
+// this will be increased to double the ping time if connected to a distant server
+#define DEFAULT_GAIN_DELAY_PERIOD_MS 50
 
 // OPUS number of coded bytes per audio packet
 // TODO we have to use new numbers for OPUS to avoid that old CELT packets
@@ -239,8 +240,8 @@ public:
     void SetMuteOutStream ( const bool bDoMute ) { bMuteOutStream = bDoMute; }
 
     void SetRemoteChanGain ( const int iId, const float fGain, const bool bIsMyOwnFader );
-
     void OnTimerRemoteChanGain();
+    void StartDelayTimer();
 
     void SetRemoteChanPan ( const int iId, const float fPan ) { Channel.SetRemoteChanPan ( iId, fPan ); }
 
@@ -366,6 +367,7 @@ protected:
     int    maxGainId;
     float  oldGain[MAX_NUM_CHANNELS];
     float  newGain[MAX_NUM_CHANNELS];
+    int    iCurPingTime;
 
     CSignalHandler* pSignalHandler;
 


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!-- Explain what your PR does -->
Adds rate-limiting for channel gain change messages.
This avoids a backlog of messages being queued due to ACK latency,
particularly if using a MIDI controller that send fine-grained
level changes. After sending a gain change message, further gain
changes will be updated locally for ~300ms~ a time and then the latest
value sent to the server. This time will be 50ms by default, or double the
current ping time, whichever is greater.

CHANGELOG: Client: Fix potential long delay in sending fader changes to the server.

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2492 

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No, bug fix only

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Tested and working

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Review and testing on other platforms, and by @bawbgale, who reported the issue

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
