### PR TITLE
clang-format issues settings.cpp

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -458,14 +458,14 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     // custom directories
     // clang-format off
 // TODO compatibility to old version (< 3.6.1)
-QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
     // clang-format on
+    QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
         // clang-format off
 // TODO compatibility to old version (< 3.8.2)
-strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
         // clang-format on
+        strDirectoryAddress        = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
         vstrDirectoryAddress[iIdx] = GetIniSetting ( IniXMLDocument, "client", QString ( "directoryaddress%1" ).arg ( iIdx ), strDirectoryAddress );
         strDirectoryAddress        = "";
     }
@@ -474,16 +474,18 @@ strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centr
     // clang-format off
 // TODO compatibility to old version (<3.4.7)
 // only the case that "centralservaddr" was set in old ini must be considered
-if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) && !bValue )
-{
-    eDirectoryType = AT_CUSTOM;
-}
-// TODO compatibility to old version (< 3.8.2)
-else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
-{
-    eDirectoryType = static_cast<EDirectoryType> ( iValue );
-}
     // clang-format on
+    if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) && !bValue )
+    {
+        eDirectoryType = AT_CUSTOM;
+    }
+    // clang-format off
+// TODO compatibility to old version (< 3.8.2)
+    // clang-format on
+    else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
+    {
+        eDirectoryType = static_cast<EDirectoryType> ( iValue );
+    }
     else if ( GetNumericIniSet ( IniXMLDocument, "client", "directorytype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
     {
         eDirectoryType = static_cast<EDirectoryType> ( iValue );
@@ -822,8 +824,8 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         QString directoryAddress = "";
         // clang-format off
 // TODO compatibility to old version < 3.8.2
-directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", directoryAddress );
         // clang-format on
+        directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", directoryAddress );
         directoryAddress = GetIniSetting ( IniXMLDocument, "server", "directoryaddress", directoryAddress );
 
         pServer->SetDirectoryAddress ( directoryAddress );
@@ -843,21 +845,25 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
     {
         // clang-format off
 // TODO compatibility to old version < 3.4.7
-if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
-{
-    directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
-}
-else
-            // clang-format on
-
-            // if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
-            // clang-format off
+        // clang-format on
+        if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
+        {
+            directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
+        }
+        // clang-format off
 // TODO compatibility to old version < 3.8.2
-if ( GetNumericIniSet ( IniXMLDocument, "server", "centservaddrtype", static_cast<int> ( AT_DEFAULT ), static_cast<int> ( AT_CUSTOM ), iValue ) )
-{
-    directoryType = static_cast<EDirectoryType> ( iValue );
-}
-else
+// if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
+        // clang-format on
+        else if ( GetNumericIniSet ( IniXMLDocument,
+                                     "server",
+                                     "centservaddrtype",
+                                     static_cast<int> ( AT_DEFAULT ),
+                                     static_cast<int> ( AT_CUSTOM ),
+                                     iValue ) )
+        {
+            directoryType = static_cast<EDirectoryType> ( iValue );
+        }
+        else
             // clang-format on
             if ( GetNumericIniSet ( IniXMLDocument,
                                     "server",
@@ -865,18 +871,18 @@ else
                                     static_cast<int> ( AT_NONE ),
                                     static_cast<int> ( AT_CUSTOM ),
                                     iValue ) )
-        {
-            directoryType = static_cast<EDirectoryType> ( iValue );
-        }
+            {
+                directoryType = static_cast<EDirectoryType> ( iValue );
+            }
 
         // clang-format off
 // TODO compatibility to old version < 3.9.0
 // override type to AT_NONE if servlistenabled exists and is false
-if (  GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
-{
-    directoryType = AT_NONE;
-}
         // clang-format on
+        if ( GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
+        {
+            directoryType = AT_NONE;
+        }
     }
 
     pServer->SetDirectoryType ( directoryType );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -863,17 +863,15 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         {
             directoryType = static_cast<EDirectoryType> ( iValue );
         }
-        else
-            // clang-format on
-            if ( GetNumericIniSet ( IniXMLDocument,
-                                    "server",
-                                    "directorytype",
-                                    static_cast<int> ( AT_NONE ),
-                                    static_cast<int> ( AT_CUSTOM ),
-                                    iValue ) )
-            {
-                directoryType = static_cast<EDirectoryType> ( iValue );
-            }
+        else if ( GetNumericIniSet ( IniXMLDocument,
+                                     "server",
+                                     "directorytype",
+                                     static_cast<int> ( AT_NONE ),
+                                     static_cast<int> ( AT_CUSTOM ),
+                                     iValue ) )
+        {
+            directoryType = static_cast<EDirectoryType> ( iValue );
+        }
 
         // clang-format off
 // TODO compatibility to old version < 3.9.0


### PR DESCRIPTION
Fixing clang-format issues caused by different behaviour of clang-format
v10 vs clang-format v13.

clang-format v10 has issues when declarations/statements are partly inside a clang-format off block.

So opening and closing brackets should always be neither or both inside the block.
Also compount statements like 'else if' should never be broken by a clang-format off/on.

To avoid these clang-format version issues at all it's the safest to use clang-format on/off
only around comments or complete declarations/definitions.

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Moved clang-format off/on locations

<!-- Explain what your PR does -->

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
It does not fix the issue, but it's a work-around for the clang-format version problem

**Does this change need documentation? What needs to be documented and how?**
Maybe we should document not to use clang-format off/on inside declarations/definitions, unless it's only around a comment ?

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
