### PR TITLE
Scripts: Set -o pipefail

### DIFF
--- a/ios/deploy_ios.sh
+++ b/ios/deploy_ios.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eu -o pipefail
 
 ## Builds an ipa file for iOS. Should be run from the repo-root
 

--- a/linux/deploy_deb.sh
+++ b/linux/deploy_deb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eu -o pipefail
 
 # Create deb files
 

--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eu -o pipefail
 
 root_path=$(pwd)
 project_path="${root_path}/Jamulus.pro"

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Requirements: git, Github CLI (gh), jq
-set -eu
+set -eu -o pipefail
 
 echo "This tool checks the ChangeLog file and compares its entries for the top-most"
 echo "release against the associated Github milestone and the git log."

--- a/tools/check-wininstaller-translations.sh
+++ b/tools/check-wininstaller-translations.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eu -o pipefail
 
 BASE_DIR=src/translation/wininstaller/
 BASE_LANG=en

--- a/tools/create-translation-issues.sh
+++ b/tools/create-translation-issues.sh
@@ -16,7 +16,7 @@
 # Example usage for web translations:
 #  ../jamulus/tools/create-translation-issues.sh 3.8.0 2021-05-15 web 'Note: The term "Central server" has been replaced with "Directory server"'
 
-set -eu
+set -eu -o pipefail
 
 if [[ -z ${1:-} ]] || [[ -z ${2:-} ]] || [[ -z ${3:-} ]]; then
     echo "Syntax: $0 RELEASE DEADLINE app|web [EXTRA_TEXT]"

--- a/tools/update-copyright-notices.sh
+++ b/tools/update-copyright-notices.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eu -o pipefail
 
 YEAR=$(date +%Y)
 echo "Updating global copyright strings..."


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
This is supposed to avoid silent failures when using pipes.
Example: #2793 (https://github.com/hoffie/jamulus/runs/7930874876?check_suite_focus=true#step:9:42)

<!-- Explain what your PR does -->

CHANGELOG: Internal: Hardened build scripts and tooling against silent failures.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
- [x] CI green
- [x] tools/ needs explicit review/testing for pipe usage.
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above