### PR TITLE
Define JACK headers and sources globally and add some documentation 

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -125,7 +125,7 @@ win32 {
                 libjackname = "libjack64.lib"
             }
             !exists("$${programfilesdir}/JACK2/include/jack/jack.h") {
-                error("Error: jack.h was not found in the expected location ($${programfilesdir}). Ensure that the right JACK2 variant is installed (32bit vs. 64bit).")
+                error("Error: jack.h was not found in the expected location ($${programfilesdir}). Ensure that the right JACK2 variant is installed (32 Bit vs. 64 Bit).")
             }
 
             HEADERS += src/sound/jack/sound.h
@@ -178,6 +178,7 @@ win32 {
     QMAKE_BUNDLE_DATA += OSX_ENTITLEMENTS
 
     macx-xcode {
+        # As of 2023-04-15 the macOS build with Xcode only fails. This is tracked in #1841
         QMAKE_INFO_PLIST = mac/Info-xcode.plist
         XCODE_ENTITLEMENTS.name = CODE_SIGN_ENTITLEMENTS
         XCODE_ENTITLEMENTS.value = mac/Jamulus.entitlements

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -68,6 +68,10 @@ INCLUDEPATH_OPUS = libs/opus/include \
     libs/opus/silk/fixed \
     libs/opus
 
+# As JACK is used in multiple OS, we declare it globally
+HEADERS_JACK = src/sound/jack/sound.h
+SOURCES_JACK = src/sound/jack/sound.cpp
+
 DEFINES += APP_VERSION=\\\"$$VERSION\\\" \
     CUSTOM_MODES \
     _REENTRANT
@@ -128,8 +132,8 @@ win32 {
                 error("Error: jack.h was not found in the expected location ($${programfilesdir}). Ensure that the right JACK2 variant is installed (32 Bit vs. 64 Bit).")
             }
 
-            HEADERS += src/sound/jack/sound.h
-            SOURCES += src/sound/jack/sound.cpp
+            HEADERS += $$HEADERS_JACK
+            SOURCES += $$SOURCES_JACK
             DEFINES += WITH_JACK
             DEFINES += JACK_ON_WINDOWS
             DEFINES += _STDINT_H # supposed to solve compilation error in systemdeps.h
@@ -209,8 +213,8 @@ win32 {
                  error("Error: jack.h was not found at the usual place, maybe JACK is not installed")
             }
         }
-        HEADERS += src/sound/jack/sound.h
-        SOURCES += src/sound/jack/sound.cpp
+        HEADERS += $$HEADERS_JACK
+        SOURCES += $$SOURCES_JACK
         DEFINES += WITH_JACK
         DEFINES += JACK_REPLACES_COREAUDIO
         INCLUDEPATH += /usr/local/include
@@ -297,8 +301,8 @@ win32 {
     } else {
         message(JACK Audio Interface Enabled.)
 
-        HEADERS += src/sound/jack/sound.h
-        SOURCES += src/sound/jack/sound.cpp
+        HEADERS += $$HEADERS_JACK
+        SOURCES += $$SOURCES_JACK
 
         contains(CONFIG, "raspijamulus") {
             message(Using JACK Audio in raspijamulus.sh mode.)


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Instead of using hardcoded paths to the sound files @pgScorpio suggested to use variables. This PR uses global definitions for JACK sources and headers and adds some small comments.
<!-- Explain what your PR does -->

CHANGELOG: Internal: Improved maintainability of Jamulus.pro by using global definitions.<!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**
Fixes: #2573
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready for testing
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Needs whole CI to pass
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (Linux (JACK gives no warning and sound is OK), Windows too. I can't test macOS at the moment - but build is OK.)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
