### PR TITLE
Audiomixerboard: Fix extra blank line when musician name length % iBreakPos == 0

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -704,7 +704,7 @@ void CChannelFader::SetChannelInfos ( const CChannelInfo& cChanInfo )
     while ( tbfName.toNextBoundary() != -1 )
     {
         ++iCount;
-        if ( iCount == iInsPos )
+        if ( iCount == iInsPos && tbfName.position() + iLineNumber < strModText.length() )
         {
             strModText.insert ( tbfName.position() + iLineNumber, QString ( "\n" ) );
             iLineNumber++;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Fix a bug where a blank line is shown after some client’s name in the mixer board when their name’s length is divisible by `iBreakPos` (which is 8 or 4).

CHANGELOG: Client: Fix a bug where a blank line is shown after some client’s name in the mixer board in some conditions.

**Context: Fixes an issue?**
There is a regression introduced in Jamulus 3.8.2 by #1994 / #1993 (which fixes #1451) causing some musician’s name to have an extra blank line at the end.
<img width="114" alt="image" src="https://user-images.githubusercontent.com/193136/159750504-01bdc246-b719-47ee-af94-ff54b4068736.png">

**Does this change need documentation? What needs to be documented and how?**
No

**Status of this Pull Request**
Working fix

<img width="102" alt="image" src="https://user-images.githubusercontent.com/193136/159750623-2bd4feee-42ce-490d-a096-5af98c025564.png">

**What is missing until this pull request can be merged?**
N/A

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
