### PR TITLE
CI: Pin Github action dependencies

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -80,7 +80,7 @@ jobs:
       - name:                       Remove release ${{steps.get-build-vars.outputs.RELEASE_TAG}}, if existing
         if:                         steps.get-build-vars.outputs.PUBLISH_TO_RELEASE == 'true'
         continue-on-error:          true
-        uses:                       dev-drprasad/delete-tag-and-release@v0.1.2
+        uses:                       dev-drprasad/delete-tag-and-release@085c6969f18bad0de1b9f3fe6692a3cd01f64fe5
         with:
           delete_release:           true
           tag_name:                 ${{ steps.get-build-vars.outputs.RELEASE_TAG }}
@@ -187,7 +187,7 @@ jobs:
     steps:
       - name:                       Select Xcode version for Mac
         if:                         matrix.config.target_os == 'macos' || matrix.config.target_os == 'ios'
-        uses:                       maxim-lobanov/setup-xcode@v1
+        uses:                       maxim-lobanov/setup-xcode@4aa4176a819ae7c019451acfda0bba67bffc6704
         with:
           xcode-version:            ${{ matrix.config.xcode_version }}
 
@@ -291,7 +291,7 @@ jobs:
                                     steps.build.outputs.macos_signed == 'true' &&
                                     needs.create_release.outputs.publish_to_release == 'true'
         id:                         staple-macOS-app
-        uses:                       devbotsxyz/xcode-staple@v1
+        uses:                       devbotsxyz/xcode-staple@ae68b22ca35d15864b7f7923e1a166533b2944bf
         with:
           product-path:             deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
 


### PR DESCRIPTION
**Short description of changes**

External dependencies should only be updated after manual review for security reasons (#1737). In addition, they need to be stable during the release process.

- dev-drprasad/delete-tag-and-release is updated from v0.1.2 to v0.2.0   (via hash); diff has been reviewed
- devbotsxyz/xcode-staple is unchanged at the latest v1 commit
- maxim-lobanov/setup-xcode is unchanged at the latest v1 commit

github/* and action/* dependencies are kept as-is as they are considered trusted due to their official status and the inevitable dependency and trust on Github.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Related: #1737

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

This specific change does not need documentation.
The general need to pin Action dependencies should be documented. This is being tracked in #1737.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**

Reviews.

cc @emlynmac as two signing-related deps are affected.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

Test for completeness after this PR (no tag-based pinning for non-official deps anymore):
```
$ grep uses.*@ .github/workflows/* | grep -vP ':.*(actions|github)/'
.github/workflows/autobuild.yml:        uses:                       dev-drprasad/delete-tag-and-release@085c6969f18bad0de1b9f3fe6692a3cd01f64fe5
.github/workflows/autobuild.yml:        uses:                       maxim-lobanov/setup-xcode@4aa4176a819ae7c019451acfda0bba67bffc6704
.github/workflows/autobuild.yml:        uses:                       devbotsxyz/xcode-notarize@d7219e1c390b47db8bab0f6b4fc1e3b7943e4b3b
.github/workflows/autobuild.yml:        uses:                       devbotsxyz/xcode-staple@ae68b22ca35d15864b7f7923e1a166533b2944bf
.github/workflows/coding-style-check.yml:      uses: DoozyX/clang-format-lint-action@2a28e3a8d9553f244243f7e1ff94f6685dff87be
```
