### PR TITLE
Stop the build if the audio SDK is missing

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -101,7 +101,7 @@ win32 {
             libjackname = "libjack64.lib"
         }
         !exists("$${programfilesdir}/JACK2/include/jack/jack.h") {
-            message("Warning: jack.h was not found in the expected location ($${programfilesdir}). Ensure that the right JACK2 variant is installed (32bit vs. 64bit).")
+            error("Error: jack.h was not found in the expected location ($${programfilesdir}). Ensure that the right JACK2 variant is installed (32bit vs. 64bit).")
         }
 
         HEADERS += linux/sound.h
@@ -115,6 +115,9 @@ win32 {
         message(Using ASIO.)
         message(Please review the ASIO SDK licence.)
 
+        !exists(windows/ASIOSDK2) {
+            error("Error: ASIOSDK2 must be placed in Jamulus windows folder.")
+        }
         # Important: Keep those ASIO includes local to this build target in
         # order to avoid poisoning other builds license-wise.
         HEADERS += windows/sound.h
@@ -177,7 +180,7 @@ win32 {
         message(Using JACK.)
         !exists(/usr/include/jack/jack.h) {
             !exists(/usr/local/include/jack/jack.h) {
-                 message("Warning: jack.h was not found at the usual place, maybe jack is not installed")
+                 error("Error: jack.h was not found at the usual place, maybe jack is not installed")
             }
         }
         HEADERS += linux/sound.h


### PR DESCRIPTION
**Short description of changes**
Stop the build if the audio SDK is missing

CHANGELOG: Stop the build if the audio SDK is missing

**Context: Fixes an issue?**
See https://github.com/jamulussoftware/jamulus/pull/2525#discussion_r830501622

**Does this change need documentation? What needs to be documented and how?**
No.

**Status of this Pull Request**
Hopefully doesn't break the build when it should work.  WFM...

**What is missing until this pull request can be merged?**
Could do with others testing the other configurations (I don't have 32bit Windows or build 32bit on 64bit).

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
