### PR TITLE
Reinstate CodeQL on Mac if not signing the build

### DIFF
--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -82,7 +82,7 @@ case "${1:-}" in
     setup)
         setup
         # check whether signing will be used and prevent
-	 # a return status of 1 from propagating to the script exit status.
+	# a return status of 1 from propagating to the script exit status.
         check_if_signing || true
         ;;
     build)

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -73,6 +73,7 @@ pass_artifact_to_job() {
 case "${1:-}" in
     setup)
         setup
+        prepare_signing
         ;;
     build)
         build_app_as_dmg_installer

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -73,7 +73,7 @@ pass_artifact_to_job() {
 case "${1:-}" in
     setup)
         setup
-        prepare_signing
+        prepare_signing || true
         ;;
     build)
         build_app_as_dmg_installer

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -82,7 +82,7 @@ case "${1:-}" in
     setup)
         setup
         # check whether signing will be used and prevent
-	# a return status of 1 from propagating to the script exit status.
+	 # a return status of 1 from propagating to the script exit status.
         check_if_signing || true
         ;;
     build)

--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -73,6 +73,8 @@ pass_artifact_to_job() {
 case "${1:-}" in
     setup)
         setup
+        # set up the macos_signed output if needed, but prevent
+        # a return status of 1 from propagating to the script exit status.
         prepare_signing || true
         ;;
     build)

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -122,22 +122,22 @@ jobs:
             base_command:           TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh
             run_codeql:             false
 
-          - config_name:            MacOS (artifacts)
+          - config_name:            MacOS (artifacts+CodeQL)
             target_os:              macos
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
             # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
-            run_codeql:             false
+            run_codeql:             true
             xcode_version:          12.1.1
 
           # Reminder: If Legacy is removed, be sure to add a dedicated job for CodeQL again.
-          - config_name:            MacOS Legacy (artifacts+CodeQL)
+          - config_name:            MacOS Legacy (artifacts)
             target_os:              macos
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh
             # Enable CodeQL on mac legacy as this version does not get signed
-            run_codeql:             true
+            run_codeql:             false
             # For Qt5 on Mac, we need to ensure SDK 10.15 is used, and not SDK 11.x.
             # Xcode 12.1 is the most-recent release which still ships SDK 10.15:
             # https://developer.apple.com/support/xcode/
@@ -225,7 +225,7 @@ jobs:
         run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
 
       - name:                       Initialize CodeQL
-        if:                         matrix.config.run_codeql
+        if:                         false && matrix.config.run_codeql
         uses:                       github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -316,5 +316,5 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
-        if:                         matrix.config.run_codeql
+        if:                         false && matrix.config.run_codeql
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -212,6 +212,7 @@ jobs:
           key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/android.sh') }}-${{ matrix.config.base_command }}
 
       - name:                       Set up build dependencies for ${{ matrix.config.config_name }}
+        id:                         setup
         run:                        ${{ matrix.config.base_command }} setup
         env:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
@@ -222,11 +223,11 @@ jobs:
           KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is true
-        if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed == 'true'
+        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed == 'true'
         run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
 
       - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is not true
-        if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed != 'true'
+        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
         run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
 
       - name:                       Initialize CodeQL

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -69,7 +69,7 @@ jobs:
         run:                        python3 ${{ github.workspace }}/.github/actions_scripts/analyse_git_reference.py
         id:                         get-build-vars
 
-      - name:                       Remove release ${{steps.get-build-vars.outputs.RELEASE_TAG}}, if existing
+      - name:                       Remove release ${{ steps.get-build-vars.outputs.RELEASE_TAG }}, if existing
         if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
         continue-on-error:          true
         uses:                       dev-drprasad/delete-tag-and-release@v0.1.2
@@ -79,7 +79,7 @@ jobs:
         env:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
 
-      - name:                       Create Release ${{steps.get-build-vars.outputs.RELEASE_TAG}}  ${{steps.get-build-vars.outputs.RELEASE_TITLE}}
+      - name:                       Create Release ${{ steps.get-build-vars.outputs.RELEASE_TAG }}  ${{ steps.get-build-vars.outputs.RELEASE_TITLE }}
         if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
         id:                         create-release
         uses:                       actions/create-release@v1
@@ -215,7 +215,7 @@ jobs:
         run:                        ${{ matrix.config.base_command }} setup
         env:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
-          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT }}
           MACOS_CERTIFICATE_PWD:    ${{ secrets.MACOS_CERT_PWD }}
           MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }}
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
@@ -232,7 +232,7 @@ jobs:
         run:                        ${{ matrix.config.base_command }} build
         env:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
-          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT }}
           MACOS_CERTIFICATE_PWD:    ${{ secrets.MACOS_CERT_PWD }}
           MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }}
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -216,6 +216,14 @@ jobs:
         env:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
 
