### PR TITLE
Translations: Add Korean to language selection

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -42,6 +42,8 @@ contains(CONFIG, "headless") {
     QT += multimedia
 }
 
+# Hint: When adding new translations, make sure to update
+# DISTFILES (above) and src/resources.qrc as well.
 LRELEASE_DIR = src/translation
 TRANSLATIONS = src/translation/translation_de_DE.ts \
     src/translation/translation_fr_FR.ts \

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -29,8 +29,11 @@
     <qresource prefix="/translations">
         <file alias="translation_sv">translation/translation_sv_SE.qm</file>
     </qresource>
-	<qresource prefix="/translations">
+    <qresource prefix="/translations">
         <file alias="translation_zh_CN">translation/translation_zh_CN.qm</file>
+    </qresource>
+    <qresource prefix="/translations">
+        <file alias="translation_ko_KR">translation/translation_ko_KR.qm</file>
     </qresource>
 
     <qresource prefix="/png/LEDs">


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

- Translations: Make ko-KR (Korean) selectable
- Jamulus.pro: Add reminder for new translations (qrc)

<!-- Explain what your PR does -->

CHANGELOG: Translation: Added Korean translation to Jamulus

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes: #2740 #2714
Related: #2685

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready.

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->
Reviews.

@bagjunggyu Could you check the release artifacts from this PR?

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
