### PR TITLE
Autobuild: Fix Mac/Windows cache key

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -190,7 +190,7 @@ jobs:
           path: |
             /usr/local/opt/qt
             ~/Library/Cache/jamulus-homebrew-bottles
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/mac/autobuild_mac_1_prepare.sh', 'mac/deploy_mac.sh') }}-${{ matrix.config.base_command }}
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/mac.sh', 'mac/deploy_mac.sh') }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Windows dependencies
         if:                         matrix.config.target_os == 'windows'
@@ -201,7 +201,7 @@ jobs:
             C:\ChocoCache
             ~\windows\NSIS
             ~\libs\ASIOSDK2
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', 'autobuild/windows.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.base_command }}
+          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/windows.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Android dependencies
         if:                         matrix.config.target_os == 'android'


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
The cache key calculation still tried to consume the old, no longer existing build scripts contents for Mac/Windows. This wasn't noticed as the hashFiles() function ignores missing files silently.

This caused usage of cached dependencies even when the workflow scripts had changed. As such, those changes were not visible and the build was broken. #2640 was affected by this.

Correctness has now been verified via:
`for f in $(grep -Pho 'hashFiles\(\K.*(?=\))' .github/workflows/* | sed -re 's#[^a-z0-9./_ ]##g'); do [[ -f $f ]] || echo "$f doesnt exit"; done`

Broken-in: #2503


<!-- Explain what your PR does -->

CHANGELOG: (List as part of Autobuild refactorings, #2503)

**Context: Fixes an issue?**
https://github.com/jamulussoftware/jamulus/pull/2640#issuecomment-1136430622

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Waiting for CI green.

**What is missing until this pull request can be merged?**
Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
