### PR TITLE
Update jamulus-headless.service

### DIFF
--- a/linux/debian/jamulus-headless.service
+++ b/linux/debian/jamulus-headless.service
@@ -16,8 +16,7 @@ IOSchedulingPriority=0
 
 #### Change this to publish this server, set genre, location and other parameters.
 #### See https://jamulus.io/wiki/Command-Line-Options ####
-ExecStart=/bin/sh -c 'exec /usr/bin/jamulus-headless -s -n'
-
+ExecStart=/usr/bin/jamulus-headless -s -n
 
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
This should be sufficient but feel free to improve if I've missed something.

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

The program was being executed indirectly via a call from a bash shell. This shell was also intercepting SIGUSR2 signals used to start/stop recording from the command line per https://github.com/jamulussoftware/jamulus/issues/1515#issuecomment-819577918
This change updates the systemd service file to execute the program directly instead of from inside a shell.

CHANGELOG: Replace old program initialization that broke start/stop recording via command line with a direct call to the executable.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
