### PR TITLE
Disable codeQL on Mac build and add com.apple.security.files.user-selected.read-write entitlements

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -127,7 +127,7 @@ jobs:
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
-            run_codeql:             true
+            run_codeql:             ${{ secrets.MACOS_CERT == null }}
             xcode_version:          12.1.1
 
           - config_name:            MacOS Legacy (artifacts)
@@ -214,10 +214,7 @@ jobs:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
       - name:                       Initialize CodeQL
-        env:
-          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
-        # Don't run CodeQL if we have a set up for signing the macOS build
-        if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == '' }}
+        if:                         matrix.config.run_codeql 
         uses:                       github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -308,8 +305,5 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
-        env:
-          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
-        # Don't run CodeQL if we have a set up for signing the macOS build
-        if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == null }}
+        if:                         matrix.config.run_codeql
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -305,5 +305,6 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
-        if:                         matrix.config.run_codeql
+        # Don't run if we're signing on macOS
+        if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed == 'false'
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -214,6 +214,8 @@ jobs:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
       - name:                       Initialize CodeQL
+        env:
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
         # Don't run CodeQL if we have a set up for signing the macOS build
         if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == '' }}
         uses:                       github/codeql-action/init@v1
@@ -306,6 +308,8 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
+        env:
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
         # Don't run CodeQL if we have a set up for signing the macOS build
-        if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == '' }}
+        if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == null }}
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -95,6 +95,8 @@ jobs:
 
   release_assets:
     name:                           Build for ${{ matrix.config.config_name }}
+    env:
+      MACOS_CERTIFICATE:            ${{ secrets.MACOS_CERT}}
     needs:                          create_release
     strategy:
       fail-fast:                    false
@@ -127,7 +129,7 @@ jobs:
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
-            run_codeql:             ${{ secrets.MACOS_CERT == null }}
+            run_codeql:             ${{ env.MACOS_CERTIFICATE == null }}
             xcode_version:          12.1.1
 
           - config_name:            MacOS Legacy (artifacts)

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -214,7 +214,8 @@ jobs:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
       - name:                       Initialize CodeQL
-        if:                         matrix.config.run_codeql
+        # Don't run CodeQL if we have a set up for signing the macOS build
+        if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == '' }}
         uses:                       github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -305,6 +306,6 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
-        # Don't run if we're signing on macOS
-        if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed == 'false'
+        # Don't run CodeQL if we have a set up for signing the macOS build
+        if:                         matrix.config.run_codeql && ${{ env.MACOS_CERTIFICATE == '' }}
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -95,8 +95,6 @@ jobs:
 
   release_assets:
     name:                           Build for ${{ matrix.config.config_name }}
-    env:
-      MACOS_CERTIFICATE:            ${{ secrets.MACOS_CERT}}
     needs:                          create_release
     strategy:
       fail-fast:                    false
@@ -129,7 +127,8 @@ jobs:
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
-            run_codeql:             ${{ env.MACOS_CERTIFICATE == null }}
+            # Disable CodeQL on mac as it interferes with signing the binaries
+            run_codeql:             false
             xcode_version:          12.1.1
 
           - config_name:            MacOS Legacy (artifacts)
@@ -216,7 +215,7 @@ jobs:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
       - name:                       Initialize CodeQL
-        if:                         matrix.config.run_codeql 
+        if:                         matrix.config.run_codeql
         uses:                       github/codeql-action/init@v1
         with:
           languages: 'cpp'

--- a/Jamulus.entitlements
+++ b/Jamulus.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
**Short description of changes**
Disables codeQL on macOS builds as it breaks signed builds.

Adds entitlements to the app under macOS to access the filesystem as needed.

**Context: Fixes an issue?**
https://github.com/jamulussoftware/jamulus/issues/2560


**Status of this Pull Request**
Ready for testing, use build here:

**What is missing until this pull request can be merged?**

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
