### PR TITLE
#2850 Remove --cleanuplegacyfadersettings command line option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -582,20 +582,6 @@ int main ( int argc, char** argv )
             continue;
         }
 
-        // Clean up legacy fader settings --------------------------------------
-        // Undocumented temporary command line argument: Clean up fader settings
-        // corrupted by bug #2680.  Only needs to be used once (per file).
-        if ( GetFlagArgument ( argv,
-                               i,
-                               "--cleanuplegacyfadersettings", // no short form
-                               "--cleanuplegacyfadersettings" ) )
-        {
-            qInfo() << "- will clean up legacy fader settings on load";
-            CommandLineOptions << "--cleanuplegacyfadersettings";
-            ClientOnlyOptions << "--cleanuplegacyfadersettings";
-            continue;
-        }
-
         // Unknown option ------------------------------------------------------
         qCritical() << qUtf8Printable ( QString ( "%1: Unknown option '%2' -- use '--help' for help" ).arg ( argv[0] ).arg ( argv[i] ) );
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -232,8 +232,6 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     int  iValue;
     bool bValue;
 
-    bCleanUpLegacyFaderSettings = CommandLineOptions.contains ( "--cleanuplegacyfadersettings" );
-
     // IP addresses
     for ( iIdx = 0; iIdx < MAX_NUM_SERVER_ADDR_ITEMS; iIdx++ )
     {
@@ -559,53 +557,6 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     ReadFaderSettingsFromXML ( IniXMLDocument );
 }
 
-QString CClientSettings::CleanUpLegacyFaderSetting ( QString strFaderTag, int iIdx )
-{
-    bool ok;
-    int  iIdy;
-    bool bDup;
-
-    if ( !bCleanUpLegacyFaderSettings || strFaderTag.isEmpty() )
-    {
-        return strFaderTag;
-    }
-
-    QStringList slChanFaderTag = strFaderTag.split ( ":" );
-    if ( slChanFaderTag.size() != 2 )
-    {
-        return strFaderTag;
-    }
-
-    const int iChan = slChanFaderTag[0].toInt ( &ok );
-    if ( ok && iChan >= 0 && iChan <= MAX_NUM_CHANNELS )
-    {
-        // *assumption*: legacy tag that needs cleaning up
-        strFaderTag = slChanFaderTag[1];
-    }
-
-    // duplicate detection
-    // this assumes the first entry into the vector is the newest one and skips any later ones.
-    // the alternative is to use iIdy for the vector entry, so overwriting the duplicate.
-    // (in both cases, this currently leaves holes in the vector.)
-    bDup = false;
-    for ( iIdy = 0; iIdy < iIdx; iIdy++ )
-    {
-        if ( strFaderTag == vecStoredFaderTags[iIdy] )
-        {
-            // duplicate entry
-            bDup = true;
-            break;
-        }
-    }
-    if ( bDup )
-    {
-        // so skip all settings for this iIdx (use iIdx here even if using iIdy and not doing continue below)
-        return QString();
-    }
-
-    return strFaderTag;
-}
-
 void CClientSettings::ReadFaderSettingsFromXML ( const QDomDocument& IniXMLDocument )
 {
     int  iIdx;
@@ -615,9 +566,8 @@ void CClientSettings::ReadFaderSettingsFromXML ( const QDomDocument& IniXMLDocum
     for ( iIdx = 0; iIdx < MAX_NUM_STORED_FADER_SETTINGS; iIdx++ )
     {
         // stored fader tags
-        QString strFaderTag = CleanUpLegacyFaderSetting (
-            FromBase64ToString ( GetIniSetting ( IniXMLDocument, "client", QString ( "storedfadertag%1_base64" ).arg ( iIdx ), "" ) ),
-            iIdx );
+        QString strFaderTag =
+            FromBase64ToString ( GetIniSetting ( IniXMLDocument, "client", QString ( "storedfadertag%1_base64" ).arg ( iIdx ), "" ) );
 
         if ( strFaderTag.isEmpty() )
         {

--- a/src/settings.h
+++ b/src/settings.h
@@ -165,7 +165,6 @@ public:
     int              iCustomDirectoryIndex; // index of selected custom directory
     bool             bEnableFeedbackDetection;
     bool             bEnableAudioAlerts;
-    bool             bCleanUpLegacyFaderSettings;
 
     // window position/state settings
     QByteArray vecWindowPosSettings;
@@ -179,9 +178,6 @@ public:
 protected:
     virtual void WriteSettingsToXML ( QDomDocument& IniXMLDocument ) override;
     virtual void ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, const QList<QString>& CommandLineOptions ) override;
-
-    // Code for #2680 clean up
-    QString CleanUpLegacyFaderSetting ( QString strFaderTag, int iIdx );
 
     void ReadFaderSettingsFromXML ( const QDomDocument& IniXMLDocument );
     void WriteFaderSettingsToXML ( QDomDocument& IniXMLDocument );


### PR DESCRIPTION
**Short description of changes**

Removes undocumented `--cleanuplegacyfadersettings` command line option.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes: #2850

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Tested

1.  Option no longer available:
```
$ ./Jamulus --cleanuplegacyfadersettings
./Jamulus: Unknown option '--cleanuplegacyfadersettings' -- use '--help' for help
```

2. `./Jamulus` after local build:

Before run:
```
 <storedfadertag0_base64>Tm8gTmFtZQ==</storedfadertag0_base64>
 <storedfadertag1_base64>QXllIE1pbiBIYW4=</storedfadertag1_base64>
 <storedfadertag2_base64>RGFuaWVsIEh0b28=</storedfadertag2_base64>
 <storedfadertag3_base64>SGFu</storedfadertag3_base64>
 <storedfadertag4_base64></storedfadertag4_base64>
 <storedfadertag5_base64></storedfadertag5_base64>
 <storedfadertag6_base64></storedfadertag6_base64>
```
Connected to a server, exited.

After run:
```
 <storedfadertag0_base64>Tm8gTmFtZQ==</storedfadertag0_base64>
 <storedfadertag1_base64>QXllIE1pbiBIYW4=</storedfadertag1_base64>
 <storedfadertag2_base64>RGFuaWVsIEh0b28=</storedfadertag2_base64>
 <storedfadertag3_base64>SGFu</storedfadertag3_base64>
 <storedfadertag4_base64></storedfadertag4_base64>
 <storedfadertag5_base64></storedfadertag5_base64>
 <storedfadertag6_base64></storedfadertag6_base64>
```

**What is missing until this pull request can be merged?**

Code review - deleting previously added code.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
