### PR TITLE
Build: Debian/Ubuntu: Avoid incorrect -dirty version suffix

### DIFF
--- a/distributions/debian/rules
+++ b/distributions/debian/rules
@@ -14,6 +14,14 @@ endif
 %:
 	dh $@
 
+override_dh_update_autotools_config:
+	# dh_update_autotools_config replaces libs/opus/config.{sub,guess}.
+	# This is unnecessary as we don't build opus via autotools at all
+	# (we use qmake). In addition, this would cause our -dev version generation
+	# logic to mark Debian builds as -dirty by default.
+	# Therefore, disable this behavior:
+	:
+
 override_dh_auto_configure:
 	mkdir -p build-gui && cd build-gui && $(QMAKE) "CONFIG+=noupcasename" PREFIX=/usr ../Jamulus.pro
 	mkdir -p build-nox && cd build-nox && $(QMAKE) "CONFIG+=headless serveronly" TARGET=jamulus-headless PREFIX=/usr ../Jamulus.pro


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
The debian build scripts will update config.{guess,sub} and will therefore cause the Jamulus.pro dev version detection to mark the build as dirty. We circumvent that by overriding the responsible debian helper call.

<!-- Explain what your PR does -->

CHANGELOG: Debian/Ubuntu: Fixed displayed version for non-release builds to remove incorrect -dirty suffixes.

**Context: Fixes an issue?**

Fixes: #2800

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No.
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready.
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
