### PR TITLE
Feature: Start server by default on "serveronly" build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,9 +72,10 @@ int main ( int argc, char** argv )
 
     // initialize all flags and string which might be changed by command line
     // arguments
-#if defined( SERVER_BUNDLE ) && defined( Q_OS_MACX )
-    // if we are on MacOS and we are building a server bundle, starts Jamulus in server mode
+#if ( defined( SERVER_BUNDLE ) && defined( Q_OS_MACX ) ) || defined( SERVER_ONLY )
+    // if we are on MacOS and we are building a server bundle or requested build with serveronly, start Jamulus in server mode
     bool bIsClient = false;
+    qInfo() << "- Starting in server mode by default (due to compile time option)";
 #else
     bool bIsClient = true;
 #endif


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Starts the server by default if serveronly option is used during compile time. This is similar to the macOS bundle.

CHANGELOG: SKIP

(this is just a follow up and I don't think it needs to be documented.)

**Context: Fixes an issue?**
No. Related to @pljones #2551 

**Does this change need documentation? What needs to be documented and how?**
No.

**Status of this Pull Request**
Ready for review/merge

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (linux only)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above
