### PR TITLE
Global MsgBoxes and Commandline

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -140,8 +140,8 @@ void CChatDlg::OnAnchorClicked ( const QUrl& Url )
     // only allow http(s) URLs to be opened in an external browser
     if ( Url.scheme() == QLatin1String ( "https" ) || Url.scheme() == QLatin1String ( "http" ) )
     {
-        if ( QMessageBox::question ( this,
-                                     APP_NAME,
+        if ( QMessageBox::question ( CMsgBoxes::MainForm(),
+                                     CMsgBoxes::MainFormName(),
                                      tr ( "Do you want to open the link '%1' in your browser?" ).arg ( "<b>" + Url.toString() + "</b>" ),
                                      QMessageBox::Yes | QMessageBox::No ) == QMessageBox::Yes )
         {

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1059,7 +1059,8 @@ void CClientDlg::OnTimerSigMet()
         // show message box about feedback issue
         QCheckBox* chb = new QCheckBox ( tr ( "Enable feedback detection" ) );
         chb->setCheckState ( pSettings->bEnableFeedbackDetection ? Qt::Checked : Qt::Unchecked );
-        QMessageBox msgbox;
+        QMessageBox msgbox ( CMsgBoxes::MainForm() );
+        msgbox.setWindowTitle ( CMsgBoxes::MainFormName() + ": " + tr ( "Warning" ) );
         msgbox.setText ( tr ( "Audio feedback or loud signal detected.\n\n"
                               "We muted your channel and activated 'Mute Myself'. Please solve "
                               "the feedback issue first and unmute yourself afterwards." ) );
@@ -1143,10 +1144,8 @@ void CClientDlg::OnTimerCheckAudioDeviceOk()
     // it is trying to connect the server which does not help to solve the problem (#129))
     if ( !pClient->IsCallbackEntered() )
     {
-        QMessageBox::warning ( this,
-                               APP_NAME,
-                               tr ( "Your sound card is not working correctly. "
-                                    "Please open the settings dialog and check the device selection and the driver settings." ) );
+        CMsgBoxes::ShowWarning ( tr ( "Your sound card is not working correctly. "
+                                      "Please open the settings dialog and check the device selection and the driver settings." ) );
     }
 }
 
@@ -1163,7 +1162,7 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
         }
 
         // show the error message of the device setup
-        QMessageBox::critical ( this, APP_NAME, strError, tr ( "Ok" ), nullptr );
+        CMsgBoxes::ShowError ( strError );
     }
 
     // if the check audio device timer is running, it must be restarted on a device change
@@ -1206,7 +1205,7 @@ void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& str
         catch ( const CGenErr& generr )
         {
             // show error message and return the function
-            QMessageBox::critical ( this, APP_NAME, generr.GetErrorText(), "Close", nullptr );
+            CMsgBoxes::ShowError ( generr.GetErrorText() );
             return;
         }
 

--- a/src/global.h
+++ b/src/global.h
@@ -359,7 +359,6 @@ public:
 };
 
 /* Prototypes for global functions ********************************************/
-// command line parsing, TODO do not declare functions globally but in a class
 QString UsageArguments ( char** argv );
 
 //============================================================================
@@ -370,27 +369,29 @@ QString UsageArguments ( char** argv );
 //============================================================================
 #ifndef HEADLESS
 #    include <QMessageBox>
+#    define tMainform QDialog
+#else
+#    define tMainform void
 #endif
 
 // html text macro's (for use in gui texts)
 #define htmlBold( T ) "<b>" + T + "</b>"
 #define htmlNewLine() "<br>"
 
-
 class CMsgBoxes
 {
 protected:
-    static QDialog* pMainForm;
-    static QString  strMainFormName;
+    static tMainform* pMainForm;
+    static QString    strMainFormName;
 
 public:
-    static void init ( QDialog* theMainForm, QString theMainFormName )
+    static void init ( tMainform* theMainForm, QString theMainFormName )
     {
         pMainForm       = theMainForm;
         strMainFormName = theMainFormName;
     }
 
-    static QDialog*       MainForm() { return pMainForm; }
+    static tMainform*     MainForm() { return pMainForm; }
     static const QString& MainFormName() { return strMainFormName; }
 
     // Message boxes:
@@ -444,22 +445,24 @@ public:
 
     static bool GetStringArgument ( int& i, const QString& strShortOpt, const QString& strLongOpt, QString& strArg );
 
-    static bool GetNumericArgument ( int& i, const QString& strShortOpt, const QString& strLongOpt, double rRangeStart, double rRangeStop, double& rValue );
+    static bool GetNumericArgument ( int&           i,
+                                     const QString& strShortOpt,
+                                     const QString& strLongOpt,
+                                     double         rRangeStart,
+                                     double         rRangeStop,
+                                     double&        rValue );
 
 public:
     // find and get a specific argument:
 
     static bool GetFlagArgument ( const QString& strShortOpt, const QString& strLongOpt )
     {
-        int i = 1;
-        while ( i < appArgc )
+        for ( int i = 1; i < appArgc; i++ )
         {
             if ( GetFlagArgument ( i, strShortOpt, strLongOpt ) )
             {
                 return true;
             }
-
-            i++;
         }
 
         return false;
@@ -467,15 +470,12 @@ public:
 
     static bool GetStringArgument ( const QString& strShortOpt, const QString& strLongOpt, QString& strArg )
     {
-        int i = 1;
-        while ( i < appArgc )
+        for ( int i = 1; i < appArgc; i++ )
         {
             if ( GetStringArgument ( i, strShortOpt, strLongOpt, strArg ) )
             {
                 return true;
             }
-
-            i++;
         }
 
         return false;
@@ -483,27 +483,23 @@ public:
 
     static bool GetNumericArgument ( const QString& strShortOpt, const QString& strLongOpt, double rRangeStart, double rRangeStop, double& rValue )
     {
-        int i = 1;
-        while ( i < appArgc )
+        for ( int i = 1; i < appArgc; i++ )
         {
             if ( GetNumericArgument ( i, strShortOpt, strLongOpt, rRangeStart, rRangeStop, rValue ) )
             {
                 return true;
             }
-
-            i++;
         }
 
         return false;
     }
 
-//=================================================
-// Non statics to parse bare arguments
-// (These need an instance of CCommandlineOptions)
-//=================================================
+    //=================================================
+    // Non statics to parse bare arguments
+    // (These need an instance of CCommandlineOptions)
+    //=================================================
 
 protected:
-
     int    currentIndex;
     char** currentArgv;
 
@@ -514,7 +510,6 @@ protected:
     }
 
 public:
-
     QString GetFirstArgument()
     {
         reset();
@@ -537,19 +532,21 @@ public:
 
         return QString();
     }
-
 };
 
 // defines for commandline options in the style "shortopt", "longopt"
 // Name is standard CMDLN_LONGOPTNAME
 // These defines can be used for strShortOpt, strLongOpt parameters
 // of the CCommandlineOptions functions.
-//
+
 // clang-format off
+
 #define CMDLN_SERVER              "-s",                    "--server"
 #define CMDLN_INIFILE             "-i",                    "--inifile"
 #define CMDLN_NOGUI               "-n",                    "--nogui"
 #define CMDLN_PORT                "-p",                    "--port"
+#define CMDLN_JSONRPCPORT         "--jsonrpcport",         "--jsonrpcport"
+#define CMDLN_JSONRPCSECRETFILE   "--jsonrpcsecretfile",   "--jsonrpcsecretfile"
 #define CMDLN_QOS                 "-Q",                    "--qos"
 #define CMDLN_NOTRANSLATION       "-t",                    "--notranslation"
 #define CMDLN_ENABLEIPV6          "-6",                    "--enableipv6"
@@ -579,11 +576,13 @@ public:
 #define CMDLN_CTRLMIDICH          "--ctrlmidich",          "--ctrlmidich"
 // Backwards compatibilyty:
 #define CMDLN_CENTRALSERVER       "--centralserver",       "--centralserver"
-// pgScorpio: TODO These are NOT in help !:
+// Debug options: (not in help)
 #define CMDLN_SHOWALLSERVERS      "--showallservers",      "--showallservers"
 #define CMDLN_SHOWANALYZERCONSOLE "--showanalyzerconsole", "--showanalyzerconsole"
-// CMDLN_SPECIAL: Mostly used for debugging, any option after --special is accepted, should NOT be in help !
+// CMDLN_SPECIAL: Used for debugging, should NOT be in help, nor documented elsewhere!
+// any option after --special is accepted
 #define CMDLN_SPECIAL             "--special",             "--special"
 // Special options for sound-redesign testing
 #define CMDLN_JACKINPUTS          "--jackinputs",          "--jackinputs"
+
 // clang-format on

--- a/src/global.h
+++ b/src/global.h
@@ -358,9 +358,6 @@ public:
     int iChanNum;
 };
 
