### PR TITLE
Docs: Document that Windows 10 is the minimum requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Please see the [.clang_format file](https://github.com/jamulussoftware/jamulus/b
 
 We support the following platforms and versions:
 
-- **Windows 7** or later
+- **Windows 10** or later
 - **macOS 10.10** or later
 - **Ubuntu 18.04** or later, **Debian 10** or later, most Linux flavors with recent enough Qt versions
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This adds Windows 10 as minimum supported version. Since #2300 was merged, 64 Bit will use QT 6 which drops Windows 7 and 8.1 support. Although 32 Bit Windows 7 and 8.1 is still there, it doesn't make sense to call that supported.
CHANGELOG: SKIP 

**Context: Fixes an issue?**
Related to: #2300
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
/
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready for review.
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Review, approval. Shouldn't be much
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