+      - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is true
+        if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed == 'true'
+        run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
+
+      - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is not true
+        if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed != 'true'
+        run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
+
       - name:                       Initialize CodeQL
         if:                         matrix.config.run_codeql
         uses:                       github/codeql-action/init@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -127,16 +127,15 @@ jobs:
             # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
-            # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
+            # run_codeql will be ignored in the steps below if building a signed image
+            # for Mac, as it causes the signing process to hang. See #2563 and #2564.
             run_codeql:             true
             xcode_version:          12.1.1
 
-          # Reminder: If Legacy is removed, be sure to add a dedicated job for CodeQL again.
           - config_name:            MacOS Legacy (artifacts)
             target_os:              macos
             building_on_os:         macos-10.15
             base_command:           QT_VERSION=5.9.9 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh
-            # Enable CodeQL on mac legacy as this version does not get signed
             run_codeql:             false
             # For Qt5 on Mac, we need to ensure SDK 10.15 is used, and not SDK 11.x.
             # Xcode 12.1 is the most-recent release which still ships SDK 10.15:
@@ -221,16 +220,6 @@ jobs:
           MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }}
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
           KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
-
-        # This step and the next can be removed after completion of debugging
-      - name:                       Run if CodeQL true and steps.setup.outputs.macos_signed is true
-        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed == 'true'
-        run:                        echo xxx${{ steps.setup.outputs.macos_signed }}yyy
-
-      - name:                       Run if CodeQL true and steps.setup.outputs.macos_signed is not true
-        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
-        run:                        echo xxx${{ steps.setup.outputs.macos_signed }}yyy
-        # end of steps to be removed
 
       - name:                       Initialize CodeQL
         if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -222,7 +222,7 @@ jobs:
           KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name:                       Initialize CodeQL
-        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
+        if:                         matrix.config.run_codeql && steps.setup.outputs.disable_codeql != 'true'
         uses:                       github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -313,5 +313,5 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
-        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
+        if:                         matrix.config.run_codeql && steps.setup.outputs.disable_codeql != 'true'
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -215,6 +215,11 @@ jobs:
         run:                        ${{ matrix.config.base_command }} setup
         env:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
+          MACOS_CERTIFICATE_PWD:    ${{ secrets.MACOS_CERT_PWD }}
+          MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }}
+          NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
+          KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
 
       - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is true
         if:                         matrix.config.run_codeql && steps.build.outputs.macos_signed == 'true'

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -222,6 +222,7 @@ jobs:
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
           KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
 
+        # This step and the next can be removed after completion of debugging
       - name:                       Run if CodeQL true and steps.setup.outputs.macos_signed is true
         if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed == 'true'
         run:                        echo xxx${{ steps.setup.outputs.macos_signed }}yyy
@@ -229,9 +230,10 @@ jobs:
       - name:                       Run if CodeQL true and steps.setup.outputs.macos_signed is not true
         if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
         run:                        echo xxx${{ steps.setup.outputs.macos_signed }}yyy
+        # end of steps to be removed
 
       - name:                       Initialize CodeQL
-        if:                         false && matrix.config.run_codeql
+        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
         uses:                       github/codeql-action/init@v1
         with:
           languages: 'cpp'
@@ -322,5 +324,5 @@ jobs:
           asset_content_type:       application/octet-stream
 
       - name:                       Perform CodeQL Analysis
-        if:                         false && matrix.config.run_codeql
+        if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
         uses:                       github/codeql-action/analyze@v1

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -222,13 +222,13 @@ jobs:
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
           KEYCHAIN_PASSWORD:        ${{ secrets.KEYCHAIN_PASSWORD }}
 
-      - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is true
+      - name:                       Run if CodeQL true and steps.setup.outputs.macos_signed is true
         if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed == 'true'
-        run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
+        run:                        echo xxx${{ steps.setup.outputs.macos_signed }}yyy
 
-      - name:                       Run if CodeQL true and steps.build.outputs.macos_signed is not true
+      - name:                       Run if CodeQL true and steps.setup.outputs.macos_signed is not true
         if:                         matrix.config.run_codeql && steps.setup.outputs.macos_signed != 'true'
-        run:                        echo xxx${{ steps.build.outputs.macos_signed }}yyy
+        run:                        echo xxx${{ steps.setup.outputs.macos_signed }}yyy
 
       - name:                       Initialize CodeQL
         if:                         false && matrix.config.run_codeql


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Moves the CodeQL from Mac Legacy back to Mac, and makes it conditional on not doing a signed build.

CHANGELOG: Mac: Make Github workflow skip CodeQL when doing a signed build, to avoid hanging.

**Context: Fixes an issue?**

Replaces #2564 and #2566, and solves the issues encountered when working on #2563.

**Does this change need documentation? What needs to be documented and how?**

Probably not

**Status of this Pull Request**

Ready for review

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
