### PR TITLE
Move CodeQL from Mac to Mac Legacy

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -122,19 +122,21 @@ jobs:
             base_command:           TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh
             run_codeql:             false
 
-          - config_name:            MacOS (artifacts+codeQL)
+          - config_name:            MacOS (artifacts)
             target_os:              macos
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
-            run_codeql:             true
+            # Disable CodeQL on mac as it interferes with signing the binaries
+            run_codeql:             false
             xcode_version:          12.1.1
 
-          - config_name:            MacOS Legacy (artifacts)
+          - config_name:            MacOS Legacy (artifacts+CodeQL)
             target_os:              macos
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh
-            run_codeql:             false
+            # Enable CodeQL on mac legacy as this version does not get signed
+            run_codeql:             true
             # For Qt5 on Mac, we need to ensure SDK 10.15 is used, and not SDK 11.x.
             # Xcode 12.1 is the most-recent release which still ships SDK 10.15:
             # https://developer.apple.com/support/xcode/


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Moved the CodeQL for Mac from the signed main build to the unsigned legacy build

CHANGELOG: Moved CodeQL from Mac to Mac Legacy to work around signing incompatibility.

**Context: Fixes an issue?**

Currently, CodeQL interferes with the signing of Mac builds. This separates the CodeQL change from #2563, leaving the latter just for the entitlements fix.

**Does this change need documentation? What needs to be documented and how?**

Probably not

**Status of this Pull Request**

Tested with a manual workflow run

**What is missing until this pull request can be merged?**

Ready to merge

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above
