### PR TITLE
Fixes #2709: reword status to say "directory"

### DIFF
--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -734,7 +734,7 @@ void CServerDlg::UpdateGUIDependencies()
 
     if ( pServer->IsDirectoryServer() )
     {
-        strStatus = tr ( "Now a directory server" );
+        strStatus = tr ( "Now a directory" );
     }
     else
     {

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -385,7 +385,7 @@ void CServerListManager::SetIsDirectoryServer()
 
     if ( bIsDirectoryServer )
     {
-        qInfo() << "Now a directory server";
+        qInfo() << "Now a directory";
         // Load any persistent server list (create it if it is not there)
         (void) Load();
     }

--- a/src/util.h
+++ b/src/util.h
@@ -645,7 +645,7 @@ inline QString svrRegStatusToString ( ESvrRegStatus eSvrRegStatus )
         return QCoreApplication::translate ( "CServerDlg", "Registered" );
 
     case SRS_SERVER_LIST_FULL:
-        return QCoreApplication::translate ( "CServerDlg", "Directory Server full" );
+        return QCoreApplication::translate ( "CServerDlg", "Directory server list full" );
 
     case SRS_VERSION_TOO_OLD:
         return QCoreApplication::translate ( "CServerDlg", "Your server version is too old" );


### PR DESCRIPTION
**Short description of changes**

Fixes three of the remaining references to "directory server" rather than "directory" in the code -- these are in messages, two of them requiring translation.

There is one I didn't change: `--directoryserver`.  I could change that, too.

There's a whole load of others in the code that don't get seen - those need changing, too, really, but not as part of this fix.

CHANGELOG: Fix (hopefully) all remaining references to "directory server" in displayed messages to say "directory"

**Context: Fixes an issue?**

Fixes: #2709 

**Does this change need documentation?**

Hopefully all documentation already refers to "directory" correctly.

**Status of this Pull Request**

Need to confirm scope.

**What is missing until this pull request can be merged?**

Decide when to merge it.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
