### PR TITLE
Code: Use clang-format 13

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,12 @@
 ---
-# Style for Clang-Format version 10
-# https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# Style for clang-format version 13
+# https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
 AlignConsecutiveMacros: true
-# Alignment of Consecutive Assignments/Declarations/Macros can be changed to `AcrossEmptyLinesAndComments` with Clang-Format version 12
+# Alignment of Consecutive Assignments/Declarations/Macros can be changed to `AcrossEmptyLinesAndComments` now that we require clang-format >=12
 #AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
 #AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments
 #AlignConsecutiveMacros: AcrossEmptyLinesAndComments

--- a/.github/workflows/coding-style-check.yml
+++ b/.github/workflows/coding-style-check.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   clang-format:
-    name: Verify Clang-Format compliance
+    name: Verify clang-format (v13) compliance
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@2a28e3a8d9553f244243f7e1ff94f6685dff87be
+    - uses: DoozyX/clang-format-lint-action@9ea72631b74e61ce337d0839a90e76180e997283
       with:
-        clangFormatVersion: 10
+        clangFormatVersion: 13
         # When updating the extension list, remember to update
         # Jamulus.pro's CLANG_SOURCES as well.
         extensions: 'cpp,h,mm'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,9 @@ If a feature or function can be achieved in another way by another system or met
 
 You can use your editor's or IDE's clang-format support to accomplish that.
 On the command line, you can run `make clang_format` to do the same before committing.
+Please use the same clang-format version which we use.
+Other versions might produce slightly different output.
+You can find the currently used version in the [workflow definition](https://github.com/jamulussoftware/jamulus/blob/master/.github/workflows/coding-style-check.yml#L20].
 
 Do not use diff/patch to send your code changes but create a Github fork of the Jamulus code and create a Pull Request when you are done.
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -856,16 +856,16 @@ if ( GetNumericIniSet ( IniXMLDocument, "server", "centservaddrtype", static_cas
     directoryType = static_cast<EDirectoryType> ( iValue );
 }
 else
-            // clang-format on
-            if ( GetNumericIniSet ( IniXMLDocument,
-                                    "server",
-                                    "directorytype",
-                                    static_cast<int> ( AT_NONE ),
-                                    static_cast<int> ( AT_CUSTOM ),
-                                    iValue ) )
-        {
-            directoryType = static_cast<EDirectoryType> ( iValue );
-        }
+                // clang-format on
+                if ( GetNumericIniSet ( IniXMLDocument,
+                                        "server",
+                                        "directorytype",
+                                        static_cast<int> ( AT_NONE ),
+                                        static_cast<int> ( AT_CUSTOM ),
+                                        iValue ) )
+                {
+                    directoryType = static_cast<EDirectoryType> ( iValue );
+                }
 
         // clang-format off
 // TODO compatibility to old version < 3.9.0


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- Coding style: Require clang-format 13
  We currently use clang-format 10 which has shown to produce unexpected output. This is annoying for PR submitters as the CI forces non-optimal code layout, especially when submitters use a later clang-format version which does not show this behavior.
  This commit changes CI to use clang-format 13 and updates relevant clang-format inline docs.

- Code: Run clang-format 13 on all source files


<!-- Explain what your PR does -->

CHANGELOG: Code: Updated clang-format version requirement and CI check to v13 due to bugs in v10.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Related: #2552

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
Yes. This necessary documentation update of CONTRIBUTING.md has part of this PR.

**Status of this Pull Request**
Ready.

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want: [CI used v13](https://github.com/jamulussoftware/jamulus/runs/5716100782?check_suite_focus=true#step:4:9)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency): Heh...
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