-/* Prototypes for global functions ********************************************/
-QString UsageArguments ( char** argv );
-
 //============================================================================
 // CMsgBoxes class:
 //  Use this static class to show basic Error, Warning and Info messageboxes
@@ -374,7 +371,7 @@ QString UsageArguments ( char** argv );
 #    define tMainform void
 #endif
 
-// html text macro's (for use in gui texts)
+// html text macro's (for use in message texts)
 #define htmlBold( T ) "<b>" + T + "</b>"
 #define htmlNewLine() "<br>"
 
@@ -395,48 +392,31 @@ public:
     static const QString& MainFormName() { return strMainFormName; }
 
     // Message boxes:
-    static void ShowError ( QString strError )
-    {
-#ifndef HEADLESS
-        QMessageBox::critical ( pMainForm, strMainFormName + ": " + QObject::tr ( "Error" ), strError, QObject::tr ( "Ok" ), nullptr );
-#endif
-    }
-
-    static void ShowWarning ( QString strWarning )
-    {
-#ifndef HEADLESS
-        QMessageBox::warning ( pMainForm, strMainFormName + ": " + QObject::tr ( "Warning" ), strWarning, QObject::tr ( "Ok" ), nullptr );
-#endif
-    }
-
-    static void ShowInfo ( QString strInfo )
-    {
-#ifndef HEADLESS
-        QMessageBox::information ( pMainForm, strMainFormName + ": " + QObject::tr ( "Information" ), strInfo, QObject::tr ( "Ok" ), nullptr );
-#endif
-    }
+    static void ShowError ( QString strError );
+    static void ShowWarning ( QString strWarning );
+    static void ShowInfo ( QString strInfo );
 };
 
 //============================================================================
-// CCommandlineOptions class:
+// CCommandline class:
 //  Note that passing commandline arguments to classes is no longer required,
 //  since via this class we can get commandline options anywhere.
 //============================================================================
 
