### PR TITLE
Make serveronly more comprehensive

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -55,11 +55,11 @@ Although not strictly necessary, we recommend using the headless flag to avoid h
 
 Note that you don’t need to install the JACK package(s) for a headless build. If you plan to run headless on Gentoo, or are compiling under Ubuntu for use on another Ubuntu machine, the only packages you should need for a headless build are `qtcore`, `qtnetwork`, `qtconcurrent` and `qtxml` (both for building and running the server).
 
-Compile the sources to ignore the JACK sound library:
+Compile the sources and create a server-only build without a UI:
 
 ```shell
 make distclean # recommended
-qmake "CONFIG+=nosound headless"
+qmake "CONFIG+=headless serveronly"
 make
 sudo make install # optional
 ```

--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -16,7 +16,7 @@ endif
 
 override_dh_auto_configure:
 	mkdir -p build-gui && cd build-gui && $(QMAKE) "CONFIG+=noupcasename" PREFIX=/usr ../Jamulus.pro
-	mkdir -p build-nox && cd build-nox && $(QMAKE) "CONFIG+=nosound headless" TARGET=jamulus-headless PREFIX=/usr ../Jamulus.pro
+	mkdir -p build-nox && cd build-nox && $(QMAKE) "CONFIG+=headless serveronly" TARGET=jamulus-headless PREFIX=/usr ../Jamulus.pro
 
 override_dh_auto_build:
 	cd src/res/translation && lrelease *.ts

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,11 +29,15 @@
 #ifndef HEADLESS
 #    include <QApplication>
 #    include <QMessageBox>
-#    include "clientdlg.h"
 #    include "serverdlg.h"
+#    ifndef SERVER_ONLY
+#        include "clientdlg.h"
+#    endif
 #endif
 #include "settings.h"
-#include "testbench.h"
+#ifndef SERVER_ONLY
+#    include "testbench.h"
+#endif
 #include "util.h"
 #ifdef ANDROID
 #    include <QtAndroidExtras/QtAndroid>
@@ -45,7 +49,9 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 #include <memory>
 #include "rpcserver.h"
 #include "serverrpc.h"
-#include "clientrpc.h"
+#ifndef SERVER_ONLY
+#    include "clientrpc.h"
+#endif
 
 // Implementation **************************************************************
 
@@ -66,7 +72,7 @@ int main ( int argc, char** argv )
 
     // initialize all flags and string which might be changed by command line
     // arguments
-#if defined( SERVER_BUNDLE ) && ( defined( Q_OS_MACX ) )
+#if defined( SERVER_BUNDLE ) && defined( Q_OS_MACX )
     // if we are on MacOS and we are building a server bundle, starts Jamulus in server mode
     bool bIsClient = false;
 #else
@@ -576,7 +582,7 @@ int main ( int argc, char** argv )
 #ifdef SERVER_ONLY
     if ( bIsClient )
     {
-        qCritical() << "Only --server mode is supported in this build with nosound.";
+        qCritical() << "Only --server mode is supported in this build.";
         exit ( 1 );
     }
 #endif
@@ -804,10 +810,12 @@ int main ( int argc, char** argv )
     // init resources
     Q_INIT_RESOURCE ( resources );
 
+#ifndef SERVER_ONLY
     // clang-format off
 // TEST -> activate the following line to activate the test bench,
 //CTestbench Testbench ( "127.0.0.1", DEFAULT_PORT_NUMBER );
-    // clang-format on
+// clang-format on
+#endif
 
     CRpcServer* pRpcServer = nullptr;
 
