### PR TITLE
Improvements to the start up logging for the server list filter

### DIFF
--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -235,7 +235,23 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
             else if ( CurWhiteListAddress.setAddress ( slWhitelistAddresses.at ( iIdx ) ) )
             {
                 vWhiteList << CurWhiteListAddress;
-                qInfo() << qUtf8Printable ( QString ( "Whitelist entry added: %1" ).arg ( CurWhiteListAddress.toString() ) );
+            }
+        }
+    }
+
+    // assume directoryType will get set to AT_CUSTOM
+    if ( !strDirectoryAddress.compare ( "localhost", Qt::CaseInsensitive ) || !strDirectoryAddress.compare ( "127.0.0.1" ) )
+    {
+        if ( !strMinServerVersion.isEmpty() )
+        {
+            qInfo() << "Registering servers must be version" << strMinServerVersion << "or later.";
+        }
+        if ( !vWhiteList.isEmpty() )
+        {
+            qInfo() << "Directory registration white list active.  Only the following addresses can register:";
+            foreach ( QHostAddress hostAddress, vWhiteList )
+            {
+                qInfo() << "  -" << hostAddress.toString();
             }
         }
     }


### PR DESCRIPTION
**Short description of changes**
Improvements to the start up logging for the server list filter.

**Context: Fixes an issue?**
No.

**Does this change need documentation? What needs to be documented and how?**
No.

**Status of this Pull Request**
Could do with testing from people who use the server _list_ part of the feature - I've been running with the version filter logging for months without issue.

**What is missing until this pull request can be merged?**
Review.  I'm not sure who now uses the server list filter (I don't think @sthenos does any more). **EDIT:** Apparently they do.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
