### PR TITLE
Autobuild: Derive all step commands from a base_command + multiple minor fixes

### DIFF
--- a/.github/actions_scripts/analyse_git_reference.py
+++ b/.github/actions_scripts/analyse_git_reference.py
@@ -43,7 +43,7 @@ def write_changelog(version):
         f.write(changelog)
 
 
-def get_release_version_name(jamulus_pro_version):
+def get_build_version(jamulus_pro_version):
     if "dev" in jamulus_pro_version:
         name = "{}-{}".format(jamulus_pro_version, get_git_hash())
         print("building an intermediate version: ", name)
@@ -61,14 +61,14 @@ def set_github_variable(varname, varval):
 
 jamulus_pro_version = get_version_from_jamulus_pro()
 write_changelog(jamulus_pro_version)
-release_version_name = get_release_version_name(jamulus_pro_version)
+build_version = get_build_version(jamulus_pro_version)
 
 fullref = os.environ['GITHUB_REF']
 publish_to_release = bool(re.match(r'^refs/tags/r\d+_\d+_\d+\S*$', fullref))
 
-# RELEASE_VERSION_NAME is required for all builds including branch pushes
+# BUILD_VERSION is required for all builds including branch pushes
 # and PRs:
-set_github_variable("RELEASE_VERSION_NAME", release_version_name)
+set_github_variable("BUILD_VERSION", build_version)
 
 # PUBLISH_TO_RELEASE is always required as the workflow decides about further
 # steps based on this. It will only be true for tag pushes with a tag
@@ -78,10 +78,10 @@ set_github_variable("PUBLISH_TO_RELEASE", str(publish_to_release).lower())
 if publish_to_release:
     reflist = fullref.split("/", 2)
     release_tag = reflist[2]
-    release_title = f"Release {release_version_name}  ({release_tag})"
+    release_title = f"Release {build_version}  ({release_tag})"
     is_prerelease = not re.match(r'^r\d+_\d+_\d+$', release_tag)
-    if not is_prerelease and release_version_name != release_tag[1:].replace('_', '.'):
-        raise Exception(f"non-pre-release tag {release_tag} doesn't match Jamulus.pro VERSION = {release_version_name}")
+    if not is_prerelease and build_version != release_tag[1:].replace('_', '.'):
+        raise Exception(f"non-pre-release tag {release_tag} doesn't match Jamulus.pro VERSION = {build_version}")
 
     # Those variables are only used when a release is created at all:
     set_github_variable("IS_PRERELEASE", str(is_prerelease).lower())