-class CCommandlineOptions
+class CCommandline
 {
 public:
-    CCommandlineOptions() { reset(); }
+    CCommandline() { reset(); }
 
 private:
     friend int main ( int argc, char** argv );
 
     // Statics assigned from main ()
-    static int    appArgc;
-    static char** appArgv;
+    static int    argc;
+    static char** argv;
 
 public:
-    static QString GetProgramPath() { return QString ( *appArgv ); }
+    static QString GetProgramPath() { return QString ( *argv ); }
 
 public:
     // sequencial parse functions using the argument index:
@@ -457,7 +437,7 @@ public:
 
     static bool GetFlagArgument ( const QString& strShortOpt, const QString& strLongOpt )
     {
-        for ( int i = 1; i < appArgc; i++ )
+        for ( int i = 1; i < argc; i++ )
         {
             if ( GetFlagArgument ( i, strShortOpt, strLongOpt ) )
             {
@@ -470,7 +450,7 @@ public:
 
     static bool GetStringArgument ( const QString& strShortOpt, const QString& strLongOpt, QString& strArg )
     {
-        for ( int i = 1; i < appArgc; i++ )
+        for ( int i = 1; i < argc; i++ )
         {
             if ( GetStringArgument ( i, strShortOpt, strLongOpt, strArg ) )
             {
@@ -483,7 +463,7 @@ public:
 
     static bool GetNumericArgument ( const QString& strShortOpt, const QString& strLongOpt, double rRangeStart, double rRangeStop, double& rValue )
     {
-        for ( int i = 1; i < appArgc; i++ )
+        for ( int i = 1; i < argc; i++ )
         {
             if ( GetNumericArgument ( i, strShortOpt, strLongOpt, rRangeStart, rRangeStop, rValue ) )
             {
@@ -496,7 +476,7 @@ public:
 
     //=================================================
     // Non statics to parse bare arguments
-    // (These need an instance of CCommandlineOptions)
+    // (These need an instance of CCommandline)
     //=================================================
 
 protected:
@@ -505,7 +485,7 @@ protected:
 
     void reset()
     {
-        currentArgv  = appArgv;
+        currentArgv  = argv;
         currentIndex = 0;
     }
 
@@ -519,12 +499,12 @@ public:
 
     QString GetNextArgument()
     {
-        if ( currentIndex < appArgc )
+        if ( currentIndex < argc )
         {
             currentArgv++;
             currentIndex++;
 
-            if ( currentIndex < appArgc )
+            if ( currentIndex < argc )
             {
                 return QString ( *currentArgv );
             }
@@ -537,7 +517,7 @@ public:
 // defines for commandline options in the style "shortopt", "longopt"
 // Name is standard CMDLN_LONGOPTNAME
 // These defines can be used for strShortOpt, strLongOpt parameters
-// of the CCommandlineOptions functions.
+// of the CCommandline functions.
 
 // clang-format off
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,8 +55,19 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 
 // Implementation **************************************************************
 
+int    CCommandlineOptions::appArgc = 0;
+char** CCommandlineOptions::appArgv = NULL;
+
+QDialog* CMsgBoxes::pMainForm       = NULL;
+QString  CMsgBoxes::strMainFormName = APP_NAME;
+
+
 int main ( int argc, char** argv )
 {
+    CCommandlineOptions::appArgc = argc;
+    CCommandlineOptions::appArgv = argv;
+
+    CCommandlineOptions cmdLine; // We don't really need an instance here, but using one improves the readability of the code.
 
 #if defined( Q_OS_MACX )
     // Mnemonic keys are default disabled in Qt for MacOS. The following function enables them.
@@ -79,6 +90,7 @@ int main ( int argc, char** argv )
 #else
     bool bIsClient = true;
 #endif
+    bool         bSpecialOptions             = false; // Any options after this option will be accepted ! (mostly used for debugging purpouses)
     bool         bUseGUI                     = true;
     bool         bStartMinimized             = false;
     bool         bShowComplRegConnList       = false;
@@ -128,14 +140,20 @@ int main ( int argc, char** argv )
     // QT docu: argv()[0] is the program name, argv()[1] is the first
     // argument and argv()[argc()-1] is the last argument.
     // Start with first argument, therefore "i = 1"
+
+    // clang-format off
+// pgScorio TODO:
+// Extra Checks on parameters:
+//      If given, CMDLN_SERVER MUST be FIRST parameter.
+//      And then only check parameters valid for common, server or client !
+    // clang-format on
+
     for ( int i = 1; i < argc; i++ )
     {
-
         // Help (usage) flag ---------------------------------------------------
         if ( ( !strcmp ( argv[i], "--help" ) ) || ( !strcmp ( argv[i], "-h" ) ) || ( !strcmp ( argv[i], "-?" ) ) )
         {
-            const QString strHelp = UsageArguments ( argv );
-            std::cout << qUtf8Printable ( strHelp );
+            std::cout << qUtf8Printable ( UsageArguments ( argv ) );
             exit ( 0 );
         }
 
@@ -149,7 +167,7 @@ int main ( int argc, char** argv )
         // Common options:
 
         // Initialization file -------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-i", "--inifile", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_INIFILE, strArgument ) )
         {
             strIniFileName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- initialization file name: %1" ).arg ( strIniFileName ) );
@@ -158,7 +176,7 @@ int main ( int argc, char** argv )
         }
 
         // Disable GUI flag ----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-n", "--nogui" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_NOGUI ) )
         {
             bUseGUI = false;
             qInfo() << "- no GUI mode chosen";
@@ -167,7 +185,7 @@ int main ( int argc, char** argv )
         }
 
         // Port number ---------------------------------------------------------
-        if ( GetNumericArgument ( argc, argv, i, "-p", "--port", 0, 65535, rDbleArgument ) )
+        if ( cmdLine.GetNumericArgument ( i, CMDLN_PORT, 0, 65535, rDbleArgument ) )
         {
             iPortNumber            = static_cast<quint16> ( rDbleArgument );
             bCustomPortNumberGiven = true;
@@ -176,26 +194,8 @@ int main ( int argc, char** argv )
             continue;
         }
 
-        // JSON-RPC port number ------------------------------------------------
-        if ( GetNumericArgument ( argc, argv, i, "--jsonrpcport", "--jsonrpcport", 0, 65535, rDbleArgument ) )
-        {
-            iJsonRpcPortNumber = static_cast<quint16> ( rDbleArgument );
-            qInfo() << qUtf8Printable ( QString ( "- JSON-RPC port number: %1" ).arg ( iJsonRpcPortNumber ) );
-            CommandLineOptions << "--jsonrpcport";
-            continue;
-        }
-
-        // JSON-RPC secret file name -------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "--jsonrpcsecretfile", "--jsonrpcsecretfile", strArgument ) )
-        {
-            strJsonRpcSecretFileName = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- JSON-RPC secret file: %1" ).arg ( strJsonRpcSecretFileName ) );
-            CommandLineOptions << "--jsonrpcsecretfile";
-            continue;
-        }
-
         // Quality of Service --------------------------------------------------
-        if ( GetNumericArgument ( argc, argv, i, "-Q", "--qos", 0, 255, rDbleArgument ) )
+        if ( cmdLine.GetNumericArgument ( i, CMDLN_QOS, 0, 255, rDbleArgument ) )
         {
             iQosNumber = static_cast<quint16> ( rDbleArgument );
             qInfo() << qUtf8Printable ( QString ( "- selected QoS value: %1" ).arg ( iQosNumber ) );
@@ -204,7 +204,7 @@ int main ( int argc, char** argv )
         }
 
         // Disable translations ------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-t", "--notranslation" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_NOTRANSLATION ) )
         {
             bUseTranslation = false;
             qInfo() << "- translations disabled";
@@ -213,7 +213,7 @@ int main ( int argc, char** argv )
         }
 
         // Enable IPv6 ---------------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-6", "--enableipv6" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_ENABLEIPV6 ) )
         {
             bEnableIPv6 = true;
             qInfo() << "- IPv6 enabled";
@@ -224,7 +224,7 @@ int main ( int argc, char** argv )
         // Server only:
 
         // Disconnect all clients on quit --------------------------------------
-        if ( GetFlagArgument ( argv, i, "-d", "--discononquit" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_DISCONONQUIT ) )
         {
             bDisconnectAllClientsOnQuit = true;
             qInfo() << "- disconnect all clients on quit";
@@ -234,22 +234,9 @@ int main ( int argc, char** argv )
         }
 
         // Directory server ----------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-e", "--directoryserver", strArgument ) )
-        {
-            strDirectoryServer = strArgument;
-            qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strDirectoryServer ) );
-            CommandLineOptions << "--directoryserver";
-            ServerOnlyOptions << "--directoryserver";
-            continue;
-        }
-
-        // Central server ** D E P R E C A T E D ** ----------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--centralserver", // no short form
-                                 "--centralserver",
-                                 strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_DIRECTORYSERVER, strArgument ) ||
+             cmdLine.GetStringArgument ( i, CMDLN_CENTRALSERVER, strArgument ) // ** D E P R E C A T E D **
+        )
         {
             strDirectoryServer = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- directory server: %1" ).arg ( strDirectoryServer ) );
@@ -259,12 +246,7 @@ int main ( int argc, char** argv )
         }
 
         // Directory file ------------------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--directoryfile", // no short form
-                                 "--directoryfile",
-                                 strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_DIRECTORYFILE, strArgument ) )
         {
             strServerListFileName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- directory server persistence file: %1" ).arg ( strServerListFileName ) );
@@ -274,7 +256,7 @@ int main ( int argc, char** argv )
         }
 
         // Server list filter --------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-f", "--listfilter", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_LISTFILTER, strArgument ) )
         {
             strServerListFilter = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- server list filter: %1" ).arg ( strServerListFilter ) );
@@ -284,7 +266,7 @@ int main ( int argc, char** argv )
         }
 
         // Use 64 samples frame size mode --------------------------------------
-        if ( GetFlagArgument ( argv, i, "-F", "--fastupdate" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_FASTUPDATE ) )
         {
             bUseDoubleSystemFrameSize = false; // 64 samples frame size
             qInfo() << qUtf8Printable ( QString ( "- using %1 samples frame size mode" ).arg ( SYSTEM_FRAME_SIZE_SAMPLES ) );
@@ -294,7 +276,7 @@ int main ( int argc, char** argv )
         }
 
         // Use logging ---------------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-l", "--log", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_LOG, strArgument ) )
         {
             strLoggingFileName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- logging file name: %1" ).arg ( strLoggingFileName ) );
@@ -304,7 +286,7 @@ int main ( int argc, char** argv )
         }
 
         // Use licence flag ----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-L", "--licence" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_LICENCE ) )
         {
             // LT_CREATIVECOMMONS is now used just to enable the pop up
             eLicenceType = LT_CREATIVECOMMONS;
@@ -315,7 +297,7 @@ int main ( int argc, char** argv )
         }
 
         // HTML status file ----------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-m", "--htmlstatus", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_HTMLSTATUS, strArgument ) )
         {
             strHTMLStatusFileName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- HTML status file name: %1" ).arg ( strHTMLStatusFileName ) );
@@ -325,7 +307,7 @@ int main ( int argc, char** argv )
         }
 
         // Server info ---------------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-o", "--serverinfo", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_SERVERINFO, strArgument ) )
         {
             strServerInfo = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- server info: %1" ).arg ( strServerInfo ) );
@@ -335,12 +317,7 @@ int main ( int argc, char** argv )
         }
 
         // Server Public IP ----------------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--serverpublicip", // no short form
-                                 "--serverpublicip",
-                                 strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_SERVERPUBLICIP, strArgument ) )
         {
             strServerPublicIP = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- server public IP: %1" ).arg ( strServerPublicIP ) );
@@ -350,7 +327,7 @@ int main ( int argc, char** argv )
         }
 
         // Enable delay panning on startup -------------------------------------
-        if ( GetFlagArgument ( argv, i, "-P", "--delaypan" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_DELAYPAN ) )
         {
             bDelayPan = true;
             qInfo() << "- starting with delay panning";
@@ -360,7 +337,7 @@ int main ( int argc, char** argv )
         }
 
         // Recording directory -------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-R", "--recording", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_RECORDING, strArgument ) )
         {
             strRecordingDirName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- recording directory name: %1" ).arg ( strRecordingDirName ) );
@@ -370,10 +347,7 @@ int main ( int argc, char** argv )
         }
 
         // Disable recording on startup ----------------------------------------
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--norecord", // no short form
-                               "--norecord" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_NORECORD ) )
         {
             bDisableRecording = true;
             qInfo() << "- recording will not take place until enabled";
@@ -383,7 +357,7 @@ int main ( int argc, char** argv )
         }
 
         // Server mode flag ----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-s", "--server" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_SERVER ) )
         {
             bIsClient = false;
             qInfo() << "- server mode chosen";
@@ -393,12 +367,7 @@ int main ( int argc, char** argv )
         }
 
         // Server Bind IP --------------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--serverbindip", // no short form
-                                 "--serverbindip",
-                                 strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_SERVERBINDIP, strArgument ) )
         {
             strServerBindIP = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- server bind IP: %1" ).arg ( strServerBindIP ) );
@@ -408,7 +377,7 @@ int main ( int argc, char** argv )
         }
 
         // Use multithreading --------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-T", "--multithreading" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_MULTITHREADING ) )
         {
             bUseMultithreading = true;
             qInfo() << "- using multithreading";
@@ -418,7 +387,7 @@ int main ( int argc, char** argv )
         }
 
         // Maximum number of channels ------------------------------------------
-        if ( GetNumericArgument ( argc, argv, i, "-u", "--numchannels", 1, MAX_NUM_CHANNELS, rDbleArgument ) )
+        if ( cmdLine.GetNumericArgument ( i, CMDLN_NUMCHANNELS, 1, MAX_NUM_CHANNELS, rDbleArgument ) )
         {
             iNumServerChannels = static_cast<int> ( rDbleArgument );
 
@@ -430,7 +399,7 @@ int main ( int argc, char** argv )
         }
 
         // Server welcome message ----------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-w", "--welcomemessage", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_WELCOMEMESSAGE, strArgument ) )
         {
             strWelcomeMessage = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- welcome message: %1" ).arg ( strWelcomeMessage ) );
@@ -440,7 +409,7 @@ int main ( int argc, char** argv )
         }
 
         // Start minimized -----------------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-z", "--startminimized" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_STARTMINIMIZED ) )
         {
             bStartMinimized = true;
             qInfo() << "- start minimized enabled";
@@ -452,7 +421,7 @@ int main ( int argc, char** argv )
         // Client only:
 
         // Connect on startup --------------------------------------------------
-        if ( GetStringArgument ( argc, argv, i, "-c", "--connect", strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_CONNECT, strArgument ) )
         {
             strConnOnStartupAddress = NetworkUtil::FixAddress ( strArgument );
             qInfo() << qUtf8Printable ( QString ( "- connect on startup to address: %1" ).arg ( strConnOnStartupAddress ) );
@@ -462,7 +431,7 @@ int main ( int argc, char** argv )
         }
 
         // Disabling auto Jack connections -------------------------------------
-        if ( GetFlagArgument ( argv, i, "-j", "--nojackconnect" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_NOJACKCONNECT ) )
         {
             bNoAutoJackConnect = true;
             qInfo() << "- disable auto Jack connections";
@@ -472,7 +441,7 @@ int main ( int argc, char** argv )
         }
 
         // Mute stream on startup ----------------------------------------------
-        if ( GetFlagArgument ( argv, i, "-M", "--mutestream" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_MUTESTREAM ) )
         {
             bMuteStream = true;
             qInfo() << "- mute stream activated";
@@ -482,10 +451,7 @@ int main ( int argc, char** argv )
         }
 
         // For headless client mute my own signal in personal mix --------------
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--mutemyown", // no short form
-                               "--mutemyown" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_MUTEMYOWN ) )
         {
             bMuteMeInPersonalMix = true;
             qInfo() << "- mute me in my personal mix";
@@ -495,12 +461,7 @@ int main ( int argc, char** argv )
         }
 
         // Client Name ---------------------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--clientname", // no short form
-                                 "--clientname",
-                                 strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_CLIENTNAME, strArgument ) )
         {
             strClientName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- client name: %1" ).arg ( strClientName ) );
@@ -510,12 +471,7 @@ int main ( int argc, char** argv )
         }
 
         // Controller MIDI channel ---------------------------------------------
