### PR TITLE
Enable macOS Darkmode support for non legacy builds

### DIFF
--- a/mac/Info-make-legacy.plist
+++ b/mac/Info-make-legacy.plist
@@ -34,7 +34,7 @@
         <string>NSApplication</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>Jamulus needs access to the microphone to record and stream your music to other musicians</string>
-        <!-- Temporarily opt out of Dark Mode as Qt 5.9 does not support it well, see https://bugreports.qt.io/browse/QTBUG-68891 -->
+        <!-- Opt out of Dark Mode as Qt 5.9 does not support it well, see https://bugreports.qt.io/browse/QTBUG-68891 -->
         <key>NSRequiresAquaSystemAppearance</key>
         <string>true</string>
     </dict>

--- a/mac/Info-make.plist
+++ b/mac/Info-make.plist
@@ -34,8 +34,5 @@
         <string>NSApplication</string>
         <key>NSMicrophoneUsageDescription</key>
         <string>Jamulus needs access to the microphone to record and stream your music to other musicians</string>
-        <!-- Temporarily opt out of Dark Mode as Qt 5.9 does not support it well, see https://bugreports.qt.io/browse/QTBUG-68891 -->
-        <key>NSRequiresAquaSystemAppearance</key>
-        <string>true</string>
     </dict>
 </plist>

--- a/mac/Info-xcode.plist
+++ b/mac/Info-xcode.plist
@@ -34,7 +34,5 @@
 	<string>NSApplication</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Jamulus needs access to the microphone to record and stream your music to other musicians</string>
-	<key>NSRequiresAquaSystemAppearance</key>
-	<string>true</string>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
The .plist files contained an opt out for macOS dark mode. Since we compile with Qt 5.15 or later on non legacy builds, there is no need to disable Dark mode support.

![grafik](https://user-images.githubusercontent.com/20726856/188223955-bcecee0d-b7c5-453d-ae06-d7147900d4f7.png)

<!-- Explain what your PR does -->

CHANGELOG: Mac: Enable dark-mode support on non legacy builds

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

No. Maybe screenshots.

**Status of this Pull Request**

Ready for review
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Nothing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
