### PR TITLE
Fix case-related ISO country code issue

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1460,7 +1460,7 @@ QLocale::Country CLocale::GetCountryCodeByTwoLetterCode ( QString sTwoLetterCode
     {
         QStringList vstrLocParts = qLocale.name().split ( "_" );
 
-        if ( vstrLocParts.size() >= 2 && vstrLocParts.at ( 1 ).toLower() == sTwoLetterCode )
+        if ( vstrLocParts.size() >= 2 && vstrLocParts.at ( 1 ).toLower() == sTwoLetterCode.toLower() )
         {
             return qLocale.country();
         }


### PR DESCRIPTION
**Short description of changes**
Fixes issue relating to ISO country codes only working if provided in lower case.  Now support any case combination.

CHANGELOG: ISO country codes can now be supplied in upper or lower case

**Context: Fixes an issue?**
Fixes issue #2933 

**Does this change need documentation? What needs to be documented and how?**
Probably not as I think the general expectation is that the country code should not be case sensitive anyway.


**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [X] I tested my code and it does what I want
-  [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [X] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
