### PR TITLE
RPC: remove remaining directory server mentions

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -280,7 +280,7 @@ Results:
 | result.city | string | The server city. |
 | result.countryId | number | The server country ID (see QLocale::Country). |
 | result.welcomeMessage | string | The server welcome message. |
-| result.directoryServer | string | The directory with which this server requested registration, or blank if none. |
+| result.directory | string | The directory with which this server requested registration, or blank if none. |
 | result.registrationStatus | string | The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus). |
 
 

--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -280,7 +280,7 @@ Results:
 | result.city | string | The server city. |
 | result.countryId | number | The server country ID (see QLocale::Country). |
 | result.welcomeMessage | string | The server welcome message. |
-| result.directoryServer | string | The directory server to which this server requested registration, or blank if none. |
+| result.directoryServer | string | The directory with which this server requested registration, or blank if none. |
 | result.registrationStatus | string | The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus). |
 
 

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -106,7 +106,7 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
     /// @result {string} result.city - The server city.
     /// @result {number} result.countryId - The server country ID (see QLocale::Country).
     /// @result {string} result.welcomeMessage - The server welcome message.
-    /// @result {string} result.directoryServer - The directory server to which this server requested registration, or blank if none.
+    /// @result {string} result.directory - The directory with which this server requested registration, or blank if none.
     /// @result {string} result.registrationStatus - The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus).
     pRpcServer->HandleMethod ( "jamulusserver/getServerProfile", [=] ( const QJsonObject& params, QJsonObject& response ) {
         QString dsName = "";
@@ -119,7 +119,7 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
             { "city", pServer->GetServerCity() },
             { "countryId", pServer->GetServerCountry() },
             { "welcomeMessage", pServer->GetWelcomeMessage() },
-            { "directoryServer", dsName }, // TODO rename to 'directory' and update doccomment above
+            { "directory", dsName },
             { "registrationStatus", SerializeRegistrationStatus ( pServer->GetSvrRegStatus() ) },
         };
         response["result"] = result;


### PR DESCRIPTION
**Short description of changes**

CHANGELOG: rename `directoryServer` to `directory` in `jamulusserver/getServerProfile` response

**Context: Fixes an issue?**

RPC changes separated from main change due to RPC doc issues that got resolved.

**Does this change need documentation? What needs to be documented and how?**

RPC doc changes in line with API change.

**Status of this Pull Request**

Untested as I don't use RPC.

**What is missing until this pull request can be merged?**

Seems trivial, so I'd just do it.  I've been running builds with this change in (but without using the RPC API).

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
