### PR TITLE
Build: Improve Windows dependency download resilience

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -213,8 +213,8 @@ jobs:
           path: |
             C:\Qt
             C:\ChocoCache
-            ~\windows\NSIS
-            ~\libs\ASIOSDK2
+            ${{ github.workspace }}\windows\NSIS
+            ${{ github.workspace }}\libs\ASIOSDK2
           key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/windows.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Android dependencies

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -109,7 +109,11 @@ Function Install-Dependency
         [string] $Destination
     )
 
-    if (Test-Path -Path "$WindowsPath\$Destination") { return }
+    if (Test-Path -Path "$WindowsPath\$Destination")
+    {
+        echo "Using ${WindowsPath}\${Destination} from previous run (actions/cache)"
+        return
+    }
 
     $TempFileName = [System.IO.Path]::GetTempFileName() + ".zip"
     $TempDir = [System.IO.Path]::GetTempPath()

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -55,10 +55,9 @@ Function Clean-Build-Environment
 
 # For sourceforge links we need to get the correct mirror (especially NISIS) Thanks: https://www.powershellmagazine.com/2013/01/29/pstip-retrieve-a-redirected-url/
 Function Get-RedirectedUrl {
-
     param(
         [Parameter(Mandatory=$true)]
-        [String]$URL
+        [string] $url
     )
 
     foreach ($attempt in 1, 2, 3) {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- CI: Fix caching of NSIS & ASIO installations
  Previously, we were caching the wrong directories for NSIS/ASIO. Therefore, the cache never hit and wasn't effective against download problems.

- Build: Windows: Log when re-using NSIS/ASIO directories
  This makes it easier to spot problems in the caching logic.

- Build: Retry SourceForge (NSIS) downloads for improved build stability
  Previously, a single download failure made the whole build fail. Now we try three times in a row after a slight delay.

- Build: windows/deploy_windows: Make spacing/case more consistent
  ... while we are at it.

CHANGELOG: SKIP

**Context: Fixes an issue?**
Fixes: #2775

**Does this change need documentation? What needs to be documented and how?**
No.

**Status of this Pull Request**
Ready.

**What is missing until this pull request can be merged?**
Reviews.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

Test results:
- [x] Cache size increased from [179MB (master)](https://github.com/jamulussoftware/jamulus/runs/7755249088?check_suite_focus=true#step:5:12) to [186MB (a stripped down version of this PR)](https://github.com/hoffie/jamulus/runs/7808199877?check_suite_focus=true#step:5:12)
- [x] The cache hit is [logged as expected now](https://github.com/hoffie/jamulus/runs/7808199877?check_suite_focus=true#step:9:22)