### PR TITLE
Build: Mac: Add universal binary and -dev build ad-hoc signing support

### DIFF
--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -6,7 +6,7 @@ QT_DIR=/usr/local/opt/qt
 # updates. Verify .github/workflows/bump-dependencies.yaml when changing those manually:
 AQTINSTALL_VERSION=2.1.0
 
-TARGET_ARCH="${TARGET_ARCH:-}"
+TARGET_ARCHS="${TARGET_ARCHS:-}"
 
 if [[ ! ${QT_VERSION:-} =~ [0-9]+\.[0-9]+\..* ]]; then
     echo "Environment variable QT_VERSION must be set to a valid Qt version"
@@ -71,7 +71,7 @@ build_app_as_dmg_installer() {
     if prepare_signing; then
         BUILD_ARGS=("-s" "${MACOS_CERTIFICATE_ID}")
     fi
-    TARGET_ARCH="${TARGET_ARCH}" ./mac/deploy_mac.sh "${BUILD_ARGS[@]}"
+    TARGET_ARCHS="${TARGET_ARCHS}" ./mac/deploy_mac.sh "${BUILD_ARGS[@]}"
 }
 
 pass_artifact_to_job() {

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -212,20 +212,12 @@ jobs:
           - config_name:            MacOS (artifacts)
             target_os:              macos
             building_on_os:         macos-12
-            base_command:           QT_VERSION=6.3.1 SIGN_IF_POSSIBLE=1 ./.github/autobuild/mac.sh
+            base_command:           QT_VERSION=6.3.1 SIGN_IF_POSSIBLE=1 TARGET_ARCHS="x86_64 arm64" ./.github/autobuild/mac.sh
             # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
             run_codeql:             false
             # Latest Xcode which runs on macos-11:
             xcode_version:          13.4.1
             is_main_build_target:   true
-
-          - config_name:            MacOS arm64 (artifacts)
-            target_os:              macos
-            building_on_os:         macos-12
-            base_command:           QT_VERSION=6.3.1 SIGN_IF_POSSIBLE=1 TARGET_ARCH=arm64 ARTIFACT_SUFFIX=_arm64 ./.github/autobuild/mac.sh
-            # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
-            run_codeql:             false
-            xcode_version:          13.4.1
 
           # Reminder: If Legacy is removed, be sure to add a dedicated job for CodeQL again.
           - config_name:            MacOS Legacy (artifacts+CodeQL)

--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -36,19 +36,37 @@ cleanup() {
 
 build_app() {
     local client_or_server="${1}"
-
-    # Build Jamulus
-    declare -a BUILD_ARGS=("_UNUSED_DUMMY=''")  # old bash fails otherwise
-    if [[ "${TARGET_ARCH:-}" ]]; then
-        BUILD_ARGS=("QMAKE_APPLE_DEVICE_ARCHS=${TARGET_ARCH}" "QT_ARCH=${TARGET_ARCH}")
-    fi
-    qmake "${project_path}" -o "${build_path}/Makefile" "CONFIG+=release" "${BUILD_ARGS[@]}" "${@:2}"
-    local target_name
-    target_name=$(sed -nE 's/^QMAKE_TARGET *= *(.*)$/\1/p' "${build_path}/Makefile")
     local job_count
     job_count=$(sysctl -n hw.ncpu)
 
-    make -f "${build_path}/Makefile" -C "${build_path}" -j "${job_count}"
+    # Build Jamulus for all requested architectures, defaulting to x86_64 if none provided:
+    local target_name
+    local target_arch
+    local target_archs_array
+    IFS=' ' read -ra target_archs_array <<< "${TARGET_ARCHS:-x86_64}"
+    for target_arch in "${target_archs_array[@]}"; do
+        if [[ "${target_arch}" != "${target_archs_array[0]}" ]]; then
+            # This is the second (or a later) first pass of a multi-architecture build.
+            # We need to prune all leftovers from the previous pass here in order to force re-compilation now.
+            make -f "${build_path}/Makefile" -C "${build_path}" distclean
+        fi
+        qmake "${project_path}" -o "${build_path}/Makefile" \
+            "CONFIG+=release" \
+            "QMAKE_APPLE_DEVICE_ARCHS=${target_arch}" "QT_ARCH=${target_arch}" \
+            "${@:2}"
+        make -f "${build_path}/Makefile" -C "${build_path}" -j "${job_count}"
+        target_name=$(sed -nE 's/^QMAKE_TARGET *= *(.*)$/\1/p' "${build_path}/Makefile")
+        if [[ ${#target_archs_array[@]} -gt 1 ]]; then
+            # When building for multiple architectures, move the binary to a safe place to avoid overwriting by the other passes.
+            mv "${build_path}/${target_name}.app/Contents/MacOS/${target_name}" "${build_path}/${target_name}.app/Contents/MacOS/${target_name}.arch_${target_arch}"
+        fi
+    done
+    if [[ ${#target_archs_array[@]} -gt 1 ]]; then
+        echo "Building universal binary from: " "${build_path}/${target_name}.app/Contents/MacOS/${target_name}.arch_"*
+        lipo -create -output "${build_path}/${target_name}.app/Contents/MacOS/${target_name}" "${build_path}/${target_name}.app/Contents/MacOS/${target_name}.arch_"*
+        rm -f "${build_path}/${target_name}.app/Contents/MacOS/${target_name}.arch_"*
+        file "${build_path}/${target_name}.app/Contents/MacOS/${target_name}"
+    fi
 
     # Add Qt deployment dependencies
     if [[ -z "$cert_name" ]]; then

--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -70,7 +70,7 @@ build_app() {
 
     # Add Qt deployment dependencies
     if [[ -z "$cert_name" ]]; then
-        macdeployqt "${build_path}/${target_name}.app" -verbose=2 -always-overwrite
+        macdeployqt "${build_path}/${target_name}.app" -verbose=2 -always-overwrite -codesign="-"
     else
         macdeployqt "${build_path}/${target_name}.app" -verbose=2 -always-overwrite -hardened-runtime -timestamp -appstore-compliant -sign-for-notarization="${cert_name}"
     fi


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- Build: Mac: Add universal binary support

  This PR combines the x86_64 and arm64e CI jobs into a single job in order to have both binary results at hand. It then uses `lipo` to combine those two binaries in a single universal binary which runs on both architectures.
  This increases user-friendliness as users no longer have to worry about downloading the proper build for their architecture.

- Build: Mac: Use ad-hoc signing when no developer certificate is available

  Previously, only (pre-)release builds were signed. This signing and notarization was only possible with a proper developer certificate. As the Jamulus project currently does not have one and has to rely on other developers doing the signing, we only go this route for (pre-)releases due to the manual effort required.
  With Mac M1 support, having a valid signature becomes more important as unsigned binaries can only be started after turning several knobs.

  This PR adds very basic ad-hoc signing which does not require any Apple account/certificate, but improves user experience for M1 users.

<!-- Explain what your PR does -->

CHANGELOG: Build: Mac: Combined Intel & M1 builds into a single Universal binary and improved M1 -dev build user-friendliness by introducing ad-hoc signing support

**Context: Fixes an issue?**
Fixes: #2790
Fixes: #2791

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
- [x] Release announcement? Added reminder to #2813

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready for review and testing.

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
- [x] M1/arm64 tests, see https://github.com/jamulussoftware/jamulus/issues/2790#issuecomment-1225618827
- [x] x86_64 tests (@ann0see?)

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
