### PR TITLE
#2975 Headless _builds_ use fewer libraries

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -593,27 +593,45 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
                         "</font></p>" );
 
     // libraries used by this compilation
-    txvLibraries->setText (
-        tr ( "This app uses the following libraries, resources or code snippets:" ) + "<br><p>" + tr ( "Qt cross-platform application framework" ) +
-        ", <i><a href=\"https://www.qt.io\">https://www.qt.io</a></i></p>"
-        "<p>Opus Interactive Audio Codec"
-        ", <i><a href=\"https://www.opus-codec.org\">https://www.opus-codec.org</a></i></p>"
-#    if defined( _WIN32 ) && !defined( WITH_JACK )
-        "<p>ASIO (Audio Stream I/O) SDK"
-        ", <i><a href=\"https://www.steinberg.net/developers/\">https://www.steinberg.net/developers</a></i><br>" +
-        "ASIO is a trademark and software of Steinberg Media Technologies GmbH</p>"
+    txvLibraries->setText ( tr ( "This app uses the following libraries, resources or code snippets:" ) + "<p>" +
+                            tr ( "Qt cross-platform application framework" ) + QString ( " %1" ).arg ( QT_VERSION_STR ) +
+                            ", <i><a href=\"https://www.qt.io\">https://www.qt.io</a></i>"
+                            "</p>"
+                            "<p>"
+                            "Opus Interactive Audio Codec"
+                            ", <i><a href=\"https://www.opus-codec.org\">https://www.opus-codec.org</a></i>"
+                            "</p>"
+#    ifndef SERVER_ONLY
+#        if defined( _WIN32 ) && !defined( WITH_JACK )
+                            "<p>"
+                            "ASIO (Audio Stream I/O) SDK"
+                            ", <i><a href=\"https://www.steinberg.net/developers/\">https://www.steinberg.net/developers</a></i>"
+                            "<br>"
+                            "ASIO is a trademark and software of Steinberg Media Technologies GmbH"
+                            "</p>"
+#        endif
+#        ifndef HEADLESS
+                            "<p>" +
+                            tr ( "Audio reverberation code by Perry R. Cook and Gary P. Scavone" ) +
+                            ", 1995 - 2021"
+                            ", The Synthesis ToolKit in C++ (STK)"
+                            ", <i><a href=\"https://ccrma.stanford.edu/software/stk\">https://ccrma.stanford.edu/software/stk</a></i>"
+                            "</p>"
+                            "<p>" +
+                            QString ( tr ( "Some pixmaps are from the %1" ) ).arg ( "Open Clip Art Library (OCAL)" ) +
+                            ", <i><a href=\"https://openclipart.org\">https://openclipart.org</a></i>"
+                            "</p>"
+                            "<p>" +
+                            tr ( "Flag icons by Mark James" ) +
+                            ", <i><a href=\"http://www.famfamfam.com\">http://www.famfamfam.com</a></i>"
+                            "</p>"
+                            "<p>" +
+                            QString ( tr ( "Some sound samples are from %1" ) ).arg ( "Freesound" ) +
+                            ", <i><a href=\"https://freesound.org\">https://freesound.org</a></i>"
+                            "</p>"
+#        endif
 #    endif
-        "<p>" +
-        tr ( "Audio reverberation code by Perry R. Cook and Gary P. Scavone" ) +
-        ", 1995 - 2021, <i><a href=\"https://ccrma.stanford.edu/software/stk\">"
-        "The Synthesis ToolKit in C++ (STK)</a></i></p>"
-        "<p>" +
-        tr ( "Some pixmaps are from the" ) +
-        " Open Clip Art Library (OCAL), "
-        "<i><a href=\"https://openclipart.org\">https://openclipart.org</a></i></p>"
-        "<p>" +
-        tr ( "Flag icons by Mark James" ) + ", <i><a href=\"http://www.famfamfam.com\">http://www.famfamfam.com</a></i></p>" + "<p>" +
-        tr ( "Some sound samples are from" ) + " Freesound, " + "<i><a href=\"https://freesound.org\">https://freesound.org</a></i></p>" );
+    );
 
     // contributors list
     txvContributors->setText (
@@ -1705,31 +1723,38 @@ QString GetVersionAndNameStr ( const bool bDisplayInGui )
         strVersionText += "\n *** Foundation; either version 2 of the License, or (at your option) any later version.";
         strVersionText += "\n *** There is NO WARRANTY, to the extent permitted by law.";
         strVersionText += "\n *** ";
-        strVersionText += "\n *** Using the following libraries, resources or code snippets:";
+
+        strVersionText += "\n *** " + QCoreApplication::tr ( "This app uses the following libraries, resources or code snippets:" );
         strVersionText += "\n *** ";
-        strVersionText += QString ( "\n *** Qt framework %1" ).arg ( QT_VERSION_STR );
-        strVersionText += "\n *** <https://doc.qt.io/qt-5/lgpl.html>";
+        strVersionText += "\n *** " + QCoreApplication::tr ( "Qt cross-platform application framework" ) + QString ( " %1" ).arg ( QT_VERSION_STR );
+        strVersionText += "\n *** <https://www.qt.io>";
         strVersionText += "\n *** ";
         strVersionText += "\n *** Opus Interactive Audio Codec";
         strVersionText += "\n *** <https://www.opus-codec.org>";
         strVersionText += "\n *** ";
-#if defined( _WIN32 ) && !defined( WITH_JACK )
+#ifndef SERVER_ONLY
+#    if defined( _WIN32 ) && !defined( WITH_JACK )
         strVersionText += "\n *** ASIO (Audio Stream I/O) SDK";
         strVersionText += "\n *** <https://www.steinberg.net/developers>";
+        strVersionText += "\n *** ASIO is a trademark and software of Steinberg Media Technologies GmbH";
         strVersionText += "\n *** ";
-#endif
-        strVersionText += "\n *** Audio reverberation code by Perry R. Cook and Gary P. Scavone";
+#    endif
+#    ifndef HEADLESS
+        strVersionText += "\n *** " + QCoreApplication::tr ( "Audio reverberation code by Perry R. Cook and Gary P. Scavone" ) +
+                          ", 1995 - 2021, The Synthesis ToolKit in C++ (STK)";
         strVersionText += "\n *** <https://ccrma.stanford.edu/software/stk>";
         strVersionText += "\n *** ";
-        strVersionText += "\n *** Some pixmaps are from the Open Clip Art Library (OCAL)";
+        strVersionText += "\n *** " + QString ( QCoreApplication::tr ( "Some pixmaps are from the %1" ) ).arg ( " Open Clip Art Library (OCAL)" );
         strVersionText += "\n *** <https://openclipart.org>";
         strVersionText += "\n *** ";
-        strVersionText += "\n *** Flag icons by Mark James";
+        strVersionText += "\n *** " + QCoreApplication::tr ( "Flag icons by Mark James" );
         strVersionText += "\n *** <http://www.famfamfam.com>";
         strVersionText += "\n *** ";
-        strVersionText += "\n *** Some sound samples are from Freesound";
+        strVersionText += "\n *** " + QString ( QCoreApplication::tr ( "Some sound samples are from %1" ) ).arg ( "Freesound" );
         strVersionText += "\n *** <https://freesound.org>";
         strVersionText += "\n *** ";
+#    endif
+#endif
         strVersionText += "\n *** Copyright © 2005-2023 The Jamulus Development Team";
         strVersionText += "\n";
     }


