### PR TITLE
JSON-RPC: Extend jamulusserver/getClients method

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -234,12 +234,17 @@ Results:
 
 | Name | Type | Description |
 | --- | --- | --- |
+| result.connections | number | The number of active connections. |
 | result.clients | array | The list of connected clients. |
 | result.clients[*].id | number | The client’s channel id. |
 | result.clients[*].address | string | The client’s address (ip:port). |
 | result.clients[*].name | string | The client’s name. |
 | result.clients[*].jitterBufferSize | number | The client’s jitter buffer size. |
 | result.clients[*].channels | number | The number of audio channels of the client. |
+| result.clients[*].instrumentCode | number | The id of the instrument for this channel. |
+| result.clients[*].city | string | The city name provided by the user for this channel. |
+| result.clients[*].countryName | number | The text name of the country specified by the user for this channel (see QLocale::Country). |
+| result.clients[*].skillLevelCode | number | The skill level id provided by the user for this channel. |
 
 
 ### jamulusserver/getRecorderStatus

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1469,16 +1469,18 @@ bool CServer::PutAudioData ( const CVector<uint8_t>& vecbyRecBuf, const int iNum
     return bNewConnection;
 }
 
-void CServer::GetConCliParam ( CVector<CHostAddress>& vecHostAddresses,
-                               CVector<QString>&      vecsName,
-                               CVector<int>&          veciJitBufNumFrames,
-                               CVector<int>&          veciNetwFrameSizeFact )
+void CServer::GetConCliParam ( CVector<CHostAddress>&     vecHostAddresses,
+                               CVector<QString>&          vecsName,
+                               CVector<int>&              veciJitBufNumFrames,
+                               CVector<int>&              veciNetwFrameSizeFact,
+                               CVector<CChannelCoreInfo>& vecChanInfo )
 {
     // init return values
     vecHostAddresses.Init ( iMaxNumChannels );
     vecsName.Init ( iMaxNumChannels );
     veciJitBufNumFrames.Init ( iMaxNumChannels );
     veciNetwFrameSizeFact.Init ( iMaxNumChannels );
+    vecChanInfo.Init ( iMaxNumChannels );
 
     // check all possible channels
     for ( int i = 0; i < iMaxNumChannels; i++ )
@@ -1490,6 +1492,7 @@ void CServer::GetConCliParam ( CVector<CHostAddress>& vecHostAddresses,
             vecsName[i]              = vecChannels[i].GetName();
             veciJitBufNumFrames[i]   = vecChannels[i].GetSockBufNumFrames();
             veciNetwFrameSizeFact[i] = vecChannels[i].GetNetwFrameSizeFact();
+            vecChanInfo[i]           = vecChannels[i].GetChanInfo();
         }
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -116,10 +116,11 @@ public:
 
     int GetNumberOfConnectedClients();
 
-    void GetConCliParam ( CVector<CHostAddress>& vecHostAddresses,
-                          CVector<QString>&      vecsName,
-                          CVector<int>&          veciJitBufNumFrames,
-                          CVector<int>&          veciNetwFrameSizeFact );
+    void GetConCliParam ( CVector<CHostAddress>&     vecHostAddresses,
+                          CVector<QString>&          vecsName,
+                          CVector<int>&              veciJitBufNumFrames,
+                          CVector<int>&              veciNetwFrameSizeFact,
+                          CVector<CChannelCoreInfo>& vecChanInfo );
 
     void CreateCLServerListReqVerAndOSMes ( const CHostAddress& InetAddr ) { ConnLessProtocol.CreateCLReqVersionAndOSMes ( InetAddr ); }
 

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -679,14 +679,15 @@ void CServerDlg::OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType
 
 void CServerDlg::OnTimer()
 {
-    CVector<CHostAddress> vecHostAddresses;
-    CVector<QString>      vecsName;
-    CVector<int>          veciJitBufNumFrames;
-    CVector<int>          veciNetwFrameSizeFact;
+    CVector<CHostAddress>     vecHostAddresses;
+    CVector<QString>          vecsName;
+    CVector<int>              veciJitBufNumFrames;
+    CVector<int>              veciNetwFrameSizeFact;
+    CVector<CChannelCoreInfo> vecChanInfo;
 
     ListViewMutex.lock();
     {
-        pServer->GetConCliParam ( vecHostAddresses, vecsName, veciJitBufNumFrames, veciNetwFrameSizeFact );
+        pServer->GetConCliParam ( vecHostAddresses, vecsName, veciJitBufNumFrames, veciNetwFrameSizeFact, vecChanInfo );
 
         // we assume that all vectors have the same length
         const int iNumChannels = vecHostAddresses.Size();


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Expands jamulusserver/getClients method to include all elements of a user profile as well as the number of active client connections.  Changes were made so they are backward compatible with the prior message format.

CHANGELOG:  jamulusserver/getClients method expanded to include all elements of a user profile as well as the number of active client connections.  

**Context: Fixes an issue?**

Addresses issue #2488 and comments in #2890 

**Does this change need documentation? What needs to be documented and how?**

JSON-RPC documentation was updated via python tool and is included in this PR.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Compile tested on Linux only.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [X] I tested my code and it does what I want
-  [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [X] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [X] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
