### PR TITLE
#2720 Add libQt5Multimedia5 dependency to deb control

### DIFF
--- a/distributions/debian/control
+++ b/distributions/debian/control
@@ -17,7 +17,7 @@ Architecture: any
 # Define dependencies explicitly for the best compatibility across all supported Ubuntu/Debian versions.
 # The automatism would otherwise select package names or versions which are not available on some systems,
 # especially when run in the Github Ubuntu 18.04 build environment.
-Depends: libc6 (>= 2.17), libgcc1 (>= 1:3.0), libjack-jackd2-0 (>= 1.9.5~dfsg-14) | libjack-0.116, libqt5core5a (>= 5.5.0), libqt5gui5 (>= 5.0.2) | libqt5gui5-gles (>= 5.0.2), libqt5network5 (>= 5.0.2), libqt5widgets5 (>= 5.2.0), libqt5xml5 (>= 5.0.2), libstdc++6 (>= 5.2)
+Depends: libc6 (>= 2.17), libstdc++6 (>= 5.2), libgcc1 (>= 1:3.0), libjack-jackd2-0 (>= 1.9.5~dfsg-14) | libjack-0.116, libqt5core5a (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5xml5 (>= 5.9.5), libqt5gui5 (>= 5.9.5) | libqt5gui5-gles (>= 5.9.5), libqt5widgets5 (>= 5.9.5), libqt5multimedia5 (>= 5.9.5)
 Recommends: qjackctl
 Description: Low latency Audio Server/Client
  Jamulus is for playing, rehearsing, or just jamming with your friends, your band
@@ -31,7 +31,7 @@ Description: Low latency Audio Server/Client
 
 Package: jamulus-headless
 Architecture: any
-Depends: libqt5core5a (>= 5.5.0), libqt5network5 (>= 5.0.2), libqt5xml5 (>= 5.0.2)
+Depends: libc6 (>= 2.17), libstdc++6 (>= 5.2), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5xml5 (>= 5.9.5)
 Description: Low latency Audio Server (headless)
  This package contains a Jamulus binary built for headless operation
  (without GUI library dependencies) and a jamulus-headless systemd service.


### PR DESCRIPTION
**Short description of changes**

Adds libQt5Multimedia5 dependency to distributions/debian/control.

CHANGELOG: Fix missing runtime dependendency

**Context: Fixes an issue?**

Fixes: #2720 

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

I'll run the Git build once it's ready to see if it's fixed.

**What is missing until this pull request can be merged?**

Testing...

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
