### PR TITLE
Fixing memory leaks.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -808,7 +808,7 @@ int main ( int argc, char** argv )
     // Application/GUI setup ---------------------------------------------------
     // Application object
 #ifdef HEADLESS
-    QCoreApplication* pApp = new QCoreApplication ( argc, argv );
+    pApp = new QCoreApplication ( argc, argv );
 #else
 #    if defined( Q_OS_IOS )
     bUseGUI        = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,8 +61,10 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 
 QCoreApplication* pApp       = NULL;
 CRpcServer*       pRpcServer = NULL;
-CClientRpc*       pClientRpc = NULL;
-CServerRpc*       pServerRpc = NULL;
+#ifndef SERVER_ONLY
+CClientRpc* pClientRpc = NULL;
+#endif
+CServerRpc* pServerRpc = NULL;
 
 void cleanup()
 {
@@ -72,11 +74,13 @@ void cleanup()
         pServerRpc = NULL;
     }
 
+#ifndef SERVER_ONLY
     if ( pClientRpc )
     {
         delete pClientRpc;
         pClientRpc = NULL;
     }
+#endif
 
     if ( pRpcServer )
     {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Moved pointers to with new assigned objects outside main and added a
cleanup function that is called before every exit to delete those objects again.

<!-- Explain what your PR does -->

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast -->
Fixed some memory leaks.

**Context: Fixes an issue?**
Fixes #2614 

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No documentation changes
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Bugfix
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
**What is missing until this pull request can be merged?**
Ready to merge.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [-] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
