### PR TITLE
Fix loading serverlist entry from CSV file

### DIFF
--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -69,9 +69,9 @@ CServerListEntry CServerListEntry::parse ( QString strHAddr,
 
     return CServerListEntry ( haServerHostAddr,
                               haServerLocalAddr,
-                              CServerCoreInfo ( FromBase64ToString ( sName.trimmed().left ( MAX_LEN_SERVER_NAME ) ),
+                              CServerCoreInfo ( FromBase64ToString ( sName.trimmed() ).left ( MAX_LEN_SERVER_NAME ),
                                                 lcCountry,
-                                                FromBase64ToString ( sCity.trimmed().left ( MAX_LEN_SERVER_CITY ) ),
+                                                FromBase64ToString ( sCity.trimmed() ).left ( MAX_LEN_SERVER_CITY ),
                                                 iNumClients,
                                                 isPermanent ) );
 }


### PR DESCRIPTION
**Short description of changes**

The server list persistence code has a but that causes corruption of the server name and city when the file is read.  It truncates the base64-encoded value to the max field length -- before decoding it

This fixes the code to truncate after decoding.

CHANGELOG: Fix loading of persistent server list entries

**Context: Fixes an issue?**

See above.

**Does this change need documentation? What needs to be documented and how?**

No.  Fix for existing feature.

**Status of this Pull Request**

Test and running on all my directories.

**What is missing until this pull request can be merged?**

Approvals.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above