### PR TITLE
tools/changelog-helper: Ignore foreign-milestone PRs despite mentions in git log

### DIFF
--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -38,7 +38,7 @@ find_or_add_missing_entries() {
         check_or_add_pr "$id"
     done
 
-    target_ref=origin/master
+    local target_ref=origin/master
     if git tag | grep -qxF "${target_release_tag}"; then
         # already released, use this
         target_ref="${target_release_tag}"

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -44,9 +44,15 @@ find_or_add_missing_entries() {
         target_ref="${target_release_tag}"
     fi
     echo
-    echo "Checking if all PR or references in git log since ${prev_release_tag} are included for ${target_release} based on ref ${target_ref}..."
+    echo "Checking if all PR references in git log since ${prev_release_tag} are included for ${target_release} based on ref ${target_ref}..."
+    local milestone
     for id in $(git log "${prev_release_tag}..master" | grep -oP '#\K(\d+)'); do
         gh pr view "${id}" --json title &> /dev/null || continue # Skip non-PRs
+        milestone=$(gh pr view "${id}" --json milestone --jq .milestone.title)
+        if [[ "${milestone}" =~ "Release " ]] && [[ "${milestone}" != "Release ${target_release}" ]]; then
+            echo "-> Ignoring PR #${id}, which was mentioned in 'git log ${prev_release_tag}..HEAD', but already has milestone '${milestone}'"
+            continue
+        fi
         check_or_add_pr "${id}"
     done
 


### PR DESCRIPTION
**Short description of changes**
Previously, all PRs from the relevant git log were added to the ChangeLog. This causes false positives when older PRs are intentionally mentioned again (e.g. for further fixes or documentation updates). At the same time, simply skipping them removes an additional method to avoid forgotten PRs.

Therefore, only add git-mentioned PRs if they don't have a milestone (or a matching one).

CHANGELOG: Internal: Improved Changelog PR listings to avoid mistakenly listing already released PRs.

**Context: Fixes an issue?**
Fixes: #2657

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready.

**What is missing until this pull request can be merged?**
Reviews.


## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want. Yes: `-> Ignoring PR #1873, which was mentioned in 'git log r3_8_2..HEAD', but already has milestone 'Release 3.8.1'`
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
