### PR TITLE
Fix overflow warnings from loop index #3161

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1249,7 +1249,7 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
         }
     }
 
-    for ( i = 0; i < iSndCrdFrameSizeFactor; i++ )
+    for ( i = 0, j = 0; i < iSndCrdFrameSizeFactor; i++, j += iNumAudioChannels * iOPUSFrameSizeSamples )
     {
         // OPUS encoding
         if ( CurOpusEncoder != nullptr )
@@ -1257,7 +1257,7 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
             if ( bMuteOutStream )
             {
                 iUnused = opus_custom_encode ( CurOpusEncoder,
-                                               &vecZeros[i * iNumAudioChannels * iOPUSFrameSizeSamples],
+                                               &vecZeros[j],
                                                iOPUSFrameSizeSamples,
                                                &vecCeltData[0],
                                                iCeltNumCodedBytes );
@@ -1265,7 +1265,7 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
             else
             {
                 iUnused = opus_custom_encode ( CurOpusEncoder,
-                                               &vecsStereoSndCrd[i * iNumAudioChannels * iOPUSFrameSizeSamples],
+                                               &vecsStereoSndCrd[j],
                                                iOPUSFrameSizeSamples,
                                                &vecCeltData[0],
                                                iCeltNumCodedBytes );
@@ -1283,7 +1283,7 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
         vecsStereoSndCrdMuteStream = vecsStereoSndCrd;
     }
 
-    for ( i = 0; i < iSndCrdFrameSizeFactor; i++ )
+    for ( i = 0, j = 0; i < iSndCrdFrameSizeFactor; i++, j += iNumAudioChannels * iOPUSFrameSizeSamples )
     {
         // receive a new block
         const bool bReceiveDataOk = ( Channel.GetData ( vecbyNetwData, iCeltNumCodedBytes ) == GS_BUFFER_OK );
@@ -1311,7 +1311,7 @@ void CClient::ProcessAudioDataIntern ( CVector<int16_t>& vecsStereoSndCrd )
             iUnused = opus_custom_decode ( CurOpusDecoder,
                                            pCurCodedData,
                                            iCeltNumCodedBytes,
-                                           &vecsStereoSndCrd[i * iNumAudioChannels * iOPUSFrameSizeSamples],
+                                           &vecsStereoSndCrd[j],
                                            iOPUSFrameSizeSamples );
         }
     }


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Intended to resolve CodeQL messages "Multiplication result converted to larger type".

CHANGELOG: Client: (Refactor) Prevent multiplication result converting to larger type

**Context: Fixes an issue?**

Fixes: #3161 
This fix is an alternative to the PR #3162, and arguably slightly more efficient. It avoids the use of casts.

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Need to assess the autobuild output.

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
