### PR TITLE
Rename CONFIG nosound to serveronly for consistency

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -28,6 +28,11 @@ QT += network \
     xml \
     concurrent
 
+contains(CONFIG, "nosound") {
+    CONFIG -= "nosound"
+    CONFIG += "serveronly"
+}
+
 contains(CONFIG, "headless") {
     message(Headless mode activated.)
     QT -= gui


### PR DESCRIPTION
**Short description of changes**
This is a trivial name change in `Jamulus.pro` to rename `nosound` to `serveronly` (with backwards compatibility).

CHANGELOG: Rename CONFIG nosound to serveronly for consistency

**Context: Fixes an issue?**
`nosound` creates a server only build on Linux.  So it should be called `serveronly`.

**Does this change need documentation? What needs to be documented and how?**
Any documentation that mentions the `nosound` build option will need changing.

**Status of this Pull Request**
Tested locally.

**What is missing until this pull request can be merged?**
Github builds.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
