### PR TITLE
A couple of minor patches to Jamulus.pro

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -81,6 +81,7 @@ win32 {
     DEFINES += NOMINMAX # solves a compiler error in qdatetime.h (Qt5)
     RC_FILE = src/res/win-mainicon.rc
     mingw* {
+        DEFINES += _WIN32_WINNT=0x0600 # solves missing inet_pton in CSocket::SendPacket
         LIBS += -lole32 \
             -luser32 \
             -ladvapi32 \

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -682,11 +682,23 @@ contains(QT_ARCH, armeabi-v7a) | contains(QT_ARCH, arm64-v8a) {
 DEFINES_OPUS += OPUS_BUILD=1 USE_ALLOCA=1 OPUS_HAVE_RTCD=1 HAVE_LRINTF=1 HAVE_LRINT=1
 
 DISTFILES += ChangeLog \
+    COMPILING.md \
     COPYING \
     CONTRIBUTING.md \
     README.md \
+    SECURITY.md \
+    docs/JAMULUS_PROTOCOL.md \
+    docs/JSON-RPC.md \
+    docs/README.md \
+    docs/RELATED-PROJECTS.md \
+    docs/TRANSLATING.md \
     linux/jamulus.desktop.in \
     linux/jamulus-server.desktop.in \
+    mac/Info-make-legacy.plist \
+    mac/Info-make.plist \
+    mac/Info-xcode.plist \
+    mac/Jamulus.entitlements \
+    mac/deploy_mac.sh \
     src/res/io.jamulus.jamulus.png \
     src/res/io.jamulus.jamulus.svg \
     src/res/io.jamulus.jamulusserver.svg \
@@ -1043,7 +1055,17 @@ DISTFILES += ChangeLog \
     src/res/flags/yt.png \
     src/res/flags/za.png \
     src/res/flags/zm.png \
-    src/res/flags/zw.png
+    src/res/flags/zw.png \
+    tools/changelog-helper.sh \
+    tools/check-wininstaller-translations.sh \
+    tools/checkkeys.pl \
+    tools/create-translation-issues.sh \
+    tools/generate_json_rpc_docs.py \
+    tools/get_release_contributors.py \
+    tools/qt5-to-qt6-country-code-table.py \
+    tools/update-copyright-notices.sh \
+    windows/deploy_windows.ps1 \
+    windows/installer.nsi
 
 DISTFILES_OPUS += libs/opus/AUTHORS \
     libs/opus/ChangeLog \


### PR DESCRIPTION
**Short description of changes**

* Qt Creator 5 "built in" MingW is "pre-Win8" and needs `_WIN32_WINNT=0x0600` to get `inet_pton` to work.
* When trying to build a distributable, I discovered quite a lot of the files aren't mentioned in `DIST_FILES` (so they don't appear as "part of the project" to Qt Creator)

CHANGELOG: Internal: Improve Qt Creator 5 compliance of Jamulus.pro

**Context: Fixes an issue?**

Minor developer issue with development tooling.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

I had to make the changes to get my fresh new Qt Creator install working fully.

**What is missing until this pull request can be merged?**

Review.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
