### PR TITLE
Code style change: Replace clang-format off/on with TODO/TEST comments.

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -639,23 +639,23 @@ void CNetBufWithStats::UpdateAutoSetting()
     // apply non-linear IIR filter
     MathUtils().UpDownIIR1 ( dCurIIRFilterResult, static_cast<double> ( iCurDecision ), dWeightUp, dWeightDown );
 
-    // clang-format off
-/*
-// TEST store important detection parameters in file for debugging
-static FILE* pFile = fopen ( "test.dat", "w" );
-static int icnt = 0;
-if ( icnt == 50 )
-{
-    fprintf ( pFile, "%d %e\n", iCurDecision, dCurIIRFilterResult );
-    fflush ( pFile );
-    icnt = 0;
-}
-else
-{
-    icnt++;
-}
-*/
-    // clang-format on
+    //### TEST: BEGIN ###//
+    // TEST store important detection parameters in file for debugging
+    /*
+    static FILE* pFile = fopen ( "test.dat", "w" );
+    static int icnt = 0;
+    if ( icnt == 50 )
+    {
+        fprintf ( pFile, "%d %e\n", iCurDecision, dCurIIRFilterResult );
+        fflush ( pFile );
+        icnt = 0;
+    }
+    else
+    {
+        icnt++;
+    }
+    */
+    //### TEST: END ###//
 
     // apply a hysteresis
     iCurAutoBufferSizeSetting = MathUtils().DecideWithHysteresis ( dCurIIRFilterResult, iCurDecidedResult, dHysteresisValue );

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -59,11 +59,11 @@ CChannel::CChannel ( const bool bNIsServer ) :
 
     // Connections -------------------------------------------------------------
 
-    // clang-format off
-// TODO if we later do not fire vectors in the emits, we can remove this again
-qRegisterMetaType<CVector<uint8_t> > ( "CVector<uint8_t>" );
-qRegisterMetaType<CHostAddress> ( "CHostAddress" );
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // if we later do not fire vectors in the emits, we can remove this again
+    qRegisterMetaType<CVector<uint8_t>> ( "CVector<uint8_t>" );
+    qRegisterMetaType<CHostAddress> ( "CHostAddress" );
+    //### TODO: END ###//
 
     QObject::connect ( &Protocol, &CProtocol::MessReadyForSending, this, &CChannel::OnSendProtMessage );
 

--- a/src/channel.h
+++ b/src/channel.h
@@ -156,10 +156,10 @@ public:
     void CreateChatTextMes ( const QString& strChatText ) { Protocol.CreateChatTextMes ( strChatText ); }
     void CreateLicReqMes ( const ELicenceType eLicenceType ) { Protocol.CreateLicenceRequiredMes ( eLicenceType ); }
 
-    // clang-format off
-// TODO needed for compatibility to old servers >= 3.4.6 and <= 3.5.12
-void CreateReqChannelLevelListMes() { Protocol.CreateReqChannelLevelListMes(); }
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // needed for compatibility to old servers >= 3.4.6 and <= 3.5.12
+    void CreateReqChannelLevelListMes() { Protocol.CreateReqChannelLevelListMes(); }
+    //### TODO: END ###//
 
     void CreateConClientListMes ( const CVector<CChannelInfo>& vecChanInfo ) { Protocol.CreateConClientListMes ( vecChanInfo ); }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -273,10 +273,10 @@ void CClient::OnNewConnection()
     Channel.CreateReqConnClientsList();
     CreateServerJitterBufferMessage();
 
-    // clang-format off
-// TODO needed for compatibility to old servers >= 3.4.6 and <= 3.5.12
-Channel.CreateReqChannelLevelListMes();
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // needed for compatibility to old servers >= 3.4.6 and <= 3.5.12
+    Channel.CreateReqChannelLevelListMes();
+    //### TODO: END ###//
 }
 
 void CClient::CreateServerJitterBufferMessage()
@@ -1088,13 +1088,13 @@ void CClient::AudioCallback ( CVector<int16_t>& psData, void* arg )
     // process audio data
     pMyClientObj->ProcessSndCrdAudioData ( psData );
 
