### PR TITLE
Copyright notices: Minimize GitHub workflow permissions

### DIFF
--- a/.github/workflows/update-copyright-notices.yml
+++ b/.github/workflows/update-copyright-notices.yml
@@ -1,5 +1,6 @@
 name: Update copyright notices
 
+permissions: {}
 on:
   push:
     branches:
@@ -14,6 +15,9 @@ jobs:
       github.repository_owner == 'jamulussoftware' &&
       github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - run: ./tools/update-copyright-notices.sh
@@ -43,6 +47,9 @@ jobs:
       github.event_name == 'pull_request' &&
       startsWith(github.event.pull_request.head.label, 'jamulussoftware:updateCopyrightNotices')
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - env:


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Minimizes permissions for copyright notices workflow. Once the series of PRs are merged, we can change the GH default permissions to read only.

POC:
Copyright change opens PR: https://github.com/ann0see/jamulus/actions/runs/3505273366
And deletes branch:
https://github.com/ann0see/jamulus/actions/runs/3505274807

That's the working PR:
https://github.com/ann0see/jamulus/pull/87
<!-- Explain what your PR does -->

CHANGELOG: SKIP
**Context: Fixes an issue?**
Related to: #1737 
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Needs review.
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Review.
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
