### PR TITLE
Server: Add --serverinfo ISO country code support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1075,7 +1075,7 @@ QString UsageArguments ( char** argv )
            "  -L, --licence         show an agreement window before users can connect\n"
            "  -m, --htmlstatus      enable HTML status file, set file name\n"
            "  -o, --serverinfo      registration info for this Server.  Format:\n"
-           "                        [name];[city];[country as Qt5 QLocale ID]\n"
+           "                        [name];[city];[country as two-letter ISO country code or Qt5 QLocale ID]\n"
            "      --serverpublicip  public IP address for this Server.  Needed when\n"
            "                        registering with a server list hosted\n"
            "                        behind the same NAT\n"

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -205,15 +205,26 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
         // [this server country as QLocale ID]
         bool      ok;
         const int iCountry = slServInfoSeparateParams[2].toInt ( &ok );
-        if ( ok && iCountry >= 0 && CLocale::IsCountryCodeSupported ( iCountry ) )
+        if ( ok )
         {
-            // Convert from externally-supplied format ("wire format", Qt5 codes) to
-            // native format. On Qt5 builds, this is a noop, on Qt6 builds, a conversion
-            // takes place.
-            // We try to do such conversions at the outer-most interface which is capable of doing it.
-            // Although the value comes from src/main -> src/server, this very place is
-            // the first where we have access to the parsed country code:
-            ThisServerListEntry.eCountry = CLocale::WireFormatCountryCodeToQtCountry ( iCountry );
+            if ( iCountry >= 0 && CLocale::IsCountryCodeSupported ( iCountry ) )
+            {
+                // Convert from externally-supplied format ("wire format", Qt5 codes) to
+                // native format. On Qt5 builds, this is a noop, on Qt6 builds, a conversion
+                // takes place.
+                // We try to do such conversions at the outer-most interface which is capable of doing it.
+                // Although the value comes from src/main -> src/server, this very place is
+                // the first where we have access to the parsed country code:
+                ThisServerListEntry.eCountry = CLocale::WireFormatCountryCodeToQtCountry ( iCountry );
+            }
+        }
+        else
+        {
+            QLocale::Country qlCountry = CLocale::GetCountryCodeByTwoLetterCode ( slServInfoSeparateParams[2] );
+            if ( qlCountry != QLocale::AnyCountry )
+            {
+                ThisServerListEntry.eCountry = qlCountry;
+            }
         }
     }
 

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -226,6 +226,15 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
                 ThisServerListEntry.eCountry = qlCountry;
             }
         }
+        qInfo() << qUtf8Printable ( QString ( "Using server info: name = \"%1\", city = \"%2\", country/region = \"%3\" (%4)" )
+                                        .arg ( ThisServerListEntry.strName )
+                                        .arg ( ThisServerListEntry.strCity )
+                                        .arg ( slServInfoSeparateParams[2] )
+                                        .arg ( QLocale::countryToString ( ThisServerListEntry.eCountry ) ) );
+    }
+    else
+    {
+        qWarning() << "Ignoring invalid serverinfo, please verify the parameter syntax.";
     }
 
     // per definition, the very first entry is this server and this entry will

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1436,6 +1436,31 @@ bool CLocale::IsCountryCodeSupported ( unsigned short iCountryCode )
 #endif
 }
 
+QLocale::Country CLocale::GetCountryCodeByTwoLetterCode ( QString sTwoLetterCode )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 )
+    return QLocale::codeToTerritory ( sTwoLetterCode );
+#else
+    QList<QLocale> vLocaleList = QLocale::matchingLocales ( QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry );
+    QStringList    vstrLocParts;
+
+    // Qt < 6.2 does not support lookups from two-letter iso codes to
+    // QLocale::Country. Therefore, we have to loop over all supported
+    // locales and perform the matching ourselves.
+    // In the future, QLocale::codeToTerritory can be used.
+    foreach ( const QLocale qLocale, vLocaleList )
+    {
+        QStringList vstrLocParts = qLocale.name().split ( "_" );
+
+        if ( vstrLocParts.size() >= 2 && vstrLocParts.at ( 1 ).toLower() == sTwoLetterCode )
+        {
+            return qLocale.country();
+        }
+    }
+    return QLocale::AnyCountry;
+#endif
+}
+
 QString CLocale::GetCountryFlagIconsResourceReference ( const QLocale::Country eCountry /* Qt-native value */ )
 {
     QString strReturn = "";

--- a/src/util.h
+++ b/src/util.h
@@ -827,6 +827,7 @@ public:
     static QLocale::Country        WireFormatCountryCodeToQtCountry ( unsigned short iCountryCode );
     static unsigned short          QtCountryToWireFormatCountryCode ( const QLocale::Country eCountry );
     static bool                    IsCountryCodeSupported ( unsigned short iCountryCode );
+    static QLocale::Country        GetCountryCodeByTwoLetterCode ( QString sTwoLetterCode );
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
     // ./tools/qt5-to-qt6-country-code-table.py generates these lists:
     constexpr int const static wireFormatToQt6Table[] = {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
With this change, --serverinfo gains support two-letter ISO country codes    such as "de", "gb", "nl", "fr". Numeric Qt5-style codes keep working as expected.

To simplify user-side debugging, the `--serverinfo` parsing now contains logging for the final values (or a warning in case of parsing problems).

<!-- Explain what your PR does -->

CHANGELOG: Server: Added support for ISO country codes (de, gb, nl, ...) in --serverinfo.

**Context: Fixes an issue?**
Fixes: #2362
Related: https://github.com/jamulussoftware/jamulus/pull/2829#discussion_r965316253

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

As this is a (tiny) new feature, docs would be useful, but not mandatory. This is not a breaking change. Delaying the docs update would be no problem.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
- [x] #2829 must be merged first

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
