### PR TITLE
JSON-RPC: Additional methods for jamulusserver/*

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -297,6 +297,41 @@ Results:
 | result | string | Always "acknowledged".   To check if the recording was restarted or if there is any error, call `jamulusserver/getRecorderStatus` again. |
 
 
+### jamulusserver/sendBroadcastChat
+
+Send a chat message to all connected clients.  Messages from the server are not escaped and can contain HTML as defined for  QTextBrowser.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.textMessage | string | The chat message to be sent. |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | Always "ok". |
+
+
+### jamulusserver/sendChat
+
+Send a chat message to the channel identified by a specificc address. The chat should be pre-escaped if necessary prior to calling this  method.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.address | string | The full channel IP address as a string XXX.XXX.XXX.XXX:PPPPP |
+| params.textMessage | string | The chat message to be sent. |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | "ok" if channel could be determined and message sent. |
+
+
 ### jamulusserver/setRecordingDirectory
 
 Sets the server recording directory.
@@ -443,5 +478,72 @@ Parameters:
 | Name | Type | Description |
 | --- | --- | --- |
 | params | object | No parameters (empty object). |
+
+
+### jamulusserver/chatReceived
+
+Emitted when a chat text is received. Server-generated chats are not included in this notification.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.id | string | The channel ID generating the chat. |
+| params.name | string | The user name generating the chat. |
+| params.address | number | The address of the channel generating the chat. |
+| params.stamp | string | The date/time of the chat (ISO 8601 format, in server configured timezone). |
+| params.text | string | The chat text. |
+
+
+### jamulusserver/clientConnect
+
+Emitted when a new client connects to the server.
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result.name | string | The client’s name. |
+| result.address | string | The client’s address (ip:port). |
+| result.instrumentCode | number | The id of the user's instrument. |
+| result.instrumentName | number | The text name of the user's instrument. |
+| result.city | string | The user's city name. |
+| result.countryCode | number | The id of the country specified by the user (see QLocale::Country). |
+| result.countryName | number | The text name of the user's country (see QLocale::Country). |
+| result.skillLevelCode | number | The user's skill level id. |
+| result.skillLevelName | number | The user's skill level text name. |
+
+
+### jamulusserver/clientDisconnect
+
+Emitted when a client disconnects from the server.
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result.id | string | The client channel id. |
+| result.name | string | The client’s name. |
+| result.address | string | The client’s address (ip:port). |
+
+
+### jamulusserver/clientInfoChanged
+
+Emitted when a client changes their information (name, instrument, country, city, skill level).
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result.oldName | string | The client’s name just prior to this change. |
+| result.name | string | The client’s name (new one, if change). |
+| result.address | string | The client’s address (ip:port). |
+| result.instrumentCode | number | The id of the user's instrument. |
+| result.instrumentName | number | The text name of the user's instrument. |
+| result.city | string | The user's city name. |
+| result.countryCode | number | The id of the country specified by the user (see QLocale::Country). |
+| result.countryName | number | The text name of the user's country (see QLocale::Country). |
+| result.skillLevelCode | number | The user's skill level id. |
+| result.skillLevelName | number | The user's skill level text name. |
 
 

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -22,6 +22,7 @@
  *
 \******************************************************************************/
 
+#include "rpcserver.h" // Here and not in channel.h to avoid circular issue
 #include "channel.h"
 
 // CChannel implementation *****************************************************
@@ -337,9 +338,23 @@ void CChannel::SetChanInfo ( const CChannelCoreInfo& NChanInf )
     // apply value (if a new channel or different from previous one)
     if ( !bIsIdentified || ChannelInfo != NChanInf )
     {
-        bIsIdentified = true; // Indicate we have received channel info
+
+        QString strOldName = ChannelInfo.strName;
 
         ChannelInfo = NChanInf;
+
+#ifndef NO_JSON_RPC
+        if ( !bIsIdentified )
+        {
+            CRpcLogging::getInstance().rpcOnNewConnection ( *this );
+        }
+        else
+        {
+            CRpcLogging::getInstance().rpcOnUpdateConnection ( *this, strOldName );
+        }
+#endif
+
+        bIsIdentified = true; // Indicate we have received channel info
 
         // fire message that the channel info has changed
         emit ChanInfoHasChanged();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -980,6 +980,7 @@ int main ( int argc, char** argv )
             if ( pRpcServer )
             {
                 new CServerRpc ( &Server, pRpcServer, pRpcServer );
+                CRpcLogging::getInstance().setRpcEnabled();
             }
 #endif
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -62,6 +62,7 @@ public:
     // Our errors
     static const int iErrAuthenticationFailed = 400;
     static const int iErrUnauthenticated      = 401;
+    static const int iErrChannelNotFound      = 402;
 
 private:
     int         iPort;
@@ -81,4 +82,40 @@ private:
 
 protected slots:
     void OnNewConnection();
+};
+
+/**
+ * Singleton class that will be used as a consolidation point
+ * for signals emitting from multi-instance classes (ie, channels)
+ */
+
+#include "channel.h"
+
+class CRpcLogging : public QObject
+{
+
+    Q_OBJECT
+
+private:
+    CRpcLogging() {}
+
+    bool rpcEnabled = false;
+
+public:
+    static CRpcLogging& getInstance()
+    {
+        static CRpcLogging instance;
+        return instance;
+    }
+
+    bool isRpcEnabled() { return rpcEnabled; }
+    void setRpcEnabled() { rpcEnabled = true; }
+    void setRpcDisabled() { rpcEnabled = false; }
+
+    void rpcOnNewConnection ( CChannel& channel ) { emit rpcClientConnected ( channel ); }
+    void rpcOnUpdateConnection ( CChannel& channel, const QString strOldName ) { emit rpcUpdateConnection ( channel, strOldName ); }
+
+signals:
+    void rpcClientConnected ( CChannel& channel );
+    void rpcUpdateConnection ( CChannel& channel, const QString strOldName );
 };