-        if ( GetStringArgument ( argc,
-                                 argv,
-                                 i,
-                                 "--ctrlmidich", // no short form
-                                 "--ctrlmidich",
-                                 strArgument ) )
+        if ( cmdLine.GetStringArgument ( i, CMDLN_CTRLMIDICH, strArgument ) )
         {
             strMIDISetup = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- MIDI controller settings: %1" ).arg ( strMIDISetup ) );
@@ -530,10 +486,7 @@ int main ( int argc, char** argv )
         // Undocumented debugging command line argument: Show all registered
         // servers in the server list regardless if a ping to the server is
         // possible or not.
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--showallservers", // no short form
-                               "--showallservers" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_SHOWALLSERVERS ) )
         {
             bShowComplRegConnList = true;
             qInfo() << "- show all registered servers in server list";
@@ -545,10 +498,7 @@ int main ( int argc, char** argv )
         // Show analyzer console -----------------------------------------------
         // Undocumented debugging command line argument: Show the analyzer
         // console to debug network buffer properties.
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--showanalyzerconsole", // no short form
-                               "--showanalyzerconsole" ) )
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_SHOWANALYZERCONSOLE ) )
         {
             bShowAnalyzerConsole = true;
             qInfo() << "- show analyzer console";
@@ -557,14 +507,27 @@ int main ( int argc, char** argv )
             continue;
         }
 
