### PR TITLE
COMPILING.md: Add table for compile time arguments

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -200,6 +200,6 @@ During compile time some CONFIG arguments can be given to enable or disable spec
 | `jackonmac`             | Use JACK instead of CoreAudio on macOS (untested)                       |
 | `server_bundle`         | macOS only: Create an application bundle which starts server by default |
 | `opus_shared_lib`       | Use external OPUS library                                               |
-| `disable_version_check` | Disable message shown when an update is available                       |
+| `disable_version_check` | Skip checks for version updates                                         |
 | `noupcasename`          | Compile Jamulus binary as lower case "jamulus" instead of "Jamulus"     |
 | `raspijamulus`          | Use raspijamulus.sh specific enhancements for build on Raspberry Pi     |

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -200,6 +200,6 @@ During compile time some CONFIG arguments can be given to enable or disable spec
 | `jackonmac`             | Use JACK instead of CoreAudio on macOS (untested)                       |
 | `server_bundle`         | macOS only: Create an application bundle which starts server by default |
 | `opus_shared_lib`       | Use external OPUS library                                               |
-| `disable_version_check` | Disable message shown if an update is available                         |
+| `disable_version_check` | Disable message shown when an update is available                       |
 | `noupcasename`          | Compile Jamulus binary as lower case "jamulus" instead of "Jamulus"     |
-| `raspijamulus`          | Use raspijamulus.sh specific enhancements for build on Rapspberry Pi    |
+| `raspijamulus`          | Use raspijamulus.sh specific enhancements for build on Raspberry Pi     |

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -16,7 +16,7 @@ First of all, you need to get the Jamulus source code. You can either download i
 
 - For .tar.gz [use this link](https://github.com/jamulussoftware/jamulus/archive/latest.tar.gz) to download the latest release
 - For .zip [use this link](https://github.com/jamulussoftware/jamulus/archive/latest.zip)
-- If you use `git`, [set it up](https://docs.github.com/en/get-started/quickstart/set-up-git) – preferably with SSH if you want to contribute.  
+- If you use `git`, [set it up](https://docs.github.com/en/get-started/quickstart/set-up-git) – preferably with SSH if you want to contribute.
 Then run `git clone git@github.com:jamulussoftware/jamulus` in Terminal to get the bleeding edge version directly from GitHub.
 
 ## Linux
@@ -186,3 +186,20 @@ If you want to build the installer, please run the `deploy_mac.sh` script: `./ma
   `git submodule update --init`
 - Open Jamulus.pro in Qt Creator
 - Now you should be able to Build & Run for Android.
+
+## Compile time arguments
+
+During compile time some CONFIG arguments can be given to enable or disable specific features. Just run `qmake "CONFIG+=<insert build time args>"`. The following table shows available compile time options:
+
+| Option                  | Description                                                             |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `serveronly`            | Only support running as Server                                          |
+| `headless`              | Disable GUI. Supports Client and Server. Usually used with serveronly   |
+| `nojsonrpc`             | Disable JSON-RPC support                                                |
+| `jackonwindows`         | Use JACK instead of ASIO on Windows                                     |
+| `jackonmac`             | Use JACK instead of CoreAudio on macOS (untested)                       |
+| `server_bundle`         | macOS only: Create an application bundle which starts server by default |
+| `opus_shared_lib`       | Use external OPUS library                                               |
+| `disable_version_check` | Disable message shown if an update is available                         |
+| `noupcasename`          | Compile Jamulus binary as lower case "jamulus" instead of "Jamulus"     |
+| `raspijamulus`          | Use raspijamulus.sh specific enhancements for build on Rapspberry Pi    |


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Add a list for supported compile time optimistic COMPILING.md. This especially documents the nojsonrpc build option

CHANGELOG: Documentation: Document compile time options to COMPILING.md

**Context: Fixes an issue?**

No. however this removes the needs documentation label of https://github.com/jamulussoftware/jamulus/pull/2660 (I don’t think we habe anything related to the compilation of the server on the website anymore)

**Does this change need documentation? What needs to be documented and how?**
 No. It is documentation 😀
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready for review 
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review by @gilgongo or @pljones 
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
