### PR TITLE
Autobuild: Make release changelog generation explicit

### DIFF
--- a/.github/actions_scripts/analyse_git_reference.py
+++ b/.github/actions_scripts/analyse_git_reference.py
@@ -32,17 +32,6 @@ def get_git_hash():
     ]).decode('ascii').strip()
 
 
-def write_changelog(version):
-    changelog = subprocess.check_output([
-        'perl',
-        f'{REPO_PATH}/.github/actions_scripts/getChangelog.pl',
-        f'{REPO_PATH}/ChangeLog',
-        version,
-    ])
-    with open(f'{REPO_PATH}/autoLatestChangelog.md', 'wb') as f:
-        f.write(changelog)
-
-
 def get_build_version(jamulus_pro_version):
     if "dev" in jamulus_pro_version:
         name = "{}-{}".format(jamulus_pro_version, get_git_hash())
@@ -60,7 +49,7 @@ def set_github_variable(varname, varval):
 
 
 jamulus_pro_version = get_version_from_jamulus_pro()
-write_changelog(jamulus_pro_version)
+set_github_variable("JAMULUS_PRO_VERSION", jamulus_pro_version)
 build_version = get_build_version(jamulus_pro_version)
 
 fullref = os.environ['GITHUB_REF']

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -62,6 +62,8 @@ jobs:
       publish_to_release:           ${{ steps.get-build-vars.outputs.PUBLISH_TO_RELEASE }}
       upload_url:                   ${{ steps.create-release.outputs.upload_url }}
       build_version:                ${{ steps.get-build-vars.outputs.BUILD_VERSION }}
+    env:
+      release_changelog_path:       ./.github_release_changelog.md
 
     steps:
       - name:                       Checkout code
@@ -83,7 +85,7 @@ jobs:
 
       - name:                       Generate release changelog
         if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
-        run:                        ./.github/actions_scripts/getChangelog.pl ./ChangeLog ${{ steps.get-build-vars.outputs.JAMULUS_PRO_VERSION }} > ./autoLatestChangelog.md
+        run:                        ./.github/actions_scripts/getChangelog.pl ./ChangeLog ${{ steps.get-build-vars.outputs.JAMULUS_PRO_VERSION }} > ${{ env.release_changelog_path }}
 
       - name:                       Create Release ${{steps.get-build-vars.outputs.RELEASE_TAG}}  ${{steps.get-build-vars.outputs.RELEASE_TITLE}}
         if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
@@ -94,7 +96,7 @@ jobs:
         with:
           tag_name:                 ${{ steps.get-build-vars.outputs.RELEASE_TAG }}
           release_name:             ${{ steps.get-build-vars.outputs.RELEASE_TITLE }}
-          body_path:                autoLatestChangelog.md
+          body_path:                ${{ env.release_changelog_path }}
           prerelease:               ${{ steps.get-build-vars.outputs.IS_PRERELEASE }}
           draft:                    false
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -67,7 +67,7 @@ jobs:
       - name:                       Checkout code
         uses:                       actions/checkout@v2
 
-      - name:                       Determine release version, type and prerelease variables and generate Changelog
+      - name:                       Determine release version, type and prerelease variables
         run:                        python3 ${{ github.workspace }}/.github/actions_scripts/analyse_git_reference.py
         id:                         get-build-vars
 
@@ -80,6 +80,10 @@ jobs:
           tag_name:                 ${{ steps.get-build-vars.outputs.RELEASE_TAG }}
         env:
           GITHUB_TOKEN:             ${{ secrets.GITHUB_TOKEN }}
+
+      - name:                       Generate release changelog
+        if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
+        run:                        ./.github/actions_scripts/getChangelog.pl ./ChangeLog ${{ steps.get-build-vars.outputs.JAMULUS_PRO_VERSION }} > ./autoLatestChangelog.md
 
       - name:                       Create Release ${{steps.get-build-vars.outputs.RELEASE_TAG}}  ${{steps.get-build-vars.outputs.RELEASE_TITLE}}
         if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- Autobuild: Use a variable instead of hardcoding the release changelog path twice
- Autobuild: Make release changelog generation explicit
  This was previously done as part of the variable extraction step.
  It's rather surprising to have a script with the name "analyze*" write
  to some Changelog file.
  
  Therefore, move all of the generation to the same abstraction level (Github workflow).
<!-- Explain what your PR does -->

CHANGELOG: (List along with the other autobuild improvements)

**Context: Fixes an issue?**
Fixes #2480

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Tested on my repo: https://github.com/hoffie/jamulus/runs/6948860313?check_suite_focus=true#step:5:1

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
