### PR TITLE
Remove wrong occurances of "URL"

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -84,9 +84,9 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
 
     // server address
     QString strServAddrH = "<b>" + tr ( "Server Address" ) + ":</b> " +
-                           tr ( "If you know the IP address or URL of a server, you can connect to it "
-                                "using the Server name/Address field. An optional port number can be added after the IP "
-                                "address or URL using a colon as a separator, e.g. %1. "
+                           tr ( "If you know the server address, you can connect to it "
+                                "using the Server name/Address field. An optional port number can be added after the server "
+                                "address using a colon as a separator, e.g. %1. "
                                 "The field will also show a list of the most recently used server addresses." )
                                .arg ( QString ( "<tt>example.org:%1</tt>" ).arg ( DEFAULT_PORT_NUMBER ) );
 
@@ -94,7 +94,7 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     cbxServerAddr->setWhatsThis ( strServAddrH );
 
     cbxServerAddr->setAccessibleName ( tr ( "Server address edit box" ) );
-    cbxServerAddr->setAccessibleDescription ( tr ( "Holds the current server IP address or URL. It also stores old URLs in the combo box list." ) );
+    cbxServerAddr->setAccessibleDescription ( tr ( "Holds the current server address. It also stores old addresses in the combo box list." ) );
 
     UpdateDirectoryServerComboBox();
 


### PR DESCRIPTION
**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: Refactoring: Removed wrongly mentioned "URL" from help texts. 

**Context: Fixes an issue?**

Fixes: https://github.com/jamulussoftware/jamulus/issues/2332

**Does this change need documentation? What needs to be documented and how?**

No. Just translation

**Status of this Pull Request**

Ready for review.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Nothing. 

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (see CI and local test)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