--- a/src/server.h
+++ b/src/server.h
@@ -168,11 +168,16 @@ public:
     void SetEnableDelayPanning ( bool bDelayPanningOn ) { bDelayPan = bDelayPanningOn; }
     bool IsDelayPanningEnabled() { return bDelayPan; }
 
+    bool CreateAndSendPreEscapedChatText ( const int iChannel, const QString& strChatText );
+
+    // Methods formally protected, now public so they can be accessed via RPC
+    virtual void CreateAndSendChatTextForAllConChannels ( const int iCurChanID, const QString& strChatText );
+    int          FindChannel ( const CHostAddress& CheckAddr, const bool bAllowNew = false );
+
 protected:
     // access functions for actual channels
     bool IsConnected ( const int iChanNum ) { return vecChannels[iChanNum].IsConnected(); }
 
-    int                   FindChannel ( const CHostAddress& CheckAddr, const bool bAllowNew = false );
     void                  InitChannel ( const int iNewChanID, const CHostAddress& InetAddr );
     void                  FreeChannel ( const int iCurChanID );
     void                  DumpChannels ( const QString& title );
@@ -180,8 +185,6 @@ protected:
 
     virtual void CreateAndSendChanListForAllConChannels();
     virtual void CreateAndSendChanListForThisChan ( const int iCurChanID );
-
-    virtual void CreateAndSendChatTextForAllConChannels ( const int iCurChanID, const QString& strChatText );
 
     virtual void CreateOtherMuteStateChanged ( const int iCurChanID, const int iOtherChanID, const bool bIsMuted );
 
@@ -311,6 +314,7 @@ signals:
     void Started();
     void Stopped();
     void ClientDisconnected ( const int iChID );
+    void rpcClientDisconnected ( const int iChID, const QString strName, const CHostAddress HostAddress );
     void SvrRegStatusChanged();
     void AudioFrame ( const int              iChID,
                       const QString          stChName,
@@ -325,6 +329,8 @@ signals:
     void StopRecorder();
     void RecordingSessionStarted ( QString sessionDir );
     void EndRecorderThread();
+
+    void rpcChatSent ( const int iCurChanID, const QString chanName, const QString chanAddr, const QString chatStamp, const QString strChatMessage );
 
 public slots:
     void OnTimer();

--- a/src/serverrpc.h
+++ b/src/serverrpc.h
@@ -27,6 +27,7 @@
 
 #include "server.h"
 #include "rpcserver.h"
+#include "channel.h"
 
 /* Classes ********************************************************************/
 class CServerRpc : public QObject


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->
**Short description of changes**

**NOTE THIS PR IS DEPENDENT ON #2918** (hence the compile failures -- I can submit both together here if that works better.  Not sure how to note this dependency in github)

Added additional RPC methods for notification of connection, disconnection, and chats.  Added the ability to send both broadcast chats to all connected clients, or targeted chats to a single connected client.

**jamulusserver/clientConnect** - a push notification on new client connect containing all info ("all info" is name, ip, instrument code, instrument name, skill code, skill name, country code, country name, city)
**jamulusserver/clientDisconnect** - a push notification on client disconnect containing channel, name, ip.
**jamulusserver/clientInfoChanged** - a push notification when a client changes any of their profile information.
**jamulusserver/chatReceived** - a push notification when a chat is received by the server including channel, name, ip, timestamp, and message.
**jamulusserver/sendBroadcastChat** - method to broadcast a server-level message to all connected clients.
**jamulusserver/sendChat** - method to send a chat to any individual connected channel based upon IP address.
Modified RPC methods:

CHANGELOG: Additional RPC methods for connection notification and chat processing.

**Context: Fixes an issue?**

Issue #2495 and discussion in #2890 

**Does this change need documentation? What needs to be documented and how?**

Yes, RPC documentation updates are included in this PR.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Linux tested/compiled only.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [X] I tested my code and it does what I want
-  [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
