### PR TITLE
Build: iOS: Use Qt6 and bump build environment

### DIFF
--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -42,7 +42,7 @@ setup() {
 build_app_as_ipa() {
     # Add the Qt binaries to the PATH:
     export PATH="${QT_DIR}/${QT_VERSION}/ios/bin:${PATH}"
-    ./ios/deploy_ios.sh -q "${QT_DIR}/${QT_VERSION}/ios/bin/qmake"
+    ./ios/deploy_ios.sh -m "${QT_DIR}/${QT_VERSION}/ios/bin/qmake"
 }
 
 pass_artifact_to_job() {

--- a/.github/autobuild/ios.sh
+++ b/.github/autobuild/ios.sh
@@ -42,7 +42,7 @@ setup() {
 build_app_as_ipa() {
     # Add the Qt binaries to the PATH:
     export PATH="${QT_DIR}/${QT_VERSION}/ios/bin:${PATH}"
-    ./ios/deploy_ios.sh
+    ./ios/deploy_ios.sh -q "${QT_DIR}/${QT_VERSION}/ios/bin/qmake"
 }
 
 pass_artifact_to_job() {

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -251,13 +251,13 @@ jobs:
 
           - config_name:            iOS (artifacts)
             target_os:              ios
-            building_on_os:         macos-11
-            base_command:           QT_VERSION=5.15.2 ./.github/autobuild/ios.sh
+            building_on_os:         macos-12
+            base_command:           QT_VERSION=6.4.3 ./.github/autobuild/ios.sh
             # Build failed with CodeQL enabled when last tested 03/2022 (#2490).
             # There are no hints that iOS is supposed to be supported by CodeQL.
             # Therefore, disable it:
             run_codeql:             false
-            xcode_version:          12.5.1
+            xcode_version:          14.2.0
 
           - config_name:            Windows (artifact+codeQL)
             target_os:              windows

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -251,7 +251,7 @@ jobs:
 
           - config_name:            iOS (artifacts)
             target_os:              ios
-            building_on_os:         macos-12
+            building_on_os:         macos-13
             base_command:           QT_VERSION=6.4.3 ./.github/autobuild/ios.sh
             # Build failed with CodeQL enabled when last tested 03/2022 (#2490).
             # There are no hints that iOS is supposed to be supported by CodeQL.

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -232,7 +232,7 @@ win32 {
     HEADERS += src/sound/coreaudio-ios/sound.h
     OBJECTIVE_SOURCES += src/sound/coreaudio-ios/sound.mm
     QMAKE_TARGET_BUNDLE_PREFIX = io.jamulus
-    # QMAKE_LFLAGS += -Wl,-e,_qt_main_wrapper
+    QMAKE_LFLAGS += -Wl,-e,_qt_main_wrapper
     LIBS += -framework AVFoundation \
         -framework AudioToolbox
 } else:android {

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -232,6 +232,7 @@ win32 {
     HEADERS += src/sound/coreaudio-ios/sound.h
     OBJECTIVE_SOURCES += src/sound/coreaudio-ios/sound.mm
     QMAKE_TARGET_BUNDLE_PREFIX = io.jamulus
+    QMAKE_LFLAGS += -Wl,-e,_qt_main_wrapper
     LIBS += -framework AVFoundation \
         -framework AudioToolbox
 } else:android {

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -232,7 +232,7 @@ win32 {
     HEADERS += src/sound/coreaudio-ios/sound.h
     OBJECTIVE_SOURCES += src/sound/coreaudio-ios/sound.mm
     QMAKE_TARGET_BUNDLE_PREFIX = io.jamulus
-    QMAKE_LFLAGS += -Wl,-e,_qt_main_wrapper
+    # QMAKE_LFLAGS += -Wl,-e,_qt_main_wrapper
     LIBS += -framework AVFoundation \
         -framework AudioToolbox
 } else:android {

--- a/ios/deploy_ios.sh
+++ b/ios/deploy_ios.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
 set -eu -o pipefail
 
+
+qmake_path=""
+
+while getopts 'hs:' flag; do
+    case "${flag}" in
+        m)
+            qmake_path=$OPTARG
+            if [[ -z "$qmake_path" ]]; then
+                echo "Please add the path to the qmake binary: -m \"</path/to/ios/qmake/binary>\""
+            fi
+            ;;
+        h)
+            echo "Usage: -m </path/to/ios/qmake/binary>"
+            exit 0
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+done
+
 ## Builds an ipa file for iOS. Should be run from the repo-root
 
 # Create Xcode file and build
-qmake -spec macx-xcode Jamulus.pro
+eval "${qmake_path} Jamulus.pro"
 /usr/bin/xcodebuild -project Jamulus.xcodeproj -scheme Jamulus -configuration Release clean archive -archivePath "build/Jamulus.xcarchive" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_ENTITLEMENTS=""
 
 # Generate ipa by copying the .app file from the xcarchive directory

--- a/ios/deploy_ios.sh
+++ b/ios/deploy_ios.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 qmake_path=""
 
-while getopts 'hs:' flag; do
+while getopts 'hm:' flag; do
     case "${flag}" in
         m)
             qmake_path=$OPTARG

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -72,6 +72,11 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );
 
+#if defined( Q_OS_ANDROID ) || defined( ANDROID ) || defined( Q_OS_IOS )
+    // for the Android/iOS version maximize the window
+    setWindowState ( Qt::WindowMaximized );
+#endif
+
     // Connections -------------------------------------------------------------
     QObject::connect ( edtLocalInputText, &QLineEdit::textChanged, this, &CChatDlg::OnLocalInputTextTextChanged );
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -53,6 +53,11 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     layout()->setMenuBar ( pMenu );
 #endif
 
+#if defined( Q_OS_ANDROID ) || defined( ANDROID ) || defined( Q_OS_IOS )
+    // for the Android/iOS version maximize the window
+    setWindowState ( Qt::WindowMaximized );
+#endif
+
     // Add help text to controls -----------------------------------------------
     // local audio input fader
     QString strAudFader = "<b>" + tr ( "Local Audio Input Fader" ) + ":</b> " +

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -151,8 +151,8 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     // setup timers
     TimerInitialSort.setSingleShot ( true ); // only once after list request
 
-#ifdef ANDROID
-    // for the android version maximize the window
+#if defined( Q_OS_ANDROID ) || defined( ANDROID ) || defined( Q_OS_IOS )
+    // for the Android/iOS version maximize the window
     setWindowState ( Qt::WindowMaximized );
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,8 +56,12 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 #endif
 
 // Implementation **************************************************************
-
+#if defined( Q_OS_IOS )
+// iOS workaround for Qt6 builds. See https://stackoverflow.com/questions/25353686/you-are-creating-qapplication-before-calling-uiapplicationmain-error-on-ios
+extern "C" int qtmn( int argc, char **argv )
+#else
 int main ( int argc, char** argv )
+#endif
 {
 
 #if defined( Q_OS_MACX )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,12 +56,8 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 #endif
 
 // Implementation **************************************************************
-#if defined( Q_OS_IOS )
-// iOS workaround for Qt6 builds. See https://stackoverflow.com/questions/25353686/you-are-creating-qapplication-before-calling-uiapplicationmain-error-on-ios
-extern "C" int qtmn( int argc, char **argv )
-#else
+
 int main ( int argc, char** argv )
-#endif
 {
 
 #if defined( Q_OS_MACX )


### PR DESCRIPTION
Adds a Crash-fix by @danryu for a new ios Qt 6 build. Unfortunately, Qt6 makes the app basically unusable on small devices. This should be fixed after this PR got in:
![Qt6 breaks iOS connect dialog](https://github.com/jamulussoftware/jamulus/assets/20726856/c7ff1ca1-007e-4ea7-a2e2-002b58cfc629)

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Updates iOS to use Qt6 (coded by @hoffie)

CHANGELOG: Update iOS build to use Qt6. For now, only larger devices are usable. Please compile with Qt5 if you use small devices.

**Context: Fixes an issue?**

Fixes: #2711
Fixes: #2939

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready for review
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Nothing. However, a follow up for the GUI fix (?) should come in after the merge of this.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
