### PR TITLE
Github: Fix bump-dependencies runs on existing PRs & adjust title

### DIFF
--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -137,7 +137,14 @@ jobs:
           fi
           if [[ $existing_pr ]]; then
             existing_title="$(gh pr view "${existing_pr}" --json title --jq .title)"
-            gh pr edit "${existing_pr}" --title "${pr_title}" --body "${body}"
+            # Use Github's API directly instead of using `gh edit`.
+            # The latter internally queries all fields of the PR which leads to
+            # a permission error as the workflow does not have access to
+            # organization projects:
+            gh api --silent -H "Accept: application/vnd.github+json" --method PATCH \
+              "/repos/${GITHUB_REPOSITORY}/pulls/${existing_pr}" \
+              -f title="${pr_title}" \
+              -f body="${body}"
             if [[ "${existing_title}" != "${pr_title}" ]]; then
               # If the title changed, this implies that we are updating the PR for a different version
               # (and not just rebasing it). Therefore, leave a comment to make that transparent:

--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -114,7 +114,7 @@ jobs:
           # Therefore, use perl instead:
           perl -pe 's/${{ matrix.components.local_version_regex }}/${1}'"${upstream_version}"'${3}/gi' -i "${files[@]}"
           git add .
-          title="Build: Update ${{ matrix.components.name }} to ${upstream_version}"
+          title="Build: Bump ${{ matrix.components.name }} from ${local_version} to ${upstream_version}"
           pr_title="${title} (Automated PR)"
           existing_pr="$(gh pr list --head "${pr_branch}" --json number --jq '.[].number')"
           git commit -m "${title}"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

The bump-dependencies workflow got permission errors from the Github API when trying to edit existing PRs which had already been added to an organization project.
The reason for this is that the GITHUB_TOKEN of the run is scoped to the repo, but `gh edit` tries to fetch all fields of a PR which includes the inaccessible organization project field. Therefore, use `gh api` instead which can be used in a more fine-grained
way.

This PR also addresses @ann0see's request to mimic the dependabot commit message style.

<!-- Explain what your PR does -->

Group with:
CHANGELOG: Internal: Enabled automated dependency updates via dependabot and custom automation

**Context: Fixes an issue?**

Fixes: https://github.com/jamulussoftware/jamulus/pull/2777#issuecomment-1222793504
Fixes: https://github.com/jamulussoftware/jamulus/pull/2787#issuecomment-1222783064

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready.

**What is missing until this pull request can be merged?**
Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
