### PR TITLE
Mac: Enable read-write files entitlement for sandbox

### DIFF
--- a/mac/Jamulus.entitlements
+++ b/mac/Jamulus.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds entitlements to the app under macOS to access the filesystem as needed, via the Load/Save dialogs, to allow Mixer Channel Setup to be saved and loaded.

CHANGELOG: Mac: Fixed non-working Save/Load Mixer Channel Setup

**Context: Fixes an issue?**

Fixes: #2560 
Replaces: #2563 

**Does this change need documentation? What needs to be documented and how?**

No, bug fix only.

**Status of this Pull Request**

Should be working

**What is missing until this pull request can be merged?**

Check the built and signed artifact for Mac

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