-    // clang-format off
-/*
-// TEST do a soundcard jitter measurement
-static CTimingMeas JitterMeas ( 1000, "test2.dat" );
-JitterMeas.Measure();
-*/
-    // clang-format on
+    //### TEST: BEGIN ###//
+    // do a soundcard jitter measurement
+    /*
+    static CTimingMeas JitterMeas ( 1000, "test2.dat" );
+    JitterMeas.Measure();
+    */
+    //### TEST: END ###//
 }
 
 void CClient::ProcessSndCrdAudioData ( CVector<int16_t>& vecsStereoSndCrd )

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1266,11 +1266,11 @@ void CClientDlg::Disconnect()
     TimerDetectFeedback.stop();
     bDetectFeedback = false;
 
-    // clang-format off
-// TODO is this still required???
-// immediately update status bar
-OnTimerStatus();
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // is this still required???
+    // immediately update status bar
+    OnTimerStatus();
+    //### TODO: END ###//
 
     // reset LEDs
     ledBuffers->Reset();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -812,10 +812,10 @@ int main ( int argc, char** argv )
     Q_INIT_RESOURCE ( resources );
 
 #ifndef SERVER_ONLY
-    // clang-format off
-// TEST -> activate the following line to activate the test bench,
-//CTestbench Testbench ( "127.0.0.1", DEFAULT_PORT_NUMBER );
-// clang-format on
+    //### TEST: BEGIN ###//
+    // activate the following line to activate the test bench,
+    // CTestbench Testbench ( "127.0.0.1", DEFAULT_PORT_NUMBER );
+    //### TEST: END ###//
 #endif
 
     CRpcServer* pRpcServer = nullptr;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -619,12 +619,10 @@ void CProtocol::CreateAndImmSendConLessMessage ( const int iID, const CVector<ui
 
 void CProtocol::ParseMessageBody ( const CVector<uint8_t>& vecbyMesBodyData, const int iRecCounter, const int iRecID )
 {
-    // clang-format off
-/*
-// TEST channel implementation: randomly delete protocol messages (50 % loss)
-if ( rand() < ( RAND_MAX / 2 ) ) return false;
-*/
-    // clang-format on
+    //### TEST: BEGIN ###//
+    // channel implementation: randomly delete protocol messages (50 % loss)
+    // if ( rand() < ( RAND_MAX / 2 ) ) return false;
+    //### TEST: END ###//
 
     // In case we received a message and returned an answer but our answer
     // did not make it to the receiver, he will resend his message. We check
@@ -842,12 +840,11 @@ if ( rand() < ( RAND_MAX / 2 ) ) return false;
 
 void CProtocol::ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMesBodyData, const int iRecID, const CHostAddress& InetAddr )
 {
-    // clang-format off
-/*
-// TEST channel implementation: randomly delete protocol messages (50 % loss)
-if ( rand() < ( RAND_MAX / 2 ) ) return false;
-*/
-    // clang-format on
+    //### TEST: BEGIN ###//
+    // Test channel implementation: randomly delete protocol messages (50 % loss)
+
+    // if ( rand() < ( RAND_MAX / 2 ) ) return false;
+    //### TEST: END ###//
 
     // check which type of message we received and do action
     switch ( iRecID )
@@ -2646,12 +2643,11 @@ bool CProtocol::ParseMessageFrame ( const CVector<uint8_t>& vecbyData,
 
     // Extract actual data -----------------------------------------------------
 
-    // clang-format off
-// TODO this memory allocation is done in the real time thread but should be
-//      done in the low priority protocol management thread
-    // clang-format on
-
+    //### TODO: BEGIN ###//
+    // this memory allocation is done in the real time thread but should be
+    // done in the low priority protocol management thread
     vecbyMesBodyData.Init ( iLenBy );
+    //### TODO: END ###//
 
     iCurPos = MESS_HEADER_LENGTH_BYTE; // start from beginning of data
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -127,10 +127,10 @@ public:
     void CreateLicenceRequiredMes ( const ELicenceType eLicenceType );
     void CreateOpusSupportedMes();
 
-    // clang-format off
-// TODO needed for compatibility to old servers >= 3.4.6 and <= 3.5.12
-void CreateReqChannelLevelListMes();
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // needed for compatibility to old servers >= 3.4.6 and <= 3.5.12
+    void CreateReqChannelLevelListMes();
+    //### TODO: END ###//
 
     void CreateVersionAndOSMes();
     void CreateRecorderStateMes ( const ERecorderState eRecorderState );

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -182,13 +182,12 @@ void CHighPrecisionTimer::run()
     {
         // call processing routine by fireing signal
 
-        // clang-format off
-// TODO by emit a signal we leave the high priority thread -> maybe use some
-//      other connection type to have something like a true callback, e.g.
-//      "Qt::DirectConnection" -> Can this work?
-        // clang-format on
-
+        //### TODO: BEGIN ###//
+        // by emit a signal we leave the high priority thread -> maybe use some
+        // other connection type to have something like a true callback, e.g.
+        //     "Qt::DirectConnection" -> Can this work?
         emit timeout();
+        //### TODO: END ###//
 
         // now wait until the next buffer shall be processed (we
         // use the "increment method" to make sure we do not introduce
@@ -756,11 +755,11 @@ void CServer::Stop()
 
 void CServer::OnTimer()
 {
-    // clang-format off
-/*
-static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure(); // TEST do a timer jitter measurement
-*/
-    // clang-format on
+    //### TEST: BEGIN ###//
+    // uncomment next line to do a timer Jitter measurement
+    // static CTimingMeas JitterMeas ( 1000, "test2.dat" ); JitterMeas.Measure();
+    //### TEST: END ###//
+
     // Get data from all connected clients -------------------------------------
     // some inits
     int  iNumClients          = 0; // init connected client counter
@@ -1344,11 +1343,12 @@ void CServer::MixEncodeTransmitData ( const int iChanCnt, const int iNumClients 
         // OPUS encoding
         if ( pCurOpusEncoder != nullptr )
         {
-            // clang-format off
-// TODO find a better place than this: the setting does not change all the time so for speed
-//      optimization it would be better to set it only if the network frame size is changed
-opus_custom_encoder_ctl ( pCurOpusEncoder, OPUS_SET_BITRATE ( CalcBitRateBitsPerSecFromCodedBytes ( iCeltNumCodedBytes, iClientFrameSizeSamples ) ) );
-            // clang-format on
+            //### TODO: BEGIN ###//
+            // find a better place than this: the setting does not change all the time so for speed
+            // optimization it would be better to set it only if the network frame size is changed
+            opus_custom_encoder_ctl ( pCurOpusEncoder,
+                                      OPUS_SET_BITRATE ( CalcBitRateBitsPerSecFromCodedBytes ( iCeltNumCodedBytes, iClientFrameSizeSamples ) ) );
+            //### TODO: END ###//
 
             for ( int iB = 0; iB < vecNumFrameSizeConvBlocks[iChanCnt]; iB++ )
             {

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -273,11 +273,11 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     lvwClients->setColumnWidth ( 3, 50 );  //         Channels
     lvwClients->clear();
 
-    // clang-format off
-// TEST workaround for resize problem of window after iconize in task bar
-lvwClients->setMinimumWidth ( 170 + 130 + 60 + 205 );
-lvwClients->setMinimumHeight ( 140 );
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // workaround for resize problem of window after iconize in task bar
+    lvwClients->setMinimumWidth ( 170 + 130 + 60 + 205 );
+    lvwClients->setMinimumHeight ( 140 );
+    //### TODO: END ###//
 
     // insert items in reverse order because in Windows all of them are
     // always visible -> put first item on the top

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -456,34 +456,39 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     }
 
     // custom directories
-    // clang-format off
-// TODO compatibility to old version (< 3.6.1)
-QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
-    // clang-format on
+
+    //### TODO: BEGIN ###//
+    // compatibility to old version (< 3.6.1)
+    QString strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", "centralservaddr", "" );
+    //### TODO: END ###//
+
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
-        // clang-format off
-// TODO compatibility to old version (< 3.8.2)
-strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
-        // clang-format on
+        //### TODO: BEGIN ###//
+        // compatibility to old version (< 3.8.2)
+        strDirectoryAddress = GetIniSetting ( IniXMLDocument, "client", QString ( "centralservaddr%1" ).arg ( iIdx ), strDirectoryAddress );
+        //### TODO: END ###//
+
         vstrDirectoryAddress[iIdx] = GetIniSetting ( IniXMLDocument, "client", QString ( "directoryaddress%1" ).arg ( iIdx ), strDirectoryAddress );
         strDirectoryAddress        = "";
     }
 
     // directory type
-    // clang-format off
-// TODO compatibility to old version (<3.4.7)
-// only the case that "centralservaddr" was set in old ini must be considered
-if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) && !bValue )
-{
-    eDirectoryType = AT_CUSTOM;
-}
-// TODO compatibility to old version (< 3.8.2)
-else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
-{
-    eDirectoryType = static_cast<EDirectoryType> ( iValue );
-}
-    // clang-format on
+
+    //### TODO: BEGIN ###//
+    // compatibility to old version (<3.4.7)
+    // only the case that "centralservaddr" was set in old ini must be considered
+    if ( !vstrDirectoryAddress[0].isEmpty() && GetFlagIniSet ( IniXMLDocument, "client", "defcentservaddr", bValue ) && !bValue )
+    {
+        eDirectoryType = AT_CUSTOM;
+    }
+    // compatibility to old version (< 3.8.2)
+    else if ( GetNumericIniSet ( IniXMLDocument, "client", "centservaddrtype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
+    {
+        eDirectoryType = static_cast<EDirectoryType> ( iValue );
+    }
+    //### TODO: END ###//
+
     else if ( GetNumericIniSet ( IniXMLDocument, "client", "directorytype", 0, static_cast<int> ( AT_CUSTOM ), iValue ) )
     {
         eDirectoryType = static_cast<EDirectoryType> ( iValue );
@@ -820,10 +825,12 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         // CServerListManager defaults to command line argument (or "" if not passed)
         // Server GUI defaults to ""
         QString directoryAddress = "";
-        // clang-format off
-// TODO compatibility to old version < 3.8.2
-directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", directoryAddress );
-        // clang-format on
+
+        //### TODO: BEGIN ###//
+        // compatibility to old version < 3.8.2
+        directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", directoryAddress );
+        //### TODO: END ###//
+
         directoryAddress = GetIniSetting ( IniXMLDocument, "server", "directoryaddress", directoryAddress );
 
         pServer->SetDirectoryAddress ( directoryAddress );
@@ -841,42 +848,48 @@ directoryAddress = GetIniSetting ( IniXMLDocument, "server", "centralservaddr", 
     }
     else
     {
-        // clang-format off
-// TODO compatibility to old version < 3.4.7
-if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
-{
-    directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
-}
-else
-            // clang-format on
+        //### TODO: BEGIN ###//
+        // compatibility to old version < 3.4.7
+        if ( GetFlagIniSet ( IniXMLDocument, "server", "defcentservaddr", bValue ) )
+        {
+            directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
+        }
+        else
+            //### TODO: END ###//
 
             // if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
-            // clang-format off
-// TODO compatibility to old version < 3.8.2
-if ( GetNumericIniSet ( IniXMLDocument, "server", "centservaddrtype", static_cast<int> ( AT_DEFAULT ), static_cast<int> ( AT_CUSTOM ), iValue ) )
-{
-    directoryType = static_cast<EDirectoryType> ( iValue );
-}
-else
-            // clang-format on
+
+            //### TODO: BEGIN ###//
+            // compatibility to old version < 3.8.2
             if ( GetNumericIniSet ( IniXMLDocument,
                                     "server",
-                                    "directorytype",
-                                    static_cast<int> ( AT_NONE ),
+                                    "centservaddrtype",
+                                    static_cast<int> ( AT_DEFAULT ),
                                     static_cast<int> ( AT_CUSTOM ),
                                     iValue ) )
         {
             directoryType = static_cast<EDirectoryType> ( iValue );
         }
+        //### TODO: END ###//
 
-        // clang-format off
-// TODO compatibility to old version < 3.9.0
-// override type to AT_NONE if servlistenabled exists and is false
-if (  GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
-{
-    directoryType = AT_NONE;
-}
-        // clang-format on
+        else if ( GetNumericIniSet ( IniXMLDocument,
+                                     "server",
+                                     "directorytype",
+                                     static_cast<int> ( AT_NONE ),
+                                     static_cast<int> ( AT_CUSTOM ),
+                                     iValue ) )
+        {
+            directoryType = static_cast<EDirectoryType> ( iValue );
+        }
+
+        //### TODO: BEGIN ###//
+        // compatibility to old version < 3.9.0
+        // override type to AT_NONE if servlistenabled exists and is false
+        if ( GetFlagIniSet ( IniXMLDocument, "server", "servlistenabled", bValue ) && !bValue )
+        {
+            directoryType = AT_NONE;
+        }
+        //### TODO: END ###//
     }
 
     pServer->SetDirectoryType ( directoryType );

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -92,9 +92,9 @@ void CSocket::Init ( const quint16 iNewPortNumber, const quint16 iNewQosNumber, 
 #ifdef _WIN32
     // for the Windows socket usage we have to start it up first
 
-    // clang-format off
-// TODO check for error and exit application on error
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // check for error and exit application on error
+    //### TODO: END ###//
 
     WSADATA wsa;
     WSAStartup ( MAKEWORD ( 1, 0 ), &wsa );
@@ -411,21 +411,17 @@ void CSocket::OnDataReceived()
         // this is a protocol message, check the type of the message
         if ( CProtocol::IsConnectionLessMessageID ( iRecID ) )
         {
-
-            // clang-format off
-// TODO a copy of the vector is used -> avoid malloc in real-time routine
-            // clang-format on
-
+            //### TODO: BEGIN ###//
+            // a copy of the vector is used -> avoid malloc in real-time routine
             emit ProtocolCLMessageReceived ( iRecID, vecbyMesBodyData, RecHostAddr );
+            //### TODO: END ###//
         }
         else
         {
-
-            // clang-format off
-// TODO a copy of the vector is used -> avoid malloc in real-time routine
-            // clang-format on
-
+            //### TODO: BEGIN ###//
+            // a copy of the vector is used -> avoid malloc in real-time routine
             emit ProtocolMessageReceived ( iRecCounter, iRecID, vecbyMesBodyData, RecHostAddr );
+            //### TODO: END ###//
         }
     }
     else

--- a/src/sound/asio/sound.cpp
+++ b/src/sound/asio/sound.cpp
@@ -311,19 +311,20 @@ int CSound::GetActualBufferSize ( const int iDesiredBufferSizeMono )
     // query the usable buffer sizes
     ASIOGetBufferSize ( &HWBufferInfo.lMinSize, &HWBufferInfo.lMaxSize, &HWBufferInfo.lPreferredSize, &HWBufferInfo.lGranularity );
 
-    // clang-format off
-/*
-// TEST
-#include <QMessageBox>
-QMessageBox::information ( 0, "APP_NAME", QString("lMinSize: %1, lMaxSize: %2, lPreferredSize: %3, lGranularity: %4").
-                           arg(HWBufferInfo.lMinSize).arg(HWBufferInfo.lMaxSize).arg(HWBufferInfo.lPreferredSize).arg(HWBufferInfo.lGranularity) );
-_exit(1);
-*/
-    // clang-format on
+    //### TEST: BEGIN ###//
+    /*
+    #include <QMessageBox>
+    QMessageBox::information ( 0, "APP_NAME", QString("lMinSize: %1, lMaxSize: %2, lPreferredSize: %3, lGranularity: %4").
+                               arg(HWBufferInfo.lMinSize).arg(HWBufferInfo.lMaxSize).arg(HWBufferInfo.lPreferredSize).arg(HWBufferInfo.lGranularity)
+    );
+    _exit(1);
+    */
+    //### TEST: END ###//
 
-    // clang-format off
-// TODO see https://github.com/EddieRingle/portaudio/blob/master/src/hostapi/asio/pa_asio.cpp#L1654 (SelectHostBufferSizeForUnspecifiedUserFramesPerBuffer)
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // see https://github.com/EddieRingle/portaudio/blob/master/src/hostapi/asio/pa_asio.cpp#L1654
+    // (SelectHostBufferSizeForUnspecifiedUserFramesPerBuffer)
+    //### TODO: END ###//
 
     // calculate "nearest" buffer size and set internal parameter accordingly
     // first check minimum and maximum values

--- a/src/sound/jack/sound.cpp
+++ b/src/sound/jack/sound.cpp
@@ -195,14 +195,13 @@ void CSound::Stop()
 int CSound::Init ( const int /* iNewPrefMonoBufferSize */ )
 {
 
-    // clang-format off
-// try setting buffer size
-// TODO seems not to work! -> no audio after this operation!
-// Doesn't this give an infinite loop? The set buffer size function will call our
-// registered callback which calls "EmitReinitRequestSignal()". In that function
-// this CSound::Init() function is called...
-//jack_set_buffer_size ( pJackClient, iNewPrefMonoBufferSize );
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // try setting buffer size seems not to work! -> no audio after this operation!
+    // Doesn't this give an infinite loop? The set buffer size function will call our
+    // registered callback which calls "EmitReinitRequestSignal()". In that function
+    // this CSound::Init() function is called...
+    // jack_set_buffer_size ( pJackClient, iNewPrefMonoBufferSize );
+    //### TODO: END ###//
 
     // without a Jack server, Jamulus makes no sense to run, throw an error message
     if ( bJackWasShutDown )
@@ -305,10 +304,11 @@ int CSound::process ( jack_nframes_t nframes, void* arg )
                 jack_midi_event_get ( &in_event, in_midi, j );
 
                 // copy packet and send it to the MIDI parser
-                // clang-format off
-// TODO do not call malloc in real-time callback
-                // clang-format on
+
+                //### TODO: BEGIN ###//
+                // do not call malloc in real-time callback
                 CVector<uint8_t> vMIDIPaketBytes ( in_event.size );
+                //### TODO: END ###//
 
                 for ( i = 0; i < static_cast<int> ( in_event.size ); i++ )
                 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -495,6 +495,7 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
         "<p>RobyDati (<a href=\"https://github.com/RobyDati\">RobyDati</a>)</p>"
         "<p>Rob-NY (<a href=\"https://github.com/Rob-NY\">Rob-NY</a>)</p>"
         "<p>Thai Pangsakulyanont (<a href=\"https://github.com/dtinth\">dtinth</a>)</p>"
+        "<p>Peter Goderie (<a href=\"https://github.com/pgScorpio\">pgScorpio</a>)</p>"
         "<br>" +
         tr ( "For details on the contributions check out the %1" )
             .arg ( "<a href=\"https://github.com/jamulussoftware/jamulus/graphs/contributors\">" + tr ( "Github Contributors list" ) + "</a>." ) );

--- a/src/util.h
+++ b/src/util.h
@@ -689,11 +689,12 @@ enum ESkillLevel
 class CStereoSignalLevelMeter
 {
 public:
-    // clang-format off
-// TODO Calculate smoothing factor from sample rate and frame size (64 or 128 samples frame size).
-//      But tests with 128 and 64 samples frame size have shown that the meter fly back
-//      is ok for both numbers of samples frame size with a factor of 0.99.
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // Calculate smoothing factor from sample rate and frame size (64 or 128 samples frame size).
+    //      But tests with 128 and 64 samples frame size have shown that the meter fly back
+    //      is ok for both numbers of samples frame size with a factor of 0.99.
+    //### TODO: END ###//
+
     CStereoSignalLevelMeter ( const bool bNIsStereoOut = true, const double dNSmoothingFactor = 0.99 ) :
         dSmoothingFactor ( dNSmoothingFactor ),
         bIsStereoOut ( bNIsStereoOut )
@@ -784,9 +785,9 @@ public:
     static EInstCategory GetCategory ( const int iInstrument );
     static void          UpdateTableOnLanguageChange() { GetTable ( true ); }
 
-    // clang-format off
-// TODO make use of instrument category (not yet implemented)
-    // clang-format on
+    //### TODO: BEGIN ###//
+    // make use of instrument category (not yet implemented)
+    //### TODO: END ###//
 
 protected:
     class CInstPictProps


### PR DESCRIPTION
Changes as discussed in issue #2591

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Replace clang-format off/on with TODO/TEST comments where applicable.
<!-- Explain what your PR does -->

CHANGELOG: Internal: Code style: TODO and TEST comments instead of un-indenting with clang-format off/on

**Context: Fixes an issue?**
partly solves clang-format problems (#2587)
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
Maybe we should document this new coding-style rule somewhere?
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready to merge
**What is missing until this pull request can be merged?**
Review
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