+        // Enable Special Options ----------------------------------------------
+        if ( cmdLine.GetFlagArgument ( i, CMDLN_SPECIAL ) )
+        {
+            bSpecialOptions = true;
+            qInfo() << "- Special options enabled !";
+            continue;
+        }
+
         // Unknown option ------------------------------------------------------
         qCritical() << qUtf8Printable ( QString ( "%1: Unknown option '%2' -- use '--help' for help" ).arg ( argv[0] ).arg ( argv[i] ) );
 
+        // pgScorpio: No exit for options after the "--special" option.
+        // Used for debugging and testing new options...
+        if ( !bSpecialOptions )
+        {
 // clicking on the Mac application bundle, the actual application
 // is called with weird command line args -> do not exit on these
 #if !( defined( Q_OS_MACX ) )
-        exit ( 1 );
+            exit ( 1 );
 #endif
+        }
     }
 
     // Dependencies ------------------------------------------------------------
@@ -596,8 +559,7 @@ int main ( int argc, char** argv )
         if ( ServerOnlyOptions.size() != 0 )
         {
             qCritical() << qUtf8Printable ( QString ( "%1: Server only option(s) '%2' used.  Did you omit '--server'?" )
-                                                .arg ( argv[0] )
-                                                .arg ( ServerOnlyOptions.join ( ", " ) ) );
+                                                .arg ( CCommandlineOptions::GetProgramPath(), ServerOnlyOptions.join ( ", " ) ) );
             exit ( 1 );
         }
 
@@ -901,6 +863,9 @@ int main ( int argc, char** argv )
                                        bEnableIPv6,
                                        nullptr );
 
+                // initialise message boxes
+                CMsgBoxes::init ( &ClientDlg, strClientName.isEmpty() ? QString ( APP_NAME ) : QString ( APP_NAME ) + " " + strClientName );
+
                 // show dialog
                 ClientDlg.show();
                 pApp->exec();
@@ -1083,9 +1048,9 @@ QString UsageArguments ( char** argv )
     // clang-format on
 }
 
-bool GetFlagArgument ( char** argv, int& i, QString strShortOpt, QString strLongOpt )
+bool CCommandlineOptions::GetFlagArgument ( int& i, const QString& strShortOpt, const QString& strLongOpt )
 {
-    if ( ( !strShortOpt.compare ( argv[i] ) ) || ( !strLongOpt.compare ( argv[i] ) ) )
+    if ( ( !strShortOpt.compare ( appArgv[i] ) ) || ( !strLongOpt.compare ( appArgv[i] ) ) )
     {
         return true;
     }
@@ -1095,17 +1060,17 @@ bool GetFlagArgument ( char** argv, int& i, QString strShortOpt, QString strLong
     }
 }
 
-bool GetStringArgument ( int argc, char** argv, int& i, QString strShortOpt, QString strLongOpt, QString& strArg )
+bool CCommandlineOptions::GetStringArgument ( int& i, const QString& strShortOpt, const QString& strLongOpt, QString& strArg )
 {
-    if ( ( !strShortOpt.compare ( argv[i] ) ) || ( !strLongOpt.compare ( argv[i] ) ) )
+    if ( ( !strShortOpt.compare ( appArgv[i] ) ) || ( !strLongOpt.compare ( appArgv[i] ) ) )
     {
-        if ( ++i >= argc )
+        if ( ++i >= appArgc )
         {
-            qCritical() << qUtf8Printable ( QString ( "%1: '%2' needs a string argument." ).arg ( argv[0] ).arg ( argv[i - 1] ) );
+            qCritical() << qUtf8Printable ( QString ( "%1: '%2' needs a string argument." ).arg ( appArgv[0] ).arg ( appArgv[i - 1] ) );
             exit ( 1 );
         }
 
-        strArg = argv[i];
+        strArg = appArgv[i];
 
         return true;
     }
@@ -1115,29 +1080,27 @@ bool GetStringArgument ( int argc, char** argv, int& i, QString strShortOpt, QSt
     }
 }
 
