### PR TITLE
JSON-RPC: Remove IPv6-untested warning from --jsonrpcbindip docs / improve empty address warning

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -17,7 +17,8 @@ It can be generated like this:
 $ openssl rand -base64 10 > /file/with/a/secret.txt
 ```
 
-The JSON-RPC server defaults to listening on the local loopback network interface (127.0.0.1).  This can be optionally changed by using the `--jsonrpcbindip <ip address>` command line option. **IPv4 only. IPv6 support has not been tested.**
+The JSON-RPC server defaults to listening on the local loopback network interface (127.0.0.1).
+This can be optionally changed by using the `--jsonrpcbindip <ip address>` command line option.
 
 
 ## Wire protocol

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1107,7 +1107,7 @@ QString UsageArguments ( char** argv )
            "      --jsonrpcsecretfile\n"
            "                        path to a single-line file which contains a freely\n"
            "                        chosen secret to authenticate JSON-RPC users.\n"
-           "      --jsonrpcbindip   optional network address to bind RPC server. Defaults to 127.0.0.1 (IPv4 only, IPv6 not tested).\n"
+           "      --jsonrpcbindip   optional network address to bind RPC server. Defaults to 127.0.0.1.\n"
            "  -Q, --qos             set the QoS value. Default is 128. Disable with 0\n"
            "                        (see the Jamulus website to enable QoS on Windows)\n"
            "  -t, --notranslation   disable translation (use English language)\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -801,7 +801,7 @@ int main ( int argc, char** argv )
 
         if ( strJsonRpcBindIP.trimmed().isEmpty() )
         {
-            qCritical() << qUtf8Printable ( QString ( "JSON-RPC is enabled but no bind address was provided, exiting." ) );
+            qCritical() << qUtf8Printable ( QString ( "JSON-RPC is enabled but the bind address provided is empty, exiting." ) );
             exit ( 1 );
         }
 

--- a/tools/generate_json_rpc_docs.py
+++ b/tools/generate_json_rpc_docs.py
@@ -204,7 +204,8 @@ It can be generated like this:
 $ openssl rand -base64 10 > /file/with/a/secret.txt
 ```
 
-The JSON-RPC server defaults to listening on the local loopback network interface (127.0.0.1).  This can be optionally changed by using the `--jsonrpcbindip <ip address>` command line option. **IPv4 only. IPv6 support has not been tested.**
+The JSON-RPC server defaults to listening on the local loopback network interface (127.0.0.1).
+This can be optionally changed by using the `--jsonrpcbindip <ip address>` command line option.
 
 
 ## Wire protocol


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- JSON-RPC: Remove IPv6-untested warning from --jsonrpcbindip docs
  IPv6 was tested successfully by @ann0see in https://github.com/jamulussoftware/jamulus/pull/2917#discussion_r1014421615

 - JSON-RPC: Improve empty-bind-address warning for --jsonrpcbindip
 References: https://github.com/jamulussoftware/jamulus/pull/2917#discussion_r1019527165

<!-- Explain what your PR does -->

CHANGELOG: SKIP

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
