### PR TITLE
Fixes #1421: Add "delete server" button to connect dialog

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -96,6 +96,11 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     cbxServerAddr->setAccessibleName ( tr ( "Server address edit box" ) );
     cbxServerAddr->setAccessibleDescription ( tr ( "Holds the current server address. It also stores old addresses in the combo box list." ) );
 
+    butDeleteServerAddr->setAccessibleName ( tr ( "Delete server address button" ) );
+    butDeleteServerAddr->setWhatsThis ( "<b>" + tr ( "Delete Server Address" ) + ":</b> " +
+                                        tr ( "Click the button to clear the currently selected server address "
+                                             "and delete it from the list of stored servers." ) );
+
     UpdateDirectoryComboBox();
 
     // init server address combo box (max MAX_NUM_SERVER_ADDR_ITEMS entries)
@@ -178,6 +183,9 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     QObject::connect ( butCancel, &QPushButton::clicked, this, &CConnectDlg::close );
 
     QObject::connect ( butConnect, &QPushButton::clicked, this, &CConnectDlg::OnConnectClicked );
+
+    // tool buttons
+    QObject::connect ( butDeleteServerAddr, &QPushButton::clicked, this, &CConnectDlg::OnDeleteServerAddrClicked );
 
     // timers
     QObject::connect ( &TimerPing, &QTimer::timeout, this, &CConnectDlg::OnTimerPing );
@@ -729,6 +737,31 @@ void CConnectDlg::OnConnectClicked()
 
     // tell the parent window that the connection shall be initiated
     done ( QDialog::Accepted );
+}
+
+void CConnectDlg::OnDeleteServerAddrClicked()
+{
+    if ( cbxServerAddr->currentText().isEmpty() )
+    {
+        return;
+    }
+
+    // move later items down one
+    for ( int iLEIdx = 0; iLEIdx < MAX_NUM_SERVER_ADDR_ITEMS - 1; iLEIdx++ )
+    {
+        while ( pSettings->vstrIPAddress[iLEIdx].compare ( cbxServerAddr->currentText() ) == 0 )
+        {
+            for ( int jLEIdx = iLEIdx + 1; jLEIdx < MAX_NUM_SERVER_ADDR_ITEMS; jLEIdx++ )
+            {
+                pSettings->vstrIPAddress[jLEIdx - 1] = pSettings->vstrIPAddress[jLEIdx];
+            }
+        }
+    }
+    // empty last entry
+    pSettings->vstrIPAddress[MAX_NUM_SERVER_ADDR_ITEMS - 1] = QString();
+
+    // redisplay to pick up updated list
+    showEvent ( nullptr );
 }
 
 void CConnectDlg::OnTimerPing()

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -101,6 +101,7 @@ public slots:
     void OnExpandAllStateChanged ( int value ) { ShowAllMusicians ( value == Qt::Checked ); }
     void OnCustomDirectoriesChanged();
     void OnConnectClicked();
+    void OnDeleteServerAddrClicked();
     void OnTimerPing();
     void OnTimerReRequestServList();
 

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -107,6 +107,30 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="butDeleteServerAddr">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Ignored">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>24</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string notr="true">⌫</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
**Short description of changes**

Adds a "delete server" tool button to the connect dialog, in the same style as the server dialog, to delete the currently selected server.  There's no "undo".
![image](https://github.com/jamulussoftware/jamulus/assets/1549463/d0fa5aea-7f10-4a6a-a454-b9221b3e724a)

Selected server gets deleted.  Next server in list is then current in field.  On exit, the updated list is saved.

CHANGELOG: Add "delete server" button to connect dialog

**Context: Fixes an issue?**

Fixes #1421

**Does this change need documentation? What needs to be documented and how?**

Yes - screenshots and translation strings need updating.

**Status of this Pull Request**

Tested locally and appears to work as expected.

**What is missing until this pull request can be merged?**

Code and UI review.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
