### PR TITLE
#2688 Make Windows console handling slick

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -73,6 +73,7 @@ DEFINES += APP_VERSION=\\\"$$VERSION\\\" \
 DEFINES += QT_NO_DEPRECATED_WARNINGS
 
 win32 {
+    CONFIG += console # fixes issue with app going into background
     DEFINES -= UNICODE # fixes issue with ASIO SDK (asiolist.cpp is not unicode compatible)
     DEFINES += NOMINMAX # solves a compiler error in qdatetime.h (Qt5)
     RC_FILE = windows/mainicon.rc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,14 +130,6 @@ int main ( int argc, char** argv )
     Q_UNUSED ( bCustomPortNumberGiven )
 #endif
 
-#if !defined( HEADLESS ) && defined( _WIN32 )
-    if ( AttachConsole ( ATTACH_PARENT_PROCESS ) )
-    {
-        freopen ( "CONOUT$", "w", stdout );
-        freopen ( "CONOUT$", "w", stderr );
-    }
-#endif
-
     // When adding new options, follow the same order as --help output
 
     // QT docu: argv()[0] is the program name, argv()[1] is the first
@@ -771,6 +763,14 @@ int main ( int argc, char** argv )
         }
     }
 
+#if defined( _WIN32 )
+    // If we are using the GUI, minimize any attached console
+    if ( bUseGUI && ::GetConsoleWindow() )
+    {
+        ::ShowWindow ( ::GetConsoleWindow(), SW_SHOWMINNOACTIVE );
+    }
+#endif
+
     // Application/GUI setup ---------------------------------------------------
     // Application object
 #ifdef HEADLESS
@@ -1031,6 +1031,13 @@ int main ( int argc, char** argv )
     activity.EndActivity();
 #endif
 
+#if defined( _WIN32 )
+    // If we are using the GUI, restore any attached console
+    if ( bUseGUI && ::GetConsoleWindow() )
+    {
+        ::ShowWindow ( ::GetConsoleWindow(), SW_SHOWNORMAL );
+    }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
**Short description of changes**

Rather than the Windows version of Jamulus being a GUI application that tries to attach a console when running "headless", this makes the program a command line program that cedes the console when running the GUI.  The console is only minimized.  Once Jamulus exits, the minimized console is restored.

If no console were in use, there is no effect (you don't get a console appearing and vanished or anything like that).

**EDIT** - **SEE COMMENTS BELOW** - Apparently this _does_ in fact happen.  Under investigation.

CHANGELOG: Improvement to Windows console handling

**Context: Fixes an issue?**

Fixes: #2688 

**Does this change need documentation?**

No.

**Status of this Pull Request**

Tested locally under Windows, both headless and GUI.  (No effect on other platforms.)

**What is missing until this pull request can be merged?**

Should be good to go.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency)
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above
