### PR TITLE
Client: Avoid losing gain changes

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -403,6 +403,7 @@ protected slots:
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
     void OnControllerInMuteMyself ( bool bMute );
     void OnClientIDReceived ( int iChanID );
+    void OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );
 
 signals:
     void ConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
PR #2535 introduced rate limiting for gain change messages. The logic required storing the previously used gain value per channel. This logic had some flaws:

1. The previously used gain value defaulted to 0, despite the server-side view of the channel being set to 1 (as the default). Therefore, gain(0) changes during a series of gain changes would be lost. The most common scenario would be the initial connection, which always triggers the rate limit and therefore the faulty logic. This also affected New Client Level = 0.
2. The previously used gain values were not reset upon changing servers. This might have caused losing arbitrary gain change messages, e.g. stored fader values.
3. The previously used gain values were not reset upon a channel disconnect. This might have caused missing fader level restores.

This PR introduces a gain level memory reset to 1 (100%) on connect as well as on channel disconnects to fix these issues.


<!-- Explain what your PR does -->

CHANGELOG: Client: Fix potential long delay in sending fader changes to the server.

**Context: Fixes an issue?**

Fixes: #2730

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready for review and testing.

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->
Needs more testing / confirmation.
@rdica Can you please try this PR?

**Helpful debug patches to confirm proper working**
```diff
diff --git a/src/client.cpp b/src/client.cpp
index ad9beb62..509dbaf7 100644
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -314,6 +314,11 @@ void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )
             // reset oldGain and newGain as this channel id is currently unused and will
             // start with a server-side gain at 1 (100%) again.
             oldGain[iId] = newGain[iId] = 1;
+            qInfo() << "OnConClientListMesReceived: resetting old/newGain[" << iId << "] as it is unused";
+        }
+        else
+        {
+            qInfo() << "OnConClientListMesReceived: not resetting old/newGain[" << iId << "] as it is still in use";
         }
     }
 }
@@ -428,6 +433,8 @@ void CClient::SetRemoteChanGain ( const int iId, const float fGain, const bool b
     // send the actual gain and reset the range of channel IDs to empty
     oldGain[iId] = newGain[iId] = fGain;
     Channel.SetRemoteChanGain ( iId, fGain );
+    qInfo() << "SetRemoteChanGain: directly sending gain changed message for iId =" << iId << ", oldGain =" << oldGain[iId]
+            << ", newGain =" << newGain[iId];
 
     StartDelayTimer();
 }
@@ -445,6 +452,13 @@ void CClient::OnTimerRemoteChanGain()
             float fGain = oldGain[iId] = newGain[iId];
             Channel.SetRemoteChanGain ( iId, fGain );
             bSent = true;
+            qInfo() << "OnTimerRemoteChainGain: sending gain changed message for iId =" << iId << ", oldGain =" << oldGain[iId]
+                    << ", newGain =" << newGain[iId];
+        }
+        else
+        {
+            qInfo() << "OnTimerRemoteChainGain: skipping unchanged gain changed message for iId =" << iId << ", oldGain =" << oldGain[iId]
+                    << ", newGain =" << newGain[iId];
         }
     }
 

```


## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want: This PR fixes the mentioned bug for me and the debug log seems ok.
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