@@ -848,6 +856,7 @@ int main ( int argc, char** argv )
 
     try
     {
+#ifndef SERVER_ONLY
         if ( bIsClient )
         {
             // Client:
@@ -877,7 +886,7 @@ int main ( int argc, char** argv )
                 new CClientRpc ( &Client, pRpcServer, pRpcServer );
             }
 
-#ifndef HEADLESS
+#    ifndef HEADLESS
             if ( bUseGUI )
             {
                 // GUI object
@@ -896,7 +905,7 @@ int main ( int argc, char** argv )
                 pApp->exec();
             }
             else
-#endif
+#    endif
             {
                 // only start application without using the GUI
                 qInfo() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
@@ -905,6 +914,7 @@ int main ( int argc, char** argv )
             }
         }
         else
+#endif
         {
             // Server:
             // actual server object

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -200,6 +200,7 @@ void CSettings::PutIniSetting ( QDomDocument& xmlFile, const QString& sSection, 
     xmlKey.appendChild ( currentValue );
 }
 
+#ifndef SERVER_ONLY
 // Client settings -------------------------------------------------------------
 void CClientSettings::LoadFaderSettings ( const QString& strCurFileName )
 {
@@ -335,11 +336,11 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
 
     if ( !strError.isEmpty() )
     {
-#ifndef HEADLESS
+#    ifndef HEADLESS
         // special case: when settings are loaded no GUI is yet created, therefore
         // we have to create a warning message box here directly
         QMessageBox::warning ( nullptr, APP_NAME, strError );
-#endif
+#    endif
     }
 
     // sound card channel mapping settings: make sure these settings are
@@ -759,6 +760,7 @@ void CClientSettings::WriteFaderSettingsToXML ( QDomDocument& IniXMLDocument )
         SetNumericIniSet ( IniXMLDocument, "client", QString ( "storedgroupid%1" ).arg ( iIdx ), vecStoredFaderGroupID[iIdx] );
     }
 }
+#endif
 
 // Server settings -------------------------------------------------------------
 // that this gets called means we are not headless

--- a/src/settings.h
+++ b/src/settings.h
@@ -32,7 +32,9 @@
 #    include <QMessageBox>
 #endif
 #include "global.h"
-#include "client.h"
+#ifndef SERVER_ONLY
+#    include "client.h"
+#endif
 #include "server.h"
 #include "util.h"
 
@@ -106,6 +108,7 @@ public slots:
     void OnAboutToQuit() { Save(); }
 };
 
+#ifndef SERVER_ONLY
 class CClientSettings : public CSettings
 {
 public:
@@ -180,6 +183,7 @@ protected:
 
     CClient* pClient;
 };
+#endif
 
 class CServerSettings : public CSettings
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -23,7 +23,9 @@
 \******************************************************************************/
 
 #include "util.h"
-#include "client.h"
+#ifndef SERVER_ONLY
+#    include "client.h"
+#endif
 
 /* Implementation *************************************************************/
 // Input level meter implementation --------------------------------------------

--- a/src/util.h
+++ b/src/util.h
@@ -68,7 +68,9 @@
 #    include <sys/time.h>
 #endif
 
+#ifndef SERVER_ONLY
 class CClient; // forward declaration of CClient
+#endif
 
 /* Definitions ****************************************************************/
 #define METER_FLY_BACK  2


### PR DESCRIPTION
**Short description of changes**
Earlier PR (if merged, else earlier commit) renamed "nosound" to "serveronly", as that's what it does.  This goes further and makes more extensive code changes to drop more parts of the client if "serveronly" is set.

CHANGELOG: Make serveronly more comprehensive

**Context: Fixes an issue?**
n/a

**Does this change need documentation? What needs to be documented and how?**
n/a - shouldn't really affect anything.  As noted on the earlier PR, "nosound" -> "serveronly" will affect docs.

**Status of this Pull Request**
Covers more than the old "serveronly", which appeared to only be for Linux, adding Windows.

The MacOS build might be feasible but there were the bundle options already there and I've no way to check what's going on with the MacOS build.  If someone else wants to have a go at that, add `DEFINES += SERVER_ONLY` and see if it works.

**What is missing until this pull request can be merged?**
Should be good to go.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I've filled all the content above