### PR DESCRIPTION
**Short description of changes**

1. Removes acknowledgements for libraries _not used_ when `CONFIG+="headless"` is used
2. Reorganise GUI acknowledgements to be more consistent
3. Add some additional translation (using existing strings) to non-GUI start up log

CHANGELOG: Improved start up logging

**Context: Fixes an issue?**

Fixes: 2975

**Does this change need documentation? What needs to be documented and how?**

Possibly there are examples of start up that might change.  Needs checking.

**Status of this Pull Request**

Tested locally:

Non-headless build:

1. GUI client:
```
$ ./Jamulus
- allocated port number: 22134
Connecting to JACK "default" instance (use the JACK_DEFAULT_SERVER environment variable to change this).
```
2. Non-GUI client:
```
$ ./Jamulus -n
- no GUI mode chosen
- allocated port number: 22134
Connecting to JACK "default" instance (use the JACK_DEFAULT_SERVER environment variable to change this).
 *** Jamulus, Version 3.9.1dev-2260dc49-dirty
 *** Internet Jam Session Software
 *** Released under the GNU General Public License version 2 or later (GPLv2)
 *** <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
 ***
 *** This program is free software; you can redistribute it and/or modify it under
 *** the terms of the GNU General Public License as published by the Free Software
 *** Foundation; either version 2 of the License, or (at your option) any later version.
 *** There is NO WARRANTY, to the extent permitted by law.
 ***
 *** This app uses the following libraries, resources or code snippets:
 ***
 *** Qt cross-platform application framework 6.5.2
 *** <https://www.qt.io>
 ***
 *** Opus Interactive Audio Codec
 *** <https://www.opus-codec.org>
 ***
 *** Audio reverberation code by Perry R. Cook and Gary P. Scavone, 1995 - 2021, The Synthesis ToolKit in C++ (STK)
 *** <https://ccrma.stanford.edu/software/stk>
 ***
 *** Some pixmaps are from the Open Clip Art Library (OCAL)
 *** <https://openclipart.org>
 ***
 *** Flag icons by Mark James
 *** <http://www.famfamfam.com>
 ***
 *** Some sound samples are from Freesound
 *** <https://freesound.org>
 ***
 *** Copyright © 2005-2023 The Jamulus Development Team
```
3. GUI server:
```
$ ./Jamulus -s -p 60000
- server mode chosen
- selected port number: 60000
Using "192.168.1.19" as external IP.
Recording state not initialised
Recording state: enabled
```
4. Non-GUI server:
```
$ ./Jamulus -s -p 60000 -n
- server mode chosen
- selected port number: 60000
- no GUI mode chosen
Using "192.168.1.19" as external IP.
Recording state not initialised
 *** Jamulus, Version 3.9.1dev-2260dc49-dirty
 *** Internet Jam Session Software
 *** Released under the GNU General Public License version 2 or later (GPLv2)
 *** <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
 ***
 *** This program is free software; you can redistribute it and/or modify it under
 *** the terms of the GNU General Public License as published by the Free Software
 *** Foundation; either version 2 of the License, or (at your option) any later version.
 *** There is NO WARRANTY, to the extent permitted by law.
 ***
 *** This app uses the following libraries, resources or code snippets:
 ***
 *** Qt cross-platform application framework 6.5.2
 *** <https://www.qt.io>
 ***
 *** Opus Interactive Audio Codec
 *** <https://www.opus-codec.org>
 ***
 *** Audio reverberation code by Perry R. Cook and Gary P. Scavone, 1995 - 2021, The Synthesis ToolKit in C++ (STK)
 *** <https://ccrma.stanford.edu/software/stk>
 ***
 *** Some pixmaps are from the Open Clip Art Library (OCAL)
 *** <https://openclipart.org>
 ***
 *** Flag icons by Mark James
 *** <http://www.famfamfam.com>
 ***
 *** Some sound samples are from Freesound
 *** <https://freesound.org>
 ***
 *** Copyright © 2005-2023 The Jamulus Development Team
````

Headless build:

1. GUI / non-GUI client:
```
$ ./Jamulus
No GUI support compiled. Running in headless mode.
- allocated port number: 22134
Connecting to JACK "default" instance (use the JACK_DEFAULT_SERVER environment variable to change this).
 *** Jamulus, Version 3.9.1dev-d857b04f
 *** Internet Jam Session Software
 *** Released under the GNU General Public License version 2 or later (GPLv2)
 *** <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
 ***
 *** This program is free software; you can redistribute it and/or modify it under
 *** the terms of the GNU General Public License as published by the Free Software
 *** Foundation; either version 2 of the License, or (at your option) any later version.
 *** There is NO WARRANTY, to the extent permitted by law.
 ***
 *** This app uses the following libraries, resources or code snippets:
 ***
 *** Qt cross-platform application framework 6.5.2
 *** <https://www.qt.io>
 ***
 *** Opus Interactive Audio Codec
 *** <https://www.opus-codec.org>
 ***
 *** Audio reverberation code by Perry R. Cook and Gary P. Scavone, 1995 - 2021, The Synthesis ToolKit in C++ (STK)
 *** <https://ccrma.stanford.edu/software/stk>
 ***
 *** Copyright © 2005-2023 The Jamulus Development Team
