### PR TITLE
Autobuild: Fix iOS artifact name

### DIFF
--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -37,7 +37,7 @@ build_app_as_ipa() {
 }
 
 pass_artifact_to_job() {
-    local artifact="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-1}.ipa"
+    local artifact="jamulus_${JAMULUS_BUILD_VERSION}_iOSUnsigned${ARTIFACT_SUFFIX:-}.ipa"
     echo "Moving build artifact to deploy/${artifact}"
     mv ./deploy/Jamulus.ipa "./deploy/${artifact}"
     echo "::set-output name=artifact_1::${artifact}"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->
The file is currently named *Unsigned1.ipa. The 1 doesn't belong there and has wrongfully been added as part of the refactoring in f460f5ce276d8907e0784e7993c9532b72daa30f.

Note: As this is a trivial fix I'll likely merge this as soon as there's a single approval.

CHANGELOG: (No extra mention; list it with the iOS refactoring PR #2521)

**Context: Fixes an issue?**

No Github Issue.

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

No.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready on CI green.

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

CI/Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