-bool GetNumericArgument ( int     argc,
-                          char**  argv,
-                          int&    i,
-                          QString strShortOpt,
-                          QString strLongOpt,
-                          double  rRangeStart,
-                          double  rRangeStop,
-                          double& rValue )
+bool CCommandlineOptions::GetNumericArgument ( int&           i,
+                                               const QString& strShortOpt,
+                                               const QString& strLongOpt,
+                                               double         rRangeStart,
+                                               double         rRangeStop,
+                                               double&        rValue )
 {
-    if ( ( !strShortOpt.compare ( argv[i] ) ) || ( !strLongOpt.compare ( argv[i] ) ) )
+    if ( ( !strShortOpt.compare ( appArgv[i] ) ) || ( !strLongOpt.compare ( appArgv[i] ) ) )
     {
         QString errmsg = "%1: '%2' needs a numeric argument from '%3' to '%4'.";
-        if ( ++i >= argc )
+        if ( ++i >= appArgc )
         {
-            qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( argv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );
+            qCritical() << qUtf8Printable ( errmsg.arg ( appArgv[0] ).arg ( appArgv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );
             exit ( 1 );
         }
 
         char* p;
-        rValue = strtod ( argv[i], &p );
+        rValue = strtod ( appArgv[i], &p );
         if ( *p || ( rValue < rRangeStart ) || ( rValue > rRangeStop ) )
         {
-            qCritical() << qUtf8Printable ( errmsg.arg ( argv[0] ).arg ( argv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );
+            qCritical() << qUtf8Printable ( errmsg.arg ( appArgv[0] ).arg ( appArgv[i - 1] ).arg ( rRangeStart ).arg ( rRangeStop ) );
             exit ( 1 );
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,8 +58,8 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 int    CCommandlineOptions::appArgc = 0;
 char** CCommandlineOptions::appArgv = NULL;
 
-QDialog* CMsgBoxes::pMainForm       = NULL;
-QString  CMsgBoxes::strMainFormName = APP_NAME;
+tMainform* CMsgBoxes::pMainForm       = NULL;
+QString    CMsgBoxes::strMainFormName = APP_NAME;
 
 int main ( int argc, char** argv )
 {
@@ -140,13 +140,6 @@ int main ( int argc, char** argv )
     // argument and argv()[argc()-1] is the last argument.
     // Start with first argument, therefore "i = 1"
 
-    // clang-format off
-// pgScorio TODO:
-// Extra Checks on parameters:
-//      If given, CMDLN_SERVER MUST be FIRST parameter.
-//      And then only check parameters valid for common, server or client !
-    // clang-format on
-
     for ( int i = 1; i < argc; i++ )
     {
         // Help (usage) flag ---------------------------------------------------
@@ -190,6 +183,24 @@ int main ( int argc, char** argv )
             bCustomPortNumberGiven = true;
             qInfo() << qUtf8Printable ( QString ( "- selected port number: %1" ).arg ( iPortNumber ) );
             CommandLineOptions << "--port";
+            continue;
+        }
+
+        // JSON-RPC port number ------------------------------------------------
+        if ( cmdLine.GetNumericArgument ( i, CMDLN_JSONRPCPORT, 0, 65535, rDbleArgument ) )
+        {
+            iJsonRpcPortNumber = static_cast<quint16> ( rDbleArgument );
+            qInfo() << qUtf8Printable ( QString ( "- JSON-RPC port number: %1" ).arg ( iJsonRpcPortNumber ) );
+            CommandLineOptions << "--jsonrpcport";
+            continue;
+        }
+
+        // JSON-RPC secret file name -------------------------------------------
+        if ( cmdLine.GetStringArgument ( i, CMDLN_JSONRPCSECRETFILE, strArgument ) )
+        {
+            strJsonRpcSecretFileName = strArgument;
+            qInfo() << qUtf8Printable ( QString ( "- JSON-RPC secret file: %1" ).arg ( strJsonRpcSecretFileName ) );
+            CommandLineOptions << "--jsonrpcsecretfile";
             continue;
         }
 
@@ -514,13 +525,13 @@ int main ( int argc, char** argv )
             continue;
         }
 
-        // Unknown option ------------------------------------------------------
-        qCritical() << qUtf8Printable ( QString ( "%1: Unknown option '%2' -- use '--help' for help" ).arg ( argv[0] ).arg ( argv[i] ) );
-
-        // pgScorpio: No exit for options after the "--special" option.
+        // No exit for options after the "--special" option.
         // Used for debugging and testing new options...
         if ( !bSpecialOptions )
         {
+            // Unknown option ------------------------------------------------------
+            qCritical() << qUtf8Printable ( QString ( "%1: Unknown option '%2' -- use '--help' for help" ).arg ( argv[0] ).arg ( argv[i] ) );
+
 // clicking on the Mac application bundle, the actual application
 // is called with weird command line args -> do not exit on these
 #if !( defined( Q_OS_MACX ) )
@@ -875,6 +886,9 @@ int main ( int argc, char** argv )
                 // only start application without using the GUI
                 qInfo() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
 
+                // initialise message boxes
+                CMsgBoxes::init ( NULL, strClientName.isEmpty() ? QString ( APP_NAME ) : QString ( APP_NAME ) + " " + strClientName );
+
                 pApp->exec();
             }
         }
@@ -925,6 +939,9 @@ int main ( int argc, char** argv )
                 // GUI object for the server
                 CServerDlg ServerDlg ( &Server, &Settings, bStartMinimized, nullptr );
 
+                // initialise message boxes
+                CMsgBoxes::init ( &ServerDlg, strClientName.isEmpty() ? QString ( APP_NAME ) : QString ( APP_NAME ) + " " + strClientName );
+
                 // show dialog (if not the minimized flag is set)
                 if ( !bStartMinimized )
                 {
@@ -945,6 +962,9 @@ int main ( int argc, char** argv )
                 {
                     Server.SetDirectoryType ( AT_CUSTOM );
                 }
+
+                // initialise message boxes
+                CMsgBoxes::init ( NULL, strClientName.isEmpty() ? QString ( APP_NAME ) : QString ( APP_NAME ) + " " + strClientName );
 
                 pApp->exec();
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,6 @@ char** CCommandlineOptions::appArgv = NULL;
 QDialog* CMsgBoxes::pMainForm       = NULL;
 QString  CMsgBoxes::strMainFormName = APP_NAME;
 
-
 int main ( int argc, char** argv )
 {
     CCommandlineOptions::appArgc = argc;
@@ -958,7 +957,7 @@ int main ( int argc, char** argv )
 #ifndef HEADLESS
         if ( bUseGUI )
         {
-            QMessageBox::critical ( nullptr, APP_NAME, generr.GetErrorText(), "Quit", nullptr );
+            CMsgBoxes::ShowError ( generr.GetErrorText() );
         }
         else
 #endif

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -571,12 +571,10 @@ void CServerDlg::OnStopRecorder()
     UpdateRecorderStatus ( QString() );
     if ( pServer->GetRecorderErrMsg() != QString() )
     {
-        QMessageBox::warning ( this,
-                               APP_NAME,
-                               tr ( "Recorder failed to start. "
-                                    "Please check available disk space and permissions and try again. "
-                                    "Error: " ) +
-                                   pServer->GetRecorderErrMsg() );
+        CMsgBoxes::ShowWarning ( tr ( "Recorder failed to start. "
+                                      "Please check available disk space and permissions and try again. "
+                                      "Error: " ) +
+                                 pServer->GetRecorderErrMsg() );
     }
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -454,14 +454,14 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     // custom directories
     // clang-format off
 // TODO compatibility to old version (< 3.6.1)
-QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
     // clang-format on
+    QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
         // clang-format off
 // TODO compatibility to old version (< 3.8.2)
-strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
         // clang-format on
+        strDirectoryAddress        = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
         vstrDirectoryAddress[iIdx] = GetIniSetting ( IniXMLDocument, "client", QString ( "directoryaddress%1" ).arg ( iIdx ), strDirectoryAddress );
         strDirectoryAddress        = "";
     }
@@ -469,17 +469,19 @@ strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centr
     // directory type
     // clang-format off
 // TODO compatibility to old version (<3.4.7)
-// only the case that "centralservaddr" was set in old ini must be considered
-if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) && !bValue )
-{
-    eDirectoryType = AT_CUSTOM;
-}
-// TODO compatibility to old version (< 3.8.2)
-else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
-{
-    eDirectoryType = static_cast<EDirectoryType> ( iValue );
-}
     // clang-format on
+    // only the case that "centralservaddr" was set in old ini must be considered
+    if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) && !bValue )
+    {
+        eDirectoryType = AT_CUSTOM;
+    }
+    // clang-format off
+// TODO compatibility to old version (< 3.8.2)
+    // clang-format on
+    else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
+    {
+        eDirectoryType = static_cast<EDirectoryType> ( iValue );
+    }
     else if ( GetNumericIniSet ( IniXMLDocument, "client", "directorytype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
     {
         eDirectoryType = static_cast<EDirectoryType> ( iValue );
@@ -818,8 +820,8 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         QString directoryAddress = "";
         // clang-format off
 // TODO compatibility to old version < 3.8.2
-directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", directoryAddress );
         // clang-format on
+        directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", directoryAddress );
         directoryAddress = GetIniSetting ( IniXMLDocument, "server", "directoryaddress", directoryAddress );
 
         pServer->SetDirectoryAddress ( directoryAddress );
@@ -839,40 +841,44 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
     {
         // clang-format off
 // TODO compatibility to old version < 3.4.7
-if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
-{
-    directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
-}
-else
-            // clang-format on
+        // clang-format on
+        if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
+        {
+            directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
+        }
+        else
 
             // if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
             // clang-format off
 // TODO compatibility to old version < 3.8.2
-if ( GetNumericIniSet ( IniXMLDocument, "server", "centservaddrtype", static_cast<int> ( AT_DEFAULT ), static_cast<int> ( AT_CUSTOM ), iValue ) )
-{
-    directoryType = static_cast<EDirectoryType> ( iValue );
-}
-else
-                // clang-format on
-                if ( GetNumericIniSet ( IniXMLDocument,
-                                        "server",
-                                        "directorytype",
-                                        static_cast<int> ( AT_NONE ),
-                                        static_cast<int> ( AT_CUSTOM ),
-                                        iValue ) )
-                {
-                    directoryType = static_cast<EDirectoryType> ( iValue );
-                }
+            // clang-format on
+            if ( GetNumericIniSet ( IniXMLDocument,
+                                    "server",
+                                    "centservaddrtype",
+                                    static_cast<int> ( AT_DEFAULT ),
+                                    static_cast<int> ( AT_CUSTOM ),
+                                    iValue ) )
+            {
+                directoryType = static_cast<EDirectoryType> ( iValue );
+            }
+            else if ( GetNumericIniSet ( IniXMLDocument,
+                                         "server",
+                                         "directorytype",
+                                         static_cast<int> ( AT_NONE ),
+                                         static_cast<int> ( AT_CUSTOM ),
+                                         iValue ) )
+            {
+                directoryType = static_cast<EDirectoryType> ( iValue );
+            }
 
         // clang-format off
 // TODO compatibility to old version < 3.9.0
-// override type to AT_NONE if servlistenabled exists and is false
-if (  GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
-{
-    directoryType = AT_NONE;
-}
         // clang-format on
+        // override type to AT_NONE if servlistenabled exists and is false
+        if ( GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
+        {
+            directoryType = AT_NONE;
+        }
     }
 
     pServer->SetDirectoryType ( directoryType );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -336,11 +336,8 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
 
     if ( !strError.isEmpty() )
     {
-#    ifndef HEADLESS
-        // special case: when settings are loaded no GUI is yet created, therefore
-        // we have to create a warning message box here directly
-        QMessageBox::warning ( nullptr, APP_NAME, strError );
-#    endif
+
+        CMsgBoxes::ShowWarning ( strError );
     }
 
     // sound card channel mapping settings: make sure these settings are
@@ -858,16 +855,16 @@ if ( GetNumericIniSet ( IniXMLDocument, "server", "centservaddrtype", static_cas
     directoryType = static_cast<EDirectoryType> ( iValue );
 }
 else
-            // clang-format on
-            if ( GetNumericIniSet ( IniXMLDocument,
-                                    "server",
-                                    "directorytype",
-                                    static_cast<int> ( AT_NONE ),
-                                    static_cast<int> ( AT_CUSTOM ),
-                                    iValue ) )
-        {
-            directoryType = static_cast<EDirectoryType> ( iValue );
-        }
+                // clang-format on
+                if ( GetNumericIniSet ( IniXMLDocument,
+                                        "server",
+                                        "directorytype",
+                                        static_cast<int> ( AT_NONE ),
+                                        static_cast<int> ( AT_CUSTOM ),
+                                        iValue ) )
+                {
+                    directoryType = static_cast<EDirectoryType> ( iValue );
+                }
 
         // clang-format off
 // TODO compatibility to old version < 3.9.0

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -846,31 +846,28 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         {
             directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
         }
-        else
-
-            // if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
-            // clang-format off
+        // if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
+        // clang-format off
 // TODO compatibility to old version < 3.8.2
-            // clang-format on
-            if ( GetNumericIniSet ( IniXMLDocument,
-                                    "server",
-                                    "centservaddrtype",
-                                    static_cast<int> ( AT_DEFAULT ),
-                                    static_cast<int> ( AT_CUSTOM ),
-                                    iValue ) )
-            {
-                directoryType = static_cast<EDirectoryType> ( iValue );
-            }
-            else if ( GetNumericIniSet ( IniXMLDocument,
-                                         "server",
-                                         "directorytype",
-                                         static_cast<int> ( AT_NONE ),
-                                         static_cast<int> ( AT_CUSTOM ),
-                                         iValue ) )
-            {
-                directoryType = static_cast<EDirectoryType> ( iValue );
-            }
-
+        // clang-format on
+        else if ( GetNumericIniSet ( IniXMLDocument,
+                                     "server",
+                                     "centservaddrtype",
+                                     static_cast<int> ( AT_DEFAULT ),
+                                     static_cast<int> ( AT_CUSTOM ),
+                                     iValue ) )
+        {
+            directoryType = static_cast<EDirectoryType> ( iValue );
+        }
+        else if ( GetNumericIniSet ( IniXMLDocument,
+                                     "server",
+                                     "directorytype",
+                                     static_cast<int> ( AT_NONE ),
+                                     static_cast<int> ( AT_CUSTOM ),
+                                     iValue ) )
+        {
+            directoryType = static_cast<EDirectoryType> ( iValue );
+        }
         // clang-format off
 // TODO compatibility to old version < 3.9.0
         // clang-format on

--- a/src/soundbase.cpp
+++ b/src/soundbase.cpp
@@ -182,7 +182,8 @@ QString CSoundBase::SetDev ( const QString strDevName )
             // ASIO drivers
             sErrorMessage += "<br/>" + tr ( "Do you want to open the ASIO driver setup to try changing your configuration to a working state?" );
 
-            if ( QMessageBox::Yes == QMessageBox::information ( nullptr, APP_NAME, sErrorMessage, QMessageBox::Yes | QMessageBox::No ) )
+            if ( QMessageBox::Yes ==
+                 QMessageBox::information ( CMsgBoxes::MainForm(), CMsgBoxes::MainFormName(), sErrorMessage, QMessageBox::Yes | QMessageBox::No ) )
             {
                 LoadAndInitializeFirstValidDriver ( true );
             }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -666,7 +666,9 @@ void CLanguageComboBox::OnLanguageActivated ( int iLanguageIdx )
     // only update if the language selection is different from the current selected language
     if ( iIdxSelectedLanguage != iLanguageIdx )
     {
-        QMessageBox::information ( this, tr ( "Restart Required" ), tr ( "Please restart the application for the language change to take effect." ) );
+        QMessageBox::information ( CMsgBoxes::MainForm(),
+                                   CMsgBoxes::MainFormName() + ": " + tr ( "Restart Required" ),
+                                   tr ( "Please restart the application for the language change to take effect." ) );
 
         emit LanguageChanged ( itemData ( iLanguageIdx ).toString() );
     }

--- a/src/util.h
+++ b/src/util.h
@@ -421,7 +421,7 @@ protected:
 public slots:
     void OnHelpWhatsThis() { QWhatsThis::enterWhatsThisMode(); }
     void OnHelpAbout() { AboutDlg.exec(); }
-    void OnHelpAboutQt() { QMessageBox::aboutQt ( nullptr, QString ( tr ( "About Qt" ) ) ); }
+    void OnHelpAboutQt() { QMessageBox::aboutQt ( CMsgBoxes::MainForm(), QString ( tr ( "About Qt" ) ) ); }
     void OnHelpClientGetStarted() { QDesktopServices::openUrl ( QUrl ( CLIENT_GETTING_STARTED_URL ) ); }
     void OnHelpServerGetStarted() { QDesktopServices::openUrl ( QUrl ( SERVER_GETTING_STARTED_URL ) ); }
     void OnHelpSoftwareMan() { QDesktopServices::openUrl ( QUrl ( SOFTWARE_MANUAL_URL ) ); }

--- a/windows/sound.cpp
+++ b/windows/sound.cpp
@@ -101,8 +101,8 @@ QString CSound::LoadAndInitializeDriver ( QString strDriverName, bool bOpenDrive
         if ( bOpenDriverSetup )
         {
             OpenDriverSetup();
-            QMessageBox::question ( nullptr,
-                                    APP_NAME,
+            QMessageBox::question ( CMsgBoxes::MainForm(),
+                                    CMsgBoxes::MainFormName(),
                                     "Are you done with your ASIO driver settings of " + GetDeviceName ( iDriverIdx ) + "?",
                                     QMessageBox::Yes );
         }
@@ -314,9 +314,8 @@ int CSound::GetActualBufferSize ( const int iDesiredBufferSizeMono )
     // clang-format off
 /*
 // TEST
-#include <QMessageBox>
-QMessageBox::information ( 0, "APP_NAME", QString("lMinSize: %1, lMaxSize: %2, lPreferredSize: %3, lGranularity: %4").
-                           arg(HWBufferInfo.lMinSize).arg(HWBufferInfo.lMaxSize).arg(HWBufferInfo.lPreferredSize).arg(HWBufferInfo.lGranularity) );
+CMsgBoxes::ShowInfo( QString("lMinSize: %1, lMaxSize: %2, lPreferredSize: %3, lGranularity: %4").
+                             arg(HWBufferInfo.lMinSize).arg(HWBufferInfo.lMaxSize).arg(HWBufferInfo.lPreferredSize).arg(HWBufferInfo.lGranularity) );
 _exit(1);
 */
     // clang-format on


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!-- Explain what your PR does -->
New attempt replacing #2541

Added global messagebox and commandline parameter parsing classes to global.h/main.c
Adapted all messageboxes to use the new CMsgBoxes class.

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
General improvement and preparation for sound-redesign.

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
