### PR TITLE
Display server title correctly in dark mode

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1358,7 +1358,6 @@ void CClientDlg::SetGUIDesign ( const EGUIDesign eNewDesign )
             "                         image:          url(:/png/fader/res/ledbuttonpressed.png); }"
             "QCheckBox {              color:          rgb(220, 220, 220);"
             "                         font:           bold; }" );
-
 #ifdef _WIN32
         // Workaround QT-Windows problem: This should not be necessary since in the
         // background frame the style sheet for QRadioButton was already set. But it
@@ -1450,31 +1449,39 @@ void CClientDlg::SetMixerBoardDeco ( const ERecorderState newRecorderState, cons
     eLastRecorderState = newRecorderState;
     eLastDesign        = eNewDesign;
 
+    // set base style
+    QString sTitleStyle = "QGroupBox::title { subcontrol-origin: margin;"
+                          "                   subcontrol-position: left top;"
+                          "                   left: 7px;";
+
     if ( newRecorderState == RS_RECORDING )
     {
-        MainMixerBoard->setStyleSheet ( "QGroupBox::title { subcontrol-origin: margin; "
-                                        "                   subcontrol-position: left top;"
-                                        "                   left: 7px;"
-                                        "                   color: rgb(255,255,255);"
-                                        "                   background-color: rgb(255,0,0); }" );
+        sTitleStyle += "color: rgb(255,255,255);"
+                       "background-color: rgb(255,0,0); }";
     }
     else
     {
         if ( eNewDesign == GD_ORIGINAL )
         {
-            MainMixerBoard->setStyleSheet ( "QGroupBox::title { subcontrol-origin: margin;"
-                                            "                   subcontrol-position: left top;"
-                                            "                   left: 7px;"
-                                            "                   color: rgb(220,220,220); }" );
+            // no need to set the background color for dark mode in fancy skin, as the background is already dark.
+            sTitleStyle += "color: rgb(220,220,220); }";
         }
         else
         {
-            MainMixerBoard->setStyleSheet ( "QGroupBox::title { subcontrol-origin: margin;"
-                                            "                   subcontrol-position: left top;"
-                                            "                   left: 7px;"
-                                            "                   color: rgb(0,0,0); }" );
+            if ( palette().color ( QPalette::Window ) == QColor::fromRgbF ( 0.196078, 0.196078, 0.196078, 1 ) )
+            {
+                // Dark mode on macOS/Linux needs a light color
+
+                sTitleStyle += "color: rgb(220,220,220); }";
+            }
+            else
+            {
+                sTitleStyle += "color: rgb(0,0,0); }";
+            }
         }
     }
+
+    MainMixerBoard->setStyleSheet ( sTitleStyle );
 }
 
 void CClientDlg::SetPingTime ( const int iPingTime, const int iOverallDelayMs, const CMultiColorLED::ELightColor eOverallDelayLEDColor )


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Fixes the color of the Server name in dark mode on Linux (Gnome, Qt6, Debian 12). This should also work on macOS. Edit: it does. 

Without fix:

![grafik](https://user-images.githubusercontent.com/20726856/218444563-069f47ce-3ee8-4a9f-b102-6a874a7d799f.png)

With fix:
![grafik](https://user-images.githubusercontent.com/20726856/218443944-e3585b0a-93ea-43b8-81cb-cb46c6d75a6a.png)

Recording and mute myself doesn't change and looks OK:

![grafik](https://user-images.githubusercontent.com/20726856/218445519-ec73d6aa-7967-4cba-b3b3-b6bc5b75da8f.png)

CHANGELOG: CONDENSE with https://github.com/jamulussoftware/jamulus/pull/2833

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
Ready for review. 

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (See screenshots. I changed through the modes and tested recording. Not sure what else to test)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
