### PR TITLE
#2555 Headless Server should unregister

### DIFF
--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -848,6 +848,17 @@ void CServerListManager::OnTimerCLRegisterServerResp()
     }
 }
 
+void CServerListManager::OnAboutToQuit()
+{
+    {
+        QMutexLocker locker ( &Mutex );
+        Save();
+    }
+
+    // Sets the lock - also needs to come after Save()
+    Unregister();
+}
+
 void CServerListManager::SetRegistered ( const bool bIsRegister )
 {
     // we need the lock since the user might change the server properties at

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -229,11 +229,7 @@ public slots:
     void OnTimerCLRegisterServerResp();
     void OnTimerIsPermanent() { ServerList[0].bPermanentOnline = true; }
 
-    void OnAboutToQuit()
-    {
-        QMutexLocker locker ( &Mutex );
-        Save();
-    }
+    void OnAboutToQuit();
 
 signals:
     void SvrRegStatusChanged();


### PR DESCRIPTION
**Short description of changes**
When SIGINT or SIGTERM is received, the headless Server initiates shutdown.  However, this did not previously include unregistering.  This change adds the call to the unregister method.

CHANGELOG: Headless Server should unregister on shutdown (regression in feature/server-list-persistence-ui)

**Context: Fixes an issue?**
Fix for #2555 

**Does this change need documentation? What needs to be documented and how?**
No, this should be existing behaviour but isn't.

**Status of this Pull Request**
Tested locally:
```
Server Registration Status update: Registration requested
Server Registration Status update: Registered
2022-03-27 13:39:48, 80.85.86.7, connected (1)
2022-03-27 13:39:48,, server idling -------------------------------------
^COnHandledSignal: 2
Server Registration Status update: Not registered
```

**What is missing until this pull request can be merged?**
Review.

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I've filled all the content above
