### PR TITLE
Fix new channel with no info not being displayed.

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -334,11 +334,11 @@ float CChannel::GetPan ( const int iChanID )
 
 void CChannel::SetChanInfo ( const CChannelCoreInfo& NChanInf )
 {
-    bIsIdentified = true; // Indicate we have received channel info
-
-    // apply value (if different from previous one)
-    if ( ChannelInfo != NChanInf )
+    // apply value (if a new channel or different from previous one)
+    if ( !bIsIdentified || ChannelInfo != NChanInf )
     {
+        bIsIdentified = true; // Indicate we have received channel info
+
         ChannelInfo = NChanInf;
 
         // fire message that the channel info has changed


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

A new connection must always cause a channel update signal to be emitted,
even if the channel info for the new channel is empty.


<!-- Explain what your PR does -->

CHANGELOG: Correct new channel not being shown to others if it connects with null channel info.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2754

**Does this change need documentation? What needs to be documented and how?**

No, bug fix only

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Tested and ready for merge

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above
