### PR TITLE
Autobuild: Mac: Build with Qt 6.3.1

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -132,12 +132,12 @@ jobs:
 
           - config_name:            MacOS (artifacts)
             target_os:              macos
-            # Stay on 10.15 as long as we use dmgbuild which does not work with 11's hdiutil (?):
-            building_on_os:         macos-10.15
-            base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
+            building_on_os:         macos-12
+            base_command:           QT_VERSION=6.3.1 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
             # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
             run_codeql:             false
-            xcode_version:          12.1.1
+            # Latest Xcode which runs on macos-11:
+            xcode_version:          13.4.1
 
           # Reminder: If Legacy is removed, be sure to add a dedicated job for CodeQL again.
           - config_name:            MacOS Legacy (artifacts+CodeQL)


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This will start building with the latest version of macOS on the latest available SDK.
Related to: https://github.com/jamulussoftware/jamulus/pull/2300

CHANGELOG: Build: macOS will now be built with Qt 6.3.1 for better support of modern versions of macOS. Users of macOS 10.14 or earlier must from now use the legacy build or compile from source.

**Context: Fixes an issue?**

Mostly GUI related issues, but it has the potential of fixing a few macOS related issues as mentioned in https://github.com/jamulussoftware/jamulus/pull/2300

**Does this change need documentation? What needs to be documented and how?**

Yes. We need to tell macOS users that they might need to use the legacy version. 

**Status of this Pull Request**

Final test on macOS. Will do as soon as the build is finished.
I used the latest SDK, but we can also use SDK 11 with Xcode 12 if that adds more compatibility

<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review and test. @emlynmac could you please test the artifacts?

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
