### PR TITLE
MacOS: Fix Xcode build

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1129,10 +1129,15 @@ contains(CONFIG, "opus_shared_lib") {
     DISTFILES += $$DISTFILES_OPUS
 
     contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
-        msvc {
+        msvc | macx-xcode {
             # According to opus/win32/config.h, "no special compiler
             # flags necessary" when using msvc.  It always supports
             # SSE intrinsics, but does not auto-vectorize.
+            # The macOS Xcode build would fail with these specific compiler flags.
+            # Thus, we omit them for macx-xcode too. This was discovered by
+            # plain testing by the Jamulus team and might mean that the
+            # optimizations are not used on macx-xcode. (See #1841, #3076)
+
             SOURCES += $$SOURCES_OPUS_ARCH
         } else {
             # Arch-specific files need special compiler flags, but we

--- a/mac/Info-xcode.plist
+++ b/mac/Info-xcode.plist
@@ -27,7 +27,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleIconFile</key>
-	<string>mainicon.icns</string>
+	<string>mac-mainicon.icns</string>
 	<key>CFBundleGetInfoString</key>
 	<string>Jamulus - Created with QT</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Fixes building on macOS via Xcode. I'm not sure if that's the correct fix - but it seems to build fine. However, the app still crashes if the PlugIn folder of a working copy isn't copied into the Jamulus.app/Contents folder - but that's another bug.

Found by testing and not verified to actually apply the optimizations. 

There's still an issue that we need to copy the PlugIns folder
CHANGELOG: MacOS: Fix building Jamulus via Xcode

**Context: Fixes an issue?**
Fixes: https://github.com/jamulussoftware/jamulus/issues/1841 (at least partly)

**Does this change need documentation? What needs to be documented and how?**
No
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready for review.
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Open another bug on the PlugIn bug.
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (not yet from this PR)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
