### PR TITLE
Server: Don't warn when no --serverinfo is provided

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -650,6 +650,13 @@ int main ( int argc, char** argv )
             exit ( 1 );
         }
 
+        if ( ServerOnlyOptions.contains ( "--serverinfo" ) && strServerInfo.split ( ";" ).count() < 3 )
+        {
+            qWarning() << qUtf8Printable (
+                QString ( "\"--serverinfo '%1'\": must contain [name];[city];[country] - value will be ignored" ).arg ( strServerInfo ) );
+            strServerInfo = "";
+        }
+
 #ifndef HEADLESS
         if ( bUseGUI )
         {

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -232,13 +232,6 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
                                         .arg ( slServInfoSeparateParams[2] )
                                         .arg ( QLocale::countryToString ( ThisServerListEntry.eCountry ) ) );
     }
-    else
-    {
-        if ( !strServerInfo.isEmpty() )
-        {
-            qWarning() << "Ignoring invalid serverinfo, please verify the parameter syntax.";
-        }
-    }
 
     // per definition, the very first entry is this server and this entry will
     // never be deleted

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -234,7 +234,10 @@ CServerListManager::CServerListManager ( const quint16  iNPortNum,
     }
     else
     {
-        qWarning() << "Ignoring invalid serverinfo, please verify the parameter syntax.";
+        if ( !strServerInfo.isEmpty() )
+        {
+            qWarning() << "Ignoring invalid serverinfo, please verify the parameter syntax.";
+        }
     }
 
     // per definition, the very first entry is this server and this entry will


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
The intention of 5b2c2de was to introduce logging for bad --serverinfo parameters. However, it also warns about bad serverinfo if no --serverinfo is given at all. This is confusing.
Therefore, this commit removes the error when no --serverinfo has been given.

<!-- Explain what your PR does -->

CHANGELOG: Server: Removed spurious log message when not using --serverinfo

**Context: Fixes an issue?**
Fixes: #2947

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready.

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Reviews.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
