### PR TITLE
Autobuild: Add Linux .deb aarch64 (Raspberry) 64bit builds

### DIFF
--- a/.github/autobuild/README.md
+++ b/.github/autobuild/README.md
@@ -4,4 +4,7 @@ The scripts in this folder are used by the Github autobuild actions in .github/w
 They are responsible for setting up the Github environment, building the binaries and passing the resulting artifacts back to the workflow.
 
 The scripts may work outside of Github, but haven't been designed or tested for that use case.
+Some of the scripts modify global system settings, install software or create files in directories which are usually managed by package managers.
+In short: They should probably only used in throw-away environments.
+
 See the various platform-specific build scripts in their own folders for standalone builds (e.g. windows/deploy_windows.ps1).

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -40,7 +40,9 @@ setup_cross_compilation_apt_sources() {
         return
     fi
     sudo dpkg --add-architecture "${TARGET_ARCH}"
+    # Duplicate the original Ubuntu sources and modify them to refer to the TARGET_ARCH:
     sed -rne "s|^deb.*/ ([^ -]+(-updates)?) main.*|deb [arch=${TARGET_ARCH}] http://ports.ubuntu.com/ubuntu-ports \1 main universe multiverse restricted|p" /etc/apt/sources.list | sudo dd of=/etc/apt/sources.list.d/"${TARGET_ARCH}".list
+    # Now take the original Ubuntu sources and limit those to the build host (i.e. non-TARGET_ARCH) architectures:
     sudo sed -re 's/^deb /deb [arch=amd64,i386] /' -i /etc/apt/sources.list
 }
 

--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -14,6 +14,9 @@ case "${TARGET_ARCH}" in
     armhf)
         ABI_NAME="arm-linux-gnueabihf"
         ;;
+    arm64)
+        ABI_NAME="aarch64-linux-gnu"
+        ;;
     *)
         echo "Unsupported TARGET_ARCH ${TARGET_ARCH}"
         exit 1
@@ -50,10 +53,10 @@ setup_cross_compiler() {
     sudo update-alternatives --install "/usr/bin/${ABI_NAME}-g++" g++ "/usr/bin/${ABI_NAME}-g++-${GCC_VERSION}" 10
     sudo update-alternatives --install "/usr/bin/${ABI_NAME}-gcc" gcc "/usr/bin/${ABI_NAME}-gcc-${GCC_VERSION}" 10
 
-    if [[ "${TARGET_ARCH}" == armhf ]]; then
-        # Ubuntu's Qt version only ships a profile for gnueabi, but not for gnueabihf. Therefore, build a custom one:
+    # Ubuntu's Qt version only ships a profile for gnueabi, but not for gnueabihf or aarch64. Therefore, build a custom one:
+    if [[ $ABI_NAME ]]; then
         sudo cp -R "/usr/lib/${ABI_NAME}/qt5/mkspecs/linux-arm-gnueabi-g++/" "/usr/lib/${ABI_NAME}/qt5/mkspecs/${ABI_NAME}-g++/"
-        sudo sed -re 's/-gnueabi/-gnueabihf/' -i "/usr/lib/${ABI_NAME}/qt5/mkspecs/${ABI_NAME}-g++/qmake.conf"
+        sudo sed -re "s/arm-linux-gnueabi/${ABI_NAME}/" -i "/usr/lib/${ABI_NAME}/qt5/mkspecs/${ABI_NAME}-g++/qmake.conf"
     fi
 }
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -209,6 +209,13 @@ jobs:
             base_command:           TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh
             run_codeql:             false
 
+          - config_name:            Linux .deb arm64 (artifacts)
+            target_os:              linux
+            building_on_os:         ubuntu-22.04
+            building_container:     ubuntu:18.04
+            base_command:           TARGET_ARCH=arm64 ./.github/autobuild/linux_deb.sh
+            run_codeql:             false
+
           - config_name:            MacOS (artifacts)
             target_os:              macos
             building_on_os:         macos-12


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This PR adds support for the Debian arm64 (aarch64) architecture. The artifacts can be used on 64bit Raspberry setups, for example.

I'm adding this to 3.10.0 right now, but I'm not opposed to merging it to 3.9.1 as well.

<!-- Explain what your PR does -->

CHANGELOG: Autobuild: Added Linux .deb aarch64 (Raspberry) 64bit builds

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes #2887

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
- [x] Docs
- [ ] Release announcement

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready & tested (see #2887).

**What is missing until this pull request can be merged?**
/

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
