### PR TITLE
Add nojsonrpc qmake CONFIG option

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -372,8 +372,6 @@ HEADERS += src/buffer.h \
     src/server.h \
     src/serverlist.h \
     src/serverlogging.h \
-    src/serverrpc.h \
-    src/rpcserver.h \
     src/settings.h \
     src/socket.h \
     src/util.h \
@@ -384,7 +382,6 @@ HEADERS += src/buffer.h \
 
 !contains(CONFIG, "serveronly") {
     HEADERS += src/client.h \
-        src/clientrpc.h \
         src/sound/soundbase.h \
         src/testbench.h
 }
@@ -482,8 +479,6 @@ SOURCES += src/buffer.cpp \
     src/server.cpp \
     src/serverlist.cpp \
     src/serverlogging.cpp \
-    src/serverrpc.cpp \
-    src/rpcserver.cpp \
     src/settings.cpp \
     src/signalhandler.cpp \
     src/socket.cpp \
@@ -494,7 +489,6 @@ SOURCES += src/buffer.cpp \
 
 !contains(CONFIG, "serveronly") {
     SOURCES += src/client.cpp \
-        src/clientrpc.cpp \
         src/sound/soundbase.cpp \
 }
 
@@ -1058,6 +1052,24 @@ contains(CONFIG, "headless") {
     HEADERS += $$HEADERS_GUI
     SOURCES += $$SOURCES_GUI
     FORMS += $$FORMS_GUI
+}
+
+contains(CONFIG, "nojsonrpc") {
+    message(JSON-RPC support excluded from build.)
+    DEFINES += NO_JSON_RPC
+} else {
+    HEADERS += \
+        src/rpcserver.h \
+        src/serverrpc.h
+    SOURCES += \
+        src/rpcserver.cpp \
+        src/serverrpc.cpp
+    contains(CONFIG, "serveronly") {
+        message("server only, skipping client rpc")
+    } else {
+        HEADERS += src/clientrpc.h
+        SOURCES += src/clientrpc.cpp
+    }
 }
 
 # use external OPUS library if requested

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,12 @@
 extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 #endif
 #include <memory>
-#include "rpcserver.h"
-#include "serverrpc.h"
-#ifndef SERVER_ONLY
-#    include "clientrpc.h"
+#ifndef NO_JSON_RPC
+#    include "rpcserver.h"
+#    include "serverrpc.h"
+#    ifndef SERVER_ONLY
+#        include "clientrpc.h"
+#    endif
 #endif
 
 // Implementation **************************************************************
@@ -829,7 +831,13 @@ int main ( int argc, char** argv )
     //### TEST: END ###//
 #endif
 
-    CRpcServer* pRpcServer = nullptr;
+#ifdef NO_JSON_RPC
+    if ( iJsonRpcPortNumber != INVALID_PORT || !strJsonRpcSecretFileName.isEmpty() )
+    {
+        qWarning() << "No JSON-RPC support in this build.";
+    }
+#else
+    CRpcServer*   pRpcServer = nullptr;
 
     if ( iJsonRpcPortNumber != INVALID_PORT )
     {
@@ -865,6 +873,7 @@ int main ( int argc, char** argv )
             exit ( 1 );
         }
     }
+#endif
 
     try
     {
@@ -893,10 +902,12 @@ int main ( int argc, char** argv )
                 CInstPictures::UpdateTableOnLanguageChange();
             }
 
+#    ifndef NO_JSON_RPC
             if ( pRpcServer )
             {
                 new CClientRpc ( &Client, pRpcServer, pRpcServer );
             }
+#    endif
 
 #    ifndef HEADLESS
             if ( bUseGUI )
@@ -951,10 +962,12 @@ int main ( int argc, char** argv )
                              bEnableIPv6,
                              eLicenceType );
 
+#ifndef NO_JSON_RPC
             if ( pRpcServer )
             {
                 new CServerRpc ( &Server, pRpcServer, pRpcServer );
             }
+#endif
 
 #ifndef HEADLESS
             if ( bUseGUI )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,19 @@ int main ( int argc, char** argv )
     QString      strClientName               = "";
     QString      strJsonRpcSecretFileName    = "";
 
