### PR TITLE
JSON-RPC: Add option to specify bind address for server

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -17,6 +17,9 @@ It can be generated like this:
 $ openssl rand -base64 10 > /file/with/a/secret.txt
 ```
 
+The JSON-RPC server defaults to listening on the local loopback network interface (127.0.0.1).  This can be optionally changed by using the `--jsonrpcbindip <ip address>` command line option. **IPv4 only. IPv6 support has not been tested.**
+
+
 ## Wire protocol
 
 The JSON-RPC server is based on the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) protocol, using [streaming newline-delimited JSON over TCP](https://clue.engineering/2018/introducing-reactphp-ndjson) as the transport. There are three main types of messages being exchanged:

--- a/src/global.h
+++ b/src/global.h
@@ -284,8 +284,8 @@ LED bar:      lbr
 // minimum length of JSON-RPC secret string (main.cpp)
 #define JSON_RPC_MINIMUM_SECRET_LENGTH 16
 
-// JSON-RPC listen address
-#define JSON_RPC_LISTEN_ADDRESS "127.0.0.1"
+// JSON-RPC listen address (Default)
+#define DEFAULT_JSON_RPC_LISTEN_ADDRESS "127.0.0.1"
 
 #define _MAXSHORT     32767
 #define _MINSHORT     ( -32768 )

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -26,8 +26,9 @@
 #include "global.h"
 #include "rpcserver.h"
 
-CRpcServer::CRpcServer ( QObject* parent, int iPort, QString strSecret ) :
+CRpcServer::CRpcServer ( QObject* parent, QString strBindIP, int iPort, QString strSecret ) :
     QObject ( parent ),
+    strBindIP ( strBindIP ),
     iPort ( iPort ),
     strSecret ( strSecret ),
     pTransportServer ( new QTcpServer ( this ) )
@@ -60,7 +61,7 @@ bool CRpcServer::Start()
     {
         return false;
     }
-    if ( pTransportServer->listen ( QHostAddress ( JSON_RPC_LISTEN_ADDRESS ), iPort ) )
+    if ( pTransportServer->listen ( QHostAddress ( strBindIP ), iPort ) )
     {
         qInfo() << qUtf8Printable ( QString ( "- JSON-RPC: Server started on %1:%2" )
                                         .arg ( pTransportServer->serverAddress().toString() )

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -44,7 +44,7 @@ class CRpcServer : public QObject
     Q_OBJECT
 
 public:
-    CRpcServer ( QObject* parent, int iPort, QString secret );
+    CRpcServer ( QObject* parent, QString strBindIP, int iPort, QString secret );
     virtual ~CRpcServer();
 
     bool Start();
@@ -64,6 +64,7 @@ public:
     static const int iErrUnauthenticated      = 401;
 
 private:
+    QString     strBindIP;
     int         iPort;
     QString     strSecret;
     QTcpServer* pTransportServer;

--- a/tools/generate_json_rpc_docs.py
+++ b/tools/generate_json_rpc_docs.py
@@ -204,6 +204,9 @@ It can be generated like this:
 $ openssl rand -base64 10 > /file/with/a/secret.txt
 ```
 
+The JSON-RPC server defaults to listening on the local loopback network interface (127.0.0.1).  This can be optionally changed by using the `--jsonrpcbindip <ip address>` command line option. **IPv4 only. IPv6 support has not been tested.**
+
+
 ## Wire protocol
 
 The JSON-RPC server is based on the [JSON-RPC 2.0](https://www.jsonrpc.org/specification) protocol, using [streaming newline-delimited JSON over TCP](https://clue.engineering/2018/introducing-reactphp-ndjson) as the transport. There are three main types of messages being exchanged:


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds a command line switch to specify the bind address for the RPC server.  Today this address is hard-coded to the loopback interface.  The loopback remains the default, but can be overridden with this new command line option.

CHANGELOG:  New command line switch (--jsonrpcbindip) to specify the bind address for the RPC server.

**Context: Fixes an issue?**

Does not fix a reported issue, but does address that there is no way to change the bind address without recompiling.

**Does this change need documentation? What needs to be documented and how?**

If accepted, will update doc repo.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Tested on Linux only.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [X] I tested my code and it does what I want
-  [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [X] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [X] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