```
2. GUI / non-GUI server
```
$ ./Jamulus -s -p 60000
- server mode chosen
- selected port number: 60000
No GUI support compiled. Running in headless mode.
Using "192.168.1.19" as external IP.
Recording state not initialised
 *** Jamulus, Version 3.9.1dev-d857b04f
 *** Internet Jam Session Software
 *** Released under the GNU General Public License version 2 or later (GPLv2)
 *** <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
 ***
 *** This program is free software; you can redistribute it and/or modify it under
 *** the terms of the GNU General Public License as published by the Free Software
 *** Foundation; either version 2 of the License, or (at your option) any later version.
 *** There is NO WARRANTY, to the extent permitted by law.
 ***
 *** This app uses the following libraries, resources or code snippets:
 ***
 *** Qt cross-platform application framework 6.5.2
 *** <https://www.qt.io>
 ***
 *** Opus Interactive Audio Codec
 *** <https://www.opus-codec.org>
 ***
 *** Audio reverberation code by Perry R. Cook and Gary P. Scavone, 1995 - 2021, The Synthesis ToolKit in C++ (STK)
 *** <https://ccrma.stanford.edu/software/stk>
 ***
 *** Copyright © 2005-2023 The Jamulus Development Team
```

The removed section reads:
```
 *** Audio reverberation code by Perry R. Cook and Gary P. Scavone, 1995 - 2021, The Synthesis ToolKit in C++ (STK)
 *** <https://ccrma.stanford.edu/software/stk>
 ***
 *** Some pixmaps are from the Open Clip Art Library (OCAL)
 *** <https://openclipart.org>
 ***
 *** Flag icons by Mark James
 *** <http://www.famfamfam.com>
 ***
 *** Some sound samples are from Freesound
 *** <https://freesound.org>
 ***
```

**What is missing until this pull request can be merged?**

* Review
* Check translated versions??

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
