### PR TITLE
Server: Fix --serverinfo country code misinterpretation on Qt6

### DIFF
--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -205,9 +205,15 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
         // [this server country as QLocale ID]
         bool      ok;
         const int iCountry = slServInfoSeparateParams[2].toInt ( &ok );
-        if ( ok && iCountry >= 0 && iCountry <= QLocale::LastCountry )
+        if ( ok && iCountry >= 0 && CLocale::IsCountryCodeSupported ( iCountry ) )
         {
-            ThisServerListEntry.eCountry = static_cast<QLocale::Country> ( iCountry );
+            // Convert from externally-supplied format ("wire format", Qt5 codes) to
+            // native format. On Qt5 builds, this is a noop, on Qt6 builds, a conversion
+            // takes place.
+            // We try to do such conversions at the outer-most interface which is capable of doing it.
+            // Although the value comes from src/main -> src/server, this very place is
+            // the first where we have access to the parsed country code:
+            ThisServerListEntry.eCountry = CLocale::WireFormatCountryCodeToQtCountry ( iCountry );
         }
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1423,11 +1423,16 @@ bool CLocale::IsCountryCodeSupported ( unsigned short iCountryCode )
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
     // On newer Qt versions there might be codes which do not have a Qt5 equivalent.
     // We have no way to support those sanely right now.
+    // Before we can check that via an array lookup, we have to ensure that
+    // we are within the boundaries of that array:
+    if ( iCountryCode >= qt6CountryToWireFormatLen )
+    {
+        return false;
+    }
     return qt6CountryToWireFormat[iCountryCode] != -1;
 #else
     // All Qt5 codes are supported.
-    Q_UNUSED ( iCountryCode );
-    return true;
+    return iCountryCode <= QLocale::LastCountry;
 #endif
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -853,6 +853,7 @@ public:
         195, 196, 114, 254, 197, 198, 201, 202, 203, 205, 206, 207, 208, 209, 210, 211, 62,  212, 213, 214, 215, 253, 216, 217, 218, 219, 220,
         221, 222, 223, 224, 226, 225, 234, 227, 228, 229, 230, 231, 232, 235, 236, 260, 237, 239, 240,
     };
+    constexpr int const static qt6CountryToWireFormatLen = sizeof ( qt6CountryToWireFormat ) / sizeof ( qt6CountryToWireFormat[0] );
 #endif
 };
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- Util: Make CLocale::IsCountryCodeSupported more robust

  On Qt6, we previously relied on the caller to only supply country codes within bounds. With this change we properly check before risking an uninitialized array access.

  On Qt5, we did not do any checks at all. Now we ensure that we what is provided is a valid Qt5 country code.

- Server: Fix --serverinfo country code misinterpretation on Qt6

  Previously, country codes in --serverinfo were interpreted natively.
  This worked for Qt5, but caused unintended changes on Qt6 builds as the codes differ. Not doing a conversion for --serverinfo was an oversight from the initial Qt6 compatibility work, which is now fixed with this change.

<!-- Explain what your PR does -->

CHANGELOG: Server: Fixed --serverinfo country code misinterpretation introduced in Jamulus 3.9.0 on Qt6-based builds such as Mac

**Context: Fixes an issue?**

Related: #2299
Fixes: #2809

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
- [ ] Release announcement

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready. Tested both on Qt5 and Qt6. Qt6 builds with this change behave like Qt5 builds again.

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