+#if defined( HEADLESS ) || defined( SERVER_ONLY )
+    Q_UNUSED ( bStartMinimized )
+    Q_UNUSED ( bUseTranslation )
+    Q_UNUSED ( bShowComplRegConnList )
+    Q_UNUSED ( bShowAnalyzerConsole )
+    Q_UNUSED ( bMuteStream )
+#endif
+#if defined( SERVER_ONLY )
+    Q_UNUSED ( bMuteMeInPersonalMix )
+    Q_UNUSED ( bNoAutoJackConnect )
+    Q_UNUSED ( bCustomPortNumberGiven )
+#endif
+
 #if !defined( HEADLESS ) && defined( _WIN32 )
     if ( AttachConsole ( ATTACH_PARENT_PROCESS ) )
     {
@@ -574,24 +587,19 @@ int main ( int argc, char** argv )
         bUseGUI = false;
         qWarning() << "No GUI support compiled. Running in headless mode.";
     }
-    Q_UNUSED ( bStartMinimized )       // avoid compiler warnings
-    Q_UNUSED ( bShowComplRegConnList ) // avoid compiler warnings
-    Q_UNUSED ( bShowAnalyzerConsole )  // avoid compiler warnings
-    Q_UNUSED ( bMuteStream )           // avoid compiler warnings
 #endif
 
-#ifdef SERVER_ONLY
     if ( bIsClient )
+#ifdef SERVER_ONLY
     {
         qCritical() << "Only --server mode is supported in this build.";
         exit ( 1 );
     }
-#endif
+#else
 
     // TODO create settings in default state, if loading from file do that next, then come back here to
     //      override from command line options, then create client or server, letting them do the validation
 
-    if ( bIsClient )
     {
         if ( ServerOnlyOptions.size() != 0 )
         {
@@ -617,6 +625,7 @@ int main ( int argc, char** argv )
         }
     }
     else
+#endif
     {
         if ( ClientOnlyOptions.size() != 0 )
         {
@@ -625,6 +634,7 @@ int main ( int argc, char** argv )
             exit ( 1 );
         }
 
+#ifndef HEADLESS
         if ( bUseGUI )
         {
             // by definition, when running with the GUI we always default to registering somewhere but
@@ -643,6 +653,7 @@ int main ( int argc, char** argv )
             }
         }
         else
+#endif
         {
             // the inifile is not supported for the headless server mode
             if ( !strIniFileName.isEmpty() )
@@ -764,11 +775,11 @@ int main ( int argc, char** argv )
     QCoreApplication* pApp = new QCoreApplication ( argc, argv );
 #else
 #    if defined( Q_OS_IOS )
-    bUseGUI        = true;
-    bIsClient      = true; // Client only - TODO: maybe a switch in interface to change to server?
+    bUseGUI   = true;
+    bIsClient = true; // Client only - TODO: maybe a switch in interface to change to server?
 
     // bUseMultithreading = true;
-    QApplication* pApp = new QApplication ( argc, argv );
+    QApplication* pApp       = new QApplication ( argc, argv );
 #    else
     QCoreApplication* pApp = bUseGUI ? new QApplication ( argc, argv ) : new QCoreApplication ( argc, argv );
 #    endif


### PR DESCRIPTION
**Short description of changes**

JSON-RPC is introduced with Jamulus 3.9.0 in an initial form.  As some potential problems may arise, having a build option to omit it gives the flexibility to (hopefully) avoid such problems.

CHANGELOG: Add nojsonrpc qmake CONFIG option to remove JSON-RPC support

**Context**

Avoids potential issues with JSON-RPC.  Also keeps the builds faster and smaller (`headless serveronly nojsonrpc` is 2.2M, a full build is 3.4M).

**Does this change need documentation? What needs to be documented and how?**

We should document it as part of the "How to build the server" documentation.  But not mentioning it won't directly cause problems.

**Status of this Pull Request**

My directories and servers have been built with this and run with this for ages.

**What is missing until this pull request can be merged?**

Should be good to go but @dtinth and @pgScorpio looking over it would probably be good.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
