### PR TITLE
Build: Remove "wc -l" from Jamulus.pro

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -237,7 +237,13 @@ win32 {
 } else:android {
     ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
     ANDROID_VERSION_NAME = $$VERSION
-    ANDROID_VERSION_CODE = $$system(git log --oneline | wc -l)
+    # Used by Play Store
+    ANDROID_VERSION_CODE = 0
+    !contains(VERSION, .*dev.*) {
+        exists(".git/config") {
+            ANDROID_VERSION_CODE = $$size($$list($$system(git log --format=format:1,lines)))
+        }
+    }
     message("Setting ANDROID_VERSION_NAME=$${ANDROID_VERSION_NAME} ANDROID_VERSION_CODE=$${ANDROID_VERSION_CODE}")
 
     # liboboe requires C++17 for std::timed_mutex


### PR DESCRIPTION
**Short description of changes**

Currently, trying to build the Android version of Jamulus on a Windows PC under QtCreator fails because `Jamulus.pro` uses `wc -l` to create a value.  This change switches how the value is created to a `qmake` built-in function.

CHANGELOG: SKIP

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Windows build gets further.  I still can't generate an APK on either Windows or Linux using QtCreator, though, so we'll have to see what the build chain makes of it...

I've checked the APK built by Github with my change works.

**What is missing until this pull request can be merged?**

Clean build.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

AUTOBUILD: Please build all targets