--- a/.github/autobuild/android.sh
+++ b/.github/autobuild/android.sh
@@ -75,8 +75,8 @@ setup_qt() {
 }
 
 build_app_as_apk() {
-    QT_DIR="${QT_BASEDIR}/${QT_VERSION}/android"
-    MAKE="${ANDROID_NDK_ROOT}/prebuilt/${ANDROID_NDK_HOST}/bin/make"
+    local QT_DIR="${QT_BASEDIR}/${QT_VERSION}/android"
+    local MAKE="${ANDROID_NDK_ROOT}/prebuilt/${ANDROID_NDK_HOST}/bin/make"
 
     "${QT_DIR}/bin/qmake" -spec android-clang
     "${MAKE}" -j "$(nproc)"
@@ -87,7 +87,7 @@ build_app_as_apk() {
 
 pass_artifact_to_job() {
     mkdir deploy
-    artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_android.apk"
+    local artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_android.apk"
     echo "Moving ${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk to deploy/${artifact_deploy_filename}"
     mv "./${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk" "./deploy/${artifact_deploy_filename}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename}"

--- a/.github/autobuild/android.sh
+++ b/.github/autobuild/android.sh
@@ -87,10 +87,10 @@ build_app_as_apk() {
 
 pass_artifact_to_job() {
     mkdir deploy
-    local artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_android.apk"
-    echo "Moving ${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk to deploy/${artifact_deploy_filename}"
-    mv "./${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk" "./deploy/${artifact_deploy_filename}"
-    echo "::set-output name=artifact_1::${artifact_deploy_filename}"
+    local artifact="jamulus_${JAMULUS_BUILD_VERSION}_android.apk"
+    echo "Moving ${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk to deploy/${artifact}"
+    mv "./${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk" "./deploy/${artifact}"
+    echo "::set-output name=artifact_1::${artifact}"
 }
 
 case "${1:-}" in

--- a/.github/autobuild/android.sh
+++ b/.github/autobuild/android.sh
@@ -22,8 +22,8 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/"
 export PATH="${PATH}:${ANDROID_SDK_ROOT}/tools"
 export PATH="${PATH}:${ANDROID_SDK_ROOT}/platform-tools"
 
-if [[ ! ${jamulus_buildversionstring:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Environment variable jamulus_buildversionstring has to be set to a valid version string"
+if [[ ! ${JAMULUS_BUILD_VERSION:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Environment variable JAMULUS_BUILD_VERSION has to be set to a valid version string"
     exit 1
 fi
 
@@ -87,7 +87,7 @@ build_app_as_apk() {
 
 pass_artifact_to_job() {
     mkdir deploy
-    artifact_deploy_filename="jamulus_${jamulus_buildversionstring}_android.apk"
+    artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_android.apk"
     echo "Moving ${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk to deploy/${artifact_deploy_filename}"
     mv "./${BUILD_DIR}/build/outputs/apk/debug/build-debug.apk" "./deploy/${artifact_deploy_filename}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename}"

--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -30,7 +30,7 @@ build_app_as_ipa() {
 }
 
 pass_artifact_to_job() {
-    artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
+    local artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
     echo "Moving build artifact to deploy/${artifact_deploy_filename}"
     mv ./deploy/Jamulus.ipa "./deploy/${artifact_deploy_filename}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename}"

--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -30,10 +30,10 @@ build_app_as_ipa() {
 }
 
 pass_artifact_to_job() {
-    local artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
-    echo "Moving build artifact to deploy/${artifact_deploy_filename}"
-    mv ./deploy/Jamulus.ipa "./deploy/${artifact_deploy_filename}"
-    echo "::set-output name=artifact_1::${artifact_deploy_filename}"
+    local artifact="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
+    echo "Moving build artifact to deploy/${artifact}"
+    mv ./deploy/Jamulus.ipa "./deploy/${artifact}"
+    echo "::set-output name=artifact_1::${artifact}"
 }
 
 case "${1:-}" in

--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -8,8 +8,8 @@ if [[ ! ${QT_VERSION:-} =~ [0-9]+\.[0-9]+\..* ]]; then
     echo "Environment variable QT_VERSION must be set to a valid Qt version"
     exit 1
 fi
-if [[ ! ${jamulus_buildversionstring:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Environment variable jamulus_buildversionstring has to be set to a valid version string"
+if [[ ! ${JAMULUS_BUILD_VERSION:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Environment variable JAMULUS_BUILD_VERSION has to be set to a valid version string"
     exit 1
 fi
 
@@ -30,7 +30,7 @@ build_app_as_ipa() {
 }
 
 pass_artifact_to_job() {
-    artifact_deploy_filename="jamulus_${jamulus_buildversionstring}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
+    artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
     echo "Moving build artifact to deploy/${artifact_deploy_filename}"
     mv ./deploy/Jamulus.ipa "./deploy/${artifact_deploy_filename}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename}"

--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -17,7 +17,7 @@ setup() {
     if [[ -d "${QT_DIR}" ]]; then
         echo "Using Qt installation from previous run (actions/cache)"
     else
-        echo "Install dependencies..."
+        echo "Installing Qt"
         python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
         python3 -m aqt install-qt --outputdir "${QT_DIR}" mac ios "${QT_VERSION}" --archives qtbase qttools qttranslations qtmacextras
     fi

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -20,6 +20,8 @@ case "${TARGET_ARCH}" in
 esac
 
 setup() {
+    export DEBIAN_FRONTEND="noninteractive"
+
     setup_cross_compilation_apt_sources
 
     echo "Update system..."

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -24,10 +24,8 @@ setup() {
 
     setup_cross_compilation_apt_sources
 
-    echo "Update system..."
+    echo "Installing dependencies..."
     sudo apt-get -qq update
-
-    echo "Install dependencies..."
     sudo apt-get -qq --no-install-recommends -y install devscripts build-essential debhelper fakeroot libjack-jackd2-dev qtbase5-dev qttools5-dev-tools
 
     setup_cross_compiler

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-if [[ ! ${jamulus_buildversionstring:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Environment variable jamulus_buildversionstring has to be set to a valid version string"
+if [[ ! ${JAMULUS_BUILD_VERSION:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Environment variable JAMULUS_BUILD_VERSION has to be set to a valid version string"
     exit 1
 fi
 
@@ -64,12 +64,12 @@ pass_artifacts_to_job() {
     mkdir deploy
 
     # rename headless first, so wildcard pattern matches only one file each
-    artifact_deploy_filename_1="jamulus_headless_${jamulus_buildversionstring}_ubuntu_${TARGET_ARCH}.deb"
+    artifact_deploy_filename_1="jamulus_headless_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
     echo "Moving headless build artifact to deploy/${artifact_deploy_filename_1}"
     mv ../jamulus-headless*"_${TARGET_ARCH}.deb" "./deploy/${artifact_deploy_filename_1}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename_1}"
 
-    artifact_deploy_filename_2="jamulus_${jamulus_buildversionstring}_ubuntu_${TARGET_ARCH}.deb"
+    artifact_deploy_filename_2="jamulus_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
     echo "Moving regular build artifact to deploy/${artifact_deploy_filename_2}"
     mv ../jamulus*_"${TARGET_ARCH}.deb" "./deploy/${artifact_deploy_filename_2}"
     echo "::set-output name=artifact_2::${artifact_deploy_filename_2}"

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -44,7 +44,7 @@ setup_cross_compiler() {
     if [[ "${TARGET_ARCH}" == amd64 ]]; then
         return
     fi
-    GCC_VERSION=7  # 7 is the default on 18.04, there is no reason not to update once 18.04 is out of support
+    local GCC_VERSION=7  # 7 is the default on 18.04, there is no reason not to update once 18.04 is out of support
     sudo apt install -qq -y --no-install-recommends "g++-${GCC_VERSION}-${ABI_NAME}" "qt5-qmake:${TARGET_ARCH}" "qtbase5-dev:${TARGET_ARCH}" "libjack-jackd2-dev:${TARGET_ARCH}"
     sudo update-alternatives --install "/usr/bin/${ABI_NAME}-g++" g++ "/usr/bin/${ABI_NAME}-g++-${GCC_VERSION}" 10
     sudo update-alternatives --install "/usr/bin/${ABI_NAME}-gcc" gcc "/usr/bin/${ABI_NAME}-gcc-${GCC_VERSION}" 10
@@ -64,12 +64,12 @@ pass_artifacts_to_job() {
     mkdir deploy
 
     # rename headless first, so wildcard pattern matches only one file each
-    artifact_deploy_filename_1="jamulus_headless_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
+    local artifact_deploy_filename_1="jamulus_headless_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
     echo "Moving headless build artifact to deploy/${artifact_deploy_filename_1}"
     mv ../jamulus-headless*"_${TARGET_ARCH}.deb" "./deploy/${artifact_deploy_filename_1}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename_1}"
 
-    artifact_deploy_filename_2="jamulus_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
+    local artifact_deploy_filename_2="jamulus_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
     echo "Moving regular build artifact to deploy/${artifact_deploy_filename_2}"
     mv ../jamulus*_"${TARGET_ARCH}.deb" "./deploy/${artifact_deploy_filename_2}"
     echo "::set-output name=artifact_2::${artifact_deploy_filename_2}"

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -64,15 +64,15 @@ pass_artifacts_to_job() {
     mkdir deploy
 
     # rename headless first, so wildcard pattern matches only one file each
-    local artifact_deploy_filename_1="jamulus_headless_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
-    echo "Moving headless build artifact to deploy/${artifact_deploy_filename_1}"
-    mv ../jamulus-headless*"_${TARGET_ARCH}.deb" "./deploy/${artifact_deploy_filename_1}"
-    echo "::set-output name=artifact_1::${artifact_deploy_filename_1}"
+    local artifact_1="jamulus_headless_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
+    echo "Moving headless build artifact to deploy/${artifact_1}"
+    mv ../jamulus-headless*"_${TARGET_ARCH}.deb" "./deploy/${artifact_1}"
+    echo "::set-output name=artifact_1::${artifact_1}"
 
-    local artifact_deploy_filename_2="jamulus_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
-    echo "Moving regular build artifact to deploy/${artifact_deploy_filename_2}"
-    mv ../jamulus*_"${TARGET_ARCH}.deb" "./deploy/${artifact_deploy_filename_2}"
-    echo "::set-output name=artifact_2::${artifact_deploy_filename_2}"
+    local artifact_2="jamulus_${JAMULUS_BUILD_VERSION}_ubuntu_${TARGET_ARCH}.deb"
+    echo "Moving regular build artifact to deploy/${artifact_2}"
+    mv ../jamulus*_"${TARGET_ARCH}.deb" "./deploy/${artifact_2}"
+    echo "::set-output name=artifact_2::${artifact_2}"
 }
 
 case "${1:-}" in

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -21,11 +21,6 @@ setup() {
         python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
         python3 -m aqt install-qt --outputdir "${QT_DIR}" mac desktop "${QT_VERSION}" --archives qtbase qttools qttranslations qtmacextras
     fi
-
-    # Add the qt binaries to the PATH.
-    # The clang_64 entry can be dropped when Qt <6.2 compatibility is no longer needed.
-    export PATH="${QT_DIR}/${QT_VERSION}/macos/bin:${QT_DIR}/${QT_VERSION}/clang_64/bin:${PATH}"
-    echo "::set-env name=PATH::${PATH}"
 }
 
 prepare_signing() {
@@ -56,6 +51,10 @@ prepare_signing() {
 }
 
 build_app_as_dmg_installer() {
+    # Add the qt binaries to the PATH.
+    # The clang_64 entry can be dropped when Qt <6.2 compatibility is no longer needed.
+    export PATH="${QT_DIR}/${QT_VERSION}/macos/bin:${QT_DIR}/${QT_VERSION}/clang_64/bin:${PATH}"
+
     # Mac's bash version considers BUILD_ARGS unset without at least one entry:
     BUILD_ARGS=("")
     if prepare_signing; then

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -64,10 +64,10 @@ build_app_as_dmg_installer() {
 }
 
 pass_artifact_to_job() {
-    artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_mac${ARTIFACT_SUFFIX:-}.dmg"
-    echo "Moving build artifact to deploy/${artifact_deploy_filename}"
-    mv ./deploy/Jamulus-*installer-mac.dmg "./deploy/${artifact_deploy_filename}"
-    echo "::set-output name=artifact_1::${artifact_deploy_filename}"
+    artifact="jamulus_${JAMULUS_BUILD_VERSION}_mac${ARTIFACT_SUFFIX:-}.dmg"
+    echo "Moving build artifact to deploy/${artifact}"
+    mv ./deploy/Jamulus-*installer-mac.dmg "./deploy/${artifact}"
+    echo "::set-output name=artifact_1::${artifact}"
 }
 
 case "${1:-}" in

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -8,8 +8,8 @@ if [[ ! ${QT_VERSION:-} =~ [0-9]+\.[0-9]+\..* ]]; then
     echo "Environment variable QT_VERSION must be set to a valid Qt version"
     exit 1
 fi
-if [[ ! ${jamulus_buildversionstring:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Environment variable jamulus_buildversionstring has to be set to a valid version string"
+if [[ ! ${JAMULUS_BUILD_VERSION:-} =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Environment variable JAMULUS_BUILD_VERSION has to be set to a valid version string"
     exit 1
 fi
 
@@ -64,7 +64,7 @@ build_app_as_dmg_installer() {
 }
 
 pass_artifact_to_job() {
-    artifact_deploy_filename="jamulus_${jamulus_buildversionstring}_mac${ARTIFACT_SUFFIX:-}.dmg"
+    artifact_deploy_filename="jamulus_${JAMULUS_BUILD_VERSION}_mac${ARTIFACT_SUFFIX:-}.dmg"
     echo "Moving build artifact to deploy/${artifact_deploy_filename}"
     mv ./deploy/Jamulus-*installer-mac.dmg "./deploy/${artifact_deploy_filename}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename}"

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -17,7 +17,7 @@ setup() {
     if [[ -d "${QT_DIR}" ]]; then
         echo "Using Qt installation from previous run (actions/cache)"
     else
-        echo "Install dependencies..."
+        echo "Installing Qt..."
         python3 -m pip install "aqtinstall==${AQTINSTALL_VERSION}"
         python3 -m aqt install-qt --outputdir "${QT_DIR}" mac desktop "${QT_VERSION}" --archives qtbase qttools qttranslations qtmacextras
     fi

--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -24,10 +24,10 @@ $Msvc32Version = "win32_msvc2019"
 $Msvc64Version = "win64_msvc2019_64"
 $JomVersion = "1.1.2"
 
-$JamulusVersion = $Env:jamulus_buildversionstring
+$JamulusVersion = $Env:JAMULUS_BUILD_VERSION
 if ( $JamulusVersion -notmatch '^\d+\.\d+\.\d+.*' )
 {
-    throw "Environment variable jamulus_buildversionstring has to be set to a valid version string"
+    throw "Environment variable JAMULUS_BUILD_VERSION has to be set to a valid version string"
 }
 
 Function Install-Qt

--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -116,7 +116,7 @@ Function Build-App-With-Installer
     {
         $ExtraArgs += ("-BuildOption", $BuildOption)
     }
-    powershell ".\windows\deploy_windows.ps1" "C:\Qt\5.15.2" "C:\Qt\5.15.2" @ExtraArgs
+    powershell ".\windows\deploy_windows.ps1" "C:\Qt\${Qt32Version}" "C:\Qt\${Qt64Version}" @ExtraArgs
     if ( !$? )
     {
         throw "deploy_windows.ps1 failed with exit code $LastExitCode"

--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -136,10 +136,10 @@ Function Pass-Artifact-to-Job
     $artifact_deploy_filename = "jamulus_${JamulusVersion}_win${ArtifactSuffix}.exe"
 
     echo "Copying artifact to ${artifact_deploy_filename}"
-    cp ".\deploy\Jamulus*installer-win.exe" ".\deploy\${artifact_deploy_filename}"
+    move ".\deploy\Jamulus*installer-win.exe" ".\deploy\${artifact_deploy_filename}"
     if ( !$? )
     {
-            throw "cp failed with exit code $LastExitCode"
+        throw "move failed with exit code $LastExitCode"
     }
     echo "Setting Github step output name=artifact_1::${artifact_deploy_filename}"
     echo "::set-output name=artifact_1::${artifact_deploy_filename}"

--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -133,16 +133,16 @@ Function Pass-Artifact-to-Job
         default         { "" }
     }
 
-    $artifact_deploy_filename = "jamulus_${JamulusVersion}_win${ArtifactSuffix}.exe"
+    $artifact = "jamulus_${JamulusVersion}_win${ArtifactSuffix}.exe"
 
-    echo "Copying artifact to ${artifact_deploy_filename}"
-    move ".\deploy\Jamulus*installer-win.exe" ".\deploy\${artifact_deploy_filename}"
+    echo "Copying artifact to ${artifact}"
+    move ".\deploy\Jamulus*installer-win.exe" ".\deploy\${artifact}"
     if ( !$? )
     {
         throw "move failed with exit code $LastExitCode"
     }
-    echo "Setting Github step output name=artifact_1::${artifact_deploy_filename}"
-    echo "::set-output name=artifact_1::${artifact_deploy_filename}"
+    echo "Setting Github step output name=artifact_1::${artifact}"
+    echo "::set-output name=artifact_1::${artifact}"
 }
 
 switch ( $Stage )

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -52,7 +52,7 @@ jobs:
         id:                         jamulus-build-vars
 
       - name:                       Remove release ${{steps.jamulus-build-vars.outputs.RELEASE_TAG}}, if existing
-        if:                         contains(steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE, 'true')
+        if:                         steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
         continue-on-error:          true
         uses:                       dev-drprasad/delete-tag-and-release@v0.1.2
         with:
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
 
       - name:                       Create Release ${{steps.jamulus-build-vars.outputs.RELEASE_TAG}}  ${{steps.jamulus-build-vars.outputs.RELEASE_TITLE}}
-        if:                         contains(steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE, 'true')
+        if:                         steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
         id:                         create_release_step
         uses:                       actions/create-release@v1
         env:
@@ -244,7 +244,7 @@ jobs:
       - name:                       Notarize macOS Release Build
         if:                         >-
                                     steps.build.outputs.macos_signed == 'true' &&
-                                    contains(needs.create_release.outputs.publish_to_release, 'true')
+                                    needs.create_release.outputs.publish_to_release == 'true'
         id:                         notarize-macOS-app
         uses:                       devbotsxyz/xcode-notarize@d7219e1c390b47db8bab0f6b4fc1e3b7943e4b3b
         with:
@@ -256,7 +256,7 @@ jobs:
       - name:                       Staple macOS Release Build
         if:                         >-
                                     steps.build.outputs.macos_signed == 'true' &&
-                                    contains(needs.create_release.outputs.publish_to_release, 'true')
+                                    needs.create_release.outputs.publish_to_release == 'true'
         id:                         staple-macOS-app
         uses:                       devbotsxyz/xcode-staple@v1
         with:
@@ -265,7 +265,7 @@ jobs:
       - name:                       Upload Artifact 1 to Release
         # Every build job has at least one artifact. Therefore, no `if artifact_1` condition here.
         # If the artifact is missing, this should fail.
-        if:                         contains(needs.create_release.outputs.publish_to_release, 'true')
+        if:                         needs.create_release.outputs.publish_to_release == 'true'
         id:                         upload-release-asset1
         uses:                       actions/upload-release-asset@v1
         env:
@@ -279,7 +279,7 @@ jobs:
       - name:                       Upload Artifact 2 to Release
         if:                         >-
                                     steps.get-artifacts.outputs.artifact_2 != '' &&
-                                    contains(needs.create_release.outputs.publish_to_release, 'true')
+                                    needs.create_release.outputs.publish_to_release == 'true'
         id:                         upload-release-asset2
         uses:                       actions/upload-release-asset@v1
         env:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -194,7 +194,6 @@ jobs:
         run:                        ${{ matrix.config.base_command }} setup
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'  # allow setting environment variables
-          jamulus_project_path:     ${{ github.workspace }}
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
 
       - name:                       Initialize CodeQL
@@ -207,7 +206,6 @@ jobs:
         id:                         build
         run:                        ${{ matrix.config.base_command }} build
         env:
-          jamulus_project_path:       ${{ github.workspace }}
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
           MACOS_CERTIFICATE:          ${{ secrets.MACOS_CERT}}
           MACOS_CERTIFICATE_PWD:      ${{ secrets.MACOS_CERT_PWD }}
@@ -219,7 +217,6 @@ jobs:
         id:                         get-artifacts
         run:                        ${{ matrix.config.base_command }} get-artifacts
         env:
-          jamulus_project_path:       ${{ github.workspace }}
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
 
       - name:                       Upload Artifact 1 to Job

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -39,9 +39,9 @@ jobs:
     name:                           Build vars & Github release (if required)
     runs-on:                        ubuntu-20.04
     outputs:
-      publish_to_release:           ${{ steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE }}
-      upload_url:                   ${{ steps.create_release_step.outputs.upload_url }}
-      build_version:                ${{ steps.jamulus-build-vars.outputs.BUILD_VERSION }}
+      publish_to_release:           ${{ steps.get-build-vars.outputs.PUBLISH_TO_RELEASE }}
+      upload_url:                   ${{ steps.create-release.outputs.upload_url }}
+      build_version:                ${{ steps.get-build-vars.outputs.BUILD_VERSION }}
 
     steps:
       - name:                       Checkout code
@@ -49,29 +49,29 @@ jobs:
 
       - name:                       Determine release version, type and prerelease variables and generate Changelog
         run:                        python3 ${{ github.workspace }}/.github/actions_scripts/analyse_git_reference.py
-        id:                         jamulus-build-vars
+        id:                         get-build-vars
 
-      - name:                       Remove release ${{steps.jamulus-build-vars.outputs.RELEASE_TAG}}, if existing
-        if:                         steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
+      - name:                       Remove release ${{steps.get-build-vars.outputs.RELEASE_TAG}}, if existing
+        if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
         continue-on-error:          true
         uses:                       dev-drprasad/delete-tag-and-release@v0.1.2
         with:
           delete_release:           true
-          tag_name:                 ${{ steps.jamulus-build-vars.outputs.RELEASE_TAG }}
+          tag_name:                 ${{ steps.get-build-vars.outputs.RELEASE_TAG }}
         env:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
 
-      - name:                       Create Release ${{steps.jamulus-build-vars.outputs.RELEASE_TAG}}  ${{steps.jamulus-build-vars.outputs.RELEASE_TITLE}}
-        if:                         steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
-        id:                         create_release_step
+      - name:                       Create Release ${{steps.get-build-vars.outputs.RELEASE_TAG}}  ${{steps.get-build-vars.outputs.RELEASE_TITLE}}
+        if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
+        id:                         create-release
         uses:                       actions/create-release@v1
         env:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name:                 ${{ steps.jamulus-build-vars.outputs.RELEASE_TAG }}
-          release_name:             ${{ steps.jamulus-build-vars.outputs.RELEASE_TITLE }}
+          tag_name:                 ${{ steps.get-build-vars.outputs.RELEASE_TAG }}
+          release_name:             ${{ steps.get-build-vars.outputs.RELEASE_TITLE }}
           body_path:                ${{ github.workspace }}/autoLatestChangelog.md
-          prerelease:               ${{ steps.jamulus-build-vars.outputs.IS_PRERELEASE }}
+          prerelease:               ${{ steps.get-build-vars.outputs.IS_PRERELEASE }}
           draft:                    false
 
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       publish_to_release:           ${{ steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE }}
       upload_url:                   ${{ steps.create_release_step.outputs.upload_url }}
-      version_name:                 ${{ steps.jamulus-build-vars.outputs.RELEASE_VERSION_NAME }}
+      version_name:                 ${{ steps.jamulus-build-vars.outputs.BUILD_VERSION }}
 
     steps:
       - name:                       Checkout code

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -193,7 +193,6 @@ jobs:
       - name:                       Set up build dependencies for ${{ matrix.config.config_name }}
         run:                        ${{ matrix.config.base_command }} setup
         env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'  # allow setting environment variables
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
 
       - name:                       Initialize CodeQL

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -87,9 +87,7 @@ jobs:
           - config_name:            Android .apk (artifact+codeQL)
             target_os:              android
             building_on_os:         ubuntu-20.04
-            cmd1_prebuild:          "./.github/autobuild/android.sh setup"
-            cmd2_build:             "./.github/autobuild/android.sh build"
-            cmd3_postbuild:         "./.github/autobuild/android.sh get-artifacts"
+            base_command:           ./.github/autobuild/android.sh
             run_codeql:             true
             # Jamulus.pro needs to count git history length for android versioning:
             checkout_fetch_depth:   '0'
@@ -97,35 +95,27 @@ jobs:
           - config_name:            Linux .deb amd64 (artifacts+codeQL)
             target_os:              linux
             building_on_os:         ubuntu-18.04
-            cmd1_prebuild:          ./.github/autobuild/linux_deb.sh setup
-            cmd2_build:             ./.github/autobuild/linux_deb.sh build
-            cmd3_postbuild:         ./.github/autobuild/linux_deb.sh get-artifacts
+            base_command:           ./.github/autobuild/linux_deb.sh
             run_codeql:             true
 
           - config_name:            Linux .deb armhf (artifacts)
             target_os:              linux
             building_on_os:         ubuntu-18.04
-            cmd1_prebuild:          TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh setup
-            cmd2_build:             TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh build
-            cmd3_postbuild:         TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh get-artifacts
+            base_command:           TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh
             run_codeql:             false
 
           - config_name:            MacOS (artifacts+codeQL)
             target_os:              macos
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
-            cmd1_prebuild:          "QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh setup"
-            cmd2_build:             "QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh build"
-            cmd3_postbuild:         "QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh get-artifacts"
+            base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
             run_codeql:             true
             xcode_version:          12.1.1
 
           - config_name:            MacOS Legacy (artifacts)
             target_os:              macos
             building_on_os:         macos-10.15
-            cmd1_prebuild:          "QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh setup"
-            cmd2_build:             "QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh build"
-            cmd3_postbuild:         "QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh get-artifacts"
+            base_command:           QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh
             run_codeql:             false
             # For Qt5 on Mac, we need to ensure SDK 10.15 is used, and not SDK 11.x.
             # Xcode 12.1 is the most-recent release which still ships SDK 10.15:
@@ -137,9 +127,7 @@ jobs:
           - config_name:            iOS (artifacts)
             target_os:              ios
             building_on_os:         macos-10.15
-            cmd1_prebuild:          "QT_VERSION=5.15.2 ./.github/autobuild/ios.sh setup"
-            cmd2_build:             "QT_VERSION=5.15.2 ./.github/autobuild/ios.sh build"
-            cmd3_postbuild:         "QT_VERSION=5.15.2 ./.github/autobuild/ios.sh get-artifacts"
+            base_command:           QT_VERSION=5.15.2 ./.github/autobuild/ios.sh
             # Build failed with CodeQL enabled when last tested 03/2022 (#2490).
             # There are no hints that iOS is supposed to be supported by CodeQL.
             # Therefore, disable it:
@@ -149,17 +137,13 @@ jobs:
           - config_name:            Windows (artifact+codeQL)
             target_os:              windows
             building_on_os:         windows-2019
-            cmd1_prebuild:          powershell .\.github\autobuild\windows.ps1 -Stage setup
-            cmd2_build:             powershell .\.github\autobuild\windows.ps1 -Stage build -GithubWorkspace
-            cmd3_postbuild:         powershell .\.github\autobuild\windows.ps1 -Stage get-artifacts -GithubWorkspace
+            base_command:           powershell .\.github\autobuild\windows.ps1 -Stage
             run_codeql:             true
 
           - config_name:            Windows JACK (artifact)
             target_os:              windows
             building_on_os:         windows-2019
-            cmd1_prebuild:          powershell .\.github\autobuild\windows.ps1 -BuildOption jackonwindows -Stage setup
-            cmd2_build:             powershell .\.github\autobuild\windows.ps1 -BuildOption jackonwindows -Stage build -GithubWorkspace
-            cmd3_postbuild:         powershell .\.github\autobuild\windows.ps1 -BuildOption jackonwindows -Stage get-artifacts -GithubWorkspace
+            base_command:           powershell .\.github\autobuild\windows.ps1 -BuildOption jackonwindows -Stage
             run_codeql:             false
 
     runs-on:                        ${{ matrix.config.building_on_os }}
@@ -183,7 +167,7 @@ jobs:
           path: |
             /usr/local/opt/qt
             ~/Library/Cache/jamulus-homebrew-bottles
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/mac/autobuild_mac_1_prepare.sh', 'mac/deploy_mac.sh') }}-${{ matrix.config.cmd1_prebuild }}
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/mac/autobuild_mac_1_prepare.sh', 'mac/deploy_mac.sh') }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Windows dependencies
         if:                         matrix.config.target_os == 'windows'
@@ -194,7 +178,7 @@ jobs:
             C:\ChocoCache
             ~\windows\NSIS
             ~\windows\ASIOSDK2
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/windows.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.cmd1_prebuild }}
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/windows.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Android dependencies
         if:                         matrix.config.target_os == 'android'
@@ -204,11 +188,10 @@ jobs:
             /opt/Qt
             /opt/android/android-sdk
             /opt/android/android-ndk
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/android.sh') }}-${{ matrix.config.cmd1_prebuild }}
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/android.sh') }}-${{ matrix.config.base_command }}
 
       - name:                       Set up build dependencies for ${{ matrix.config.config_name }}
-        if:                         matrix.config.cmd1_prebuild
-        run:                        ${{ matrix.config.cmd1_prebuild }}
+        run:                        ${{ matrix.config.base_command }} setup
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'  # allow setting environment variables
           jamulus_project_path:     ${{ github.workspace }}
@@ -221,9 +204,8 @@ jobs:
           languages: 'cpp'
 
       - name:                       Build for ${{ matrix.config.config_name }}
-        id:                         step_build
-        if:                         matrix.config.cmd2_build
-        run:                        ${{ matrix.config.cmd2_build }} ${{ github.workspace }}
+        id:                         build
+        run:                        ${{ matrix.config.base_command }} build
         env:
           jamulus_project_path:       ${{ github.workspace }}
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
@@ -234,9 +216,8 @@ jobs:
           KEYCHAIN_PASSWORD:          ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name:                       Post-Build for ${{ matrix.config.config_name }}
-        id:                         step_cmd3_postbuild
-        if:                         matrix.config.cmd3_postbuild
-        run:                        ${{ matrix.config.cmd3_postbuild }} ${{ github.workspace }}
+        id:                         get-artifacts
+        run:                        ${{ matrix.config.base_command }} get-artifacts
         env:
           jamulus_project_path:       ${{ github.workspace }}
           jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
@@ -246,40 +227,40 @@ jobs:
         # If the artifact is missing, this should fail.
         uses:                       actions/upload-artifact@v2
         with:
-          name:                     ${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
-          path:                     deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+          name:                     ${{ steps.get-artifacts.outputs.artifact_1 }}
+          path:                     deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
           retention-days:           31
           if-no-files-found:        error
 
       - name:                       Upload Artifact 2 to Job
-        if:                         steps.step_cmd3_postbuild.outputs.artifact_2
+        if:                         steps.get-artifacts.outputs.artifact_2
         uses:                       actions/upload-artifact@v2
         with:
-          name:                     ${{ steps.step_cmd3_postbuild.outputs.artifact_2 }}
-          path:                     deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_2 }}
+          name:                     ${{ steps.get-artifacts.outputs.artifact_2 }}
+          path:                     deploy/${{ steps.get-artifacts.outputs.artifact_2 }}
           retention-days:           31
           if-no-files-found:        error
 
       - name:                       Notarize macOS Release Build
         if:                         >-
-                                    steps.step_build.outputs.macos_signed == 'true' &&
+                                    steps.build.outputs.macos_signed == 'true' &&
                                     contains(needs.create_release.outputs.publish_to_release, 'true')
         id:                         notarize-macOS-app
         uses:                       devbotsxyz/xcode-notarize@d7219e1c390b47db8bab0f6b4fc1e3b7943e4b3b
         with:
-          product-path:             deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+          product-path:             deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
           primary-bundle-id:        io.jamulus.Jamulus
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
       - name:                       Staple macOS Release Build
         if:                         >-
-                                    steps.step_build.outputs.macos_signed == 'true' &&
+                                    steps.build.outputs.macos_signed == 'true' &&
                                     contains(needs.create_release.outputs.publish_to_release, 'true')
         id:                         staple-macOS-app
         uses:                       devbotsxyz/xcode-staple@v1
         with:
-          product-path:             deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+          product-path:             deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
 
       - name:                       Upload Artifact 1 to Release
         # Every build job has at least one artifact. Therefore, no `if artifact_1` condition here.
@@ -291,13 +272,13 @@ jobs:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url:               ${{ needs.create_release.outputs.upload_url }}
-          asset_path:               deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
-          asset_name:               ${{ steps.step_cmd3_postbuild.outputs.artifact_1 }}
+          asset_path:               deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
+          asset_name:               ${{ steps.get-artifacts.outputs.artifact_1 }}
           asset_content_type:       application/octet-stream
 
       - name:                       Upload Artifact 2 to Release
         if:                         >-
-                                    steps.step_cmd3_postbuild.outputs.artifact_2 != '' &&
+                                    steps.get-artifacts.outputs.artifact_2 != '' &&
                                     contains(needs.create_release.outputs.publish_to_release, 'true')
         id:                         upload-release-asset2
         uses:                       actions/upload-release-asset@v1
@@ -305,8 +286,8 @@ jobs:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url:               ${{ needs.create_release.outputs.upload_url }}
-          asset_path:               deploy/${{ steps.step_cmd3_postbuild.outputs.artifact_2 }}
-          asset_name:               ${{ steps.step_cmd3_postbuild.outputs.artifact_2 }}
+          asset_path:               deploy/${{ steps.get-artifacts.outputs.artifact_2 }}
+          asset_name:               ${{ steps.get-artifacts.outputs.artifact_2 }}
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       publish_to_release:           ${{ steps.jamulus-build-vars.outputs.PUBLISH_TO_RELEASE }}
       upload_url:                   ${{ steps.create_release_step.outputs.upload_url }}
-      version_name:                 ${{ steps.jamulus-build-vars.outputs.BUILD_VERSION }}
+      build_version:                ${{ steps.jamulus-build-vars.outputs.BUILD_VERSION }}
 
     steps:
       - name:                       Checkout code
@@ -193,7 +193,7 @@ jobs:
       - name:                       Set up build dependencies for ${{ matrix.config.config_name }}
         run:                        ${{ matrix.config.base_command }} setup
         env:
-          jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
+          JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
       - name:                       Initialize CodeQL
         if:                         matrix.config.run_codeql
@@ -205,18 +205,18 @@ jobs:
         id:                         build
         run:                        ${{ matrix.config.base_command }} build
         env:
-          jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
-          MACOS_CERTIFICATE:          ${{ secrets.MACOS_CERT}}
-          MACOS_CERTIFICATE_PWD:      ${{ secrets.MACOS_CERT_PWD }}
-          MACOS_CERTIFICATE_ID:       ${{ secrets.MACOS_CERT_ID }}
-          NOTARIZATION_PASSWORD:      ${{ secrets.NOTARIZATION_PASSWORD }}
-          KEYCHAIN_PASSWORD:          ${{ secrets.KEYCHAIN_PASSWORD }}
+          JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
+          MACOS_CERTIFICATE_PWD:    ${{ secrets.MACOS_CERT_PWD }}
+          MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }}
+          NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
+          KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name:                       Post-Build for ${{ matrix.config.config_name }}
         id:                         get-artifacts
         run:                        ${{ matrix.config.base_command }} get-artifacts
         env:
-          jamulus_buildversionstring: ${{ needs.create_release.outputs.version_name }}
+          JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
       - name:                       Upload Artifact 1 to Job
         # Every build job has at least one artifact. Therefore, no `if` here.


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!-- Explain what your PR does -->
This is the last bigger PR in this Autobuild cleanup series. It performs several refactorings, cleanups and fixes which only became possible after the previous ground-work or only became apparent by now.
This PR touches multiple aspects of Autobuild, but is solely focused on refactoring without any changes in the output.

- Autobuild: Derive all step commands from a base_command
  Previously, the build matrix had to provide three different command lines for the three different build steps. As all command invocations are normalized across platforms now, we can condense that into a base_command per matrix entry and will just add the build stage as a parameter in the generic invocation. This allows removal of several lines of definitions and makes the
workflow more readable/maintenable.

- Autobuild: Drop irregular contains() usage from Workflow
  The Workflow used the `contains()` function in multiple places. [contains() will either perform an in-array check or a substring check](https://docs.github.com/en/actions/learn-github-actions/expressions#contains). We are not dealing with arrays, nor do we want a substring check when checking for `'true'`. Therefore, use an ordinary string comparison here which is more readable anyways.

- Autobuild: Drop jamulus_project_path from Workflow
  The previous refactorings have adjusted all platform autobuild scripts to stop using this variable. Therefore, we can now safely drop the definition from the Workflow.

- Autobuild: Mac: Set PATH before build step directly
  There's no need to set PATH in the prepare step, pass it back to the workflow, let the workflow pass it back to the build stage and use it only then. Therefore, just set PATH right before it's needed in the build step and drop the Github logic.

- Autobuild: Workflow: Drop discouraged ACTIONS_ALLOW_UNSECURE_COMMANDS
  As no autobuild scripts require setting environment variables across build steps anymore, we can now safely drop this discouraged configuration.
  In case we ever need to set environment variables across steps again, there are better ways to do that by now (env files).

- Autobuild: Rename RELEASE_VERSION_NAME -> BUILD_VERSION
  This renames the RELEASE_VERSION_NAME (and all calculation in analyse_git_reference.py beforehand) to BUILD_VERSION instead. The variable does not contain a name (e.g. "Jamulus"), so that's confusing. It isn't solely used for releases either, so BUILD_ seems like a better fit.

- Autobuild: Rename jamulus_buildversionstring -> JAMULUS_BUILD_VERSION
  - "string" is redundant
  - use uppercase as all other environment variables do
  - using BUILD_VERSION is consistent with the source of the variable (create-release step)
  - prefixing with JAMULUS_ is helpful as other versions are in play in the Workflow as well.

- Autobuild: Windows: Rename the artifact instead of copying
  This is more consistent with the other platforms and might be slightly faster.

- Autobuild: Windows: Use Qt version variables instead of hardcoding

- Autobuild: Linux: Silence apt questions

- Autobuild: Improve dependency installation log messages

- Autobuild: Mark local variables as local

- Autobuild: Workflow: Unify id naming scheme

- Autobuild: Shorten artifact_deploy_filename variable name

CHANGELOG: Autobuild: Simplified build matrix and cleaned up redundant functionality
(also to be condensed with other autobuild PRs)

**Context: Fixes an issue?**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Related: #2503

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for review.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Reviews.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want:
  - [x] [Build is green](https://github.com/hoffie/jamulus/actions/runs/2027994842)
  - [x] All artifacts are there
  - [x] Artifact size is unchanged compared to latest [`master` run](https://github.com/jamulussoftware/jamulus/actions/runs/2022402481)
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
