### PR TITLE
#1420 Fader Settings improvements

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -298,9 +298,17 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // Edit menu  --------------------------------------------------------------
     QMenu* pEditMenu = new QMenu ( tr ( "&Edit" ), this );
 
-    pEditMenu->addAction ( tr ( "Clear &All Stored Solo and Mute Settings" ), this, SLOT ( OnClearAllStoredSoloMuteSettings() ) );
+    QMenu* pFaderMenu = new QMenu ( tr ( "Stored &Fader Settings" ), this );
 
-    pEditMenu->addAction ( tr ( "Set All Faders to New Client &Level" ),
+    pEditMenu->addMenu ( pFaderMenu );
+
+    pFaderMenu->addAction ( tr ( "Clear &All Stored Fader Settings" ), this, SLOT ( OnClearFaderAllSettings() ) );
+    pFaderMenu->addAction ( tr ( "Clear Stored &Level Settings" ), this, SLOT ( OnClearFaderLevelSettings() ) );
+    pFaderMenu->addAction ( tr ( "Clear Stored &Solo Settings" ), this, SLOT ( OnClearFaderSoloSettings() ) );
+    pFaderMenu->addAction ( tr ( "Clear Stored &Mute Settings" ), this, SLOT ( OnClearFaderMuteSettings() ) );
+    pFaderMenu->addAction ( tr ( "Clear Stored &Group ID Settings" ), this, SLOT ( OnClearFaderGroupIdSettings() ) );
+
+    pEditMenu->addAction ( tr ( "Set Current Faders to New Client &Level" ),
                            this,
                            SLOT ( OnSetAllFadersToNewClientLevel() ),
                            QKeySequence ( Qt::CTRL + Qt::Key_L ) );
@@ -767,13 +775,44 @@ void CClientDlg::OnConnectDisconBut()
     }
 }
 
-void CClientDlg::OnClearAllStoredSoloMuteSettings()
+// if we are in an active connection, we first have to store all fader settings in
+// the settings struct, clear the solo and mute states and then apply the settings again
+void CClientDlg::OnClearFaderAllSettings()
 {
-    // if we are in an active connection, we first have to store all fader settings in
-    // the settings struct, clear the solo and mute states and then apply the settings again
     MainMixerBoard->StoreAllFaderSettings();
+    pSettings->vecStoredFaderLevels.Reset ( false );
+    pSettings->vecStoredFaderLevels.Reset ( false );
     pSettings->vecStoredFaderIsSolo.Reset ( false );
     pSettings->vecStoredFaderIsMute.Reset ( false );
+    pSettings->vecStoredFaderTags.Reset ( QString() );
+    MainMixerBoard->LoadAllFaderSettings();
+}
+
+void CClientDlg::OnClearFaderLevelSettings()
+{
+    MainMixerBoard->StoreAllFaderSettings();
+    pSettings->vecStoredFaderLevels.Reset ( false );
+    MainMixerBoard->LoadAllFaderSettings();
+}
+
+void CClientDlg::OnClearFaderSoloSettings()
+{
+    MainMixerBoard->StoreAllFaderSettings();
+    pSettings->vecStoredFaderIsSolo.Reset ( false );
+    MainMixerBoard->LoadAllFaderSettings();
+}
+
+void CClientDlg::OnClearFaderMuteSettings()
+{
+    MainMixerBoard->StoreAllFaderSettings();
+    pSettings->vecStoredFaderIsMute.Reset ( false );
+    MainMixerBoard->LoadAllFaderSettings();
+}
+
+void CClientDlg::OnClearFaderGroupIdSettings()
+{
+    MainMixerBoard->StoreAllFaderSettings();
+    pSettings->vecStoredFaderGroupID.Reset ( false );
     MainMixerBoard->LoadAllFaderSettings();
 }
 

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -175,9 +175,15 @@ public slots:
     void OnSortChannelsByGroupID() { MainMixerBoard->SetFaderSorting ( ST_BY_GROUPID ); }
     void OnSortChannelsByCity() { MainMixerBoard->SetFaderSorting ( ST_BY_CITY ); }
     void OnSortChannelsByChannel() { MainMixerBoard->SetFaderSorting ( ST_BY_SERVER_CHANNEL ); }
-    void OnClearAllStoredSoloMuteSettings();
+
+    void OnClearFaderAllSettings();
+    void OnClearFaderLevelSettings();
+    void OnClearFaderSoloSettings();
+    void OnClearFaderMuteSettings();
+    void OnClearFaderGroupIdSettings();
     void OnSetAllFadersToNewClientLevel() { MainMixerBoard->SetAllFaderLevelsToNewClientLevel(); }
     void OnAutoAdjustAllFaderLevels() { MainMixerBoard->AutoAdjustAllFaderLevels(); }
+
     void OnNumMixerPanelRowsChanged ( int value ) { MainMixerBoard->SetNumMixerPanelRows ( value ); }
 
     void OnSettingsStateChanged ( int value );


### PR DESCRIPTION
**Short description of changes**

Two changes relating to #1420:

* Edit -> Set All Faders to New Client Level
This retained the last known level for any client, so when that client rejoined the server, their old level was restored
![image](https://github.com/jamulussoftware/jamulus/assets/1549463/150029ca-1839-42cf-9797-5acfd3697e58)
This has been reworded to make its behaviour clear
![image](https://github.com/jamulussoftware/jamulus/assets/1549463/731d8b5f-f182-43cb-9ada-60fa866f8e78)
"Set Current Faders to New Client Level" will be the behaviour that is intended - it will not take any stored fader levels into account.  (Of course, these fader levels will then apply should a "current" client leave and rejoin.)

* Edit -> Stored Fader Settings
This new sub-menu replaces "Clear All Stored Solo and Mute Settings" and adds finer-grained control, including allowing all settings to be purged:
![image](https://github.com/jamulussoftware/jamulus/assets/1549463/a9fce7b0-e1d9-4446-bc33-33ce2e248b54)
![image](https://github.com/jamulussoftware/jamulus/assets/1549463/84c027c9-163e-41ce-acd0-12a25d798455)

CHANGELOG: Client: Fader Settings improvements

**Context: Fixes an issue?**

Fixes: #1420 

**Does this change need documentation? What needs to be documented and how?**

Yes!
- App translations are affected
- Site documentation is affected

**Status of this Pull Request**

It runs and looks okay.  I don't generally worry about stored fader settings, so I've not got much to test on.  It could do with several people who use the feature heavily looking at it.

@pgScorpio, hopefully this is what you were after.

**What is missing until this pull request can be merged?**

* [ ] Code review.
* [ ] More testing by people who use the feature.
* [ ] Usability feedback.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
