### PR TITLE
create an empty default welcome file

### DIFF
--- a/linux/debian/jamulus-headless.postinst
+++ b/linux/debian/jamulus-headless.postinst
@@ -6,7 +6,7 @@ set -e
 
 adduser --system --quiet --home /nonexistent --no-create-home jamulus
 
-sudo mkdir /etc/jamulus
+sudo mkdir -p /etc/jamulus
 sudo touch /etc/jamulus/welcome.html
 
 #DEBHELPER#

--- a/linux/debian/jamulus-headless.postinst
+++ b/linux/debian/jamulus-headless.postinst
@@ -8,5 +8,6 @@ adduser --system --quiet --home /nonexistent --no-create-home jamulus
 
 sudo mkdir -p /etc/jamulus
 sudo touch /etc/jamulus/welcome.html
+chmod a+r /etc/jamulus/welcome.html
 
 #DEBHELPER#

--- a/linux/debian/jamulus-headless.postinst
+++ b/linux/debian/jamulus-headless.postinst
@@ -6,4 +6,7 @@ set -e
 
 adduser --system --quiet --home /nonexistent --no-create-home jamulus
 
+mkdir /etc/jamulus
+touch /etc/jamulus/welcome.html
+
 #DEBHELPER#

--- a/linux/debian/jamulus-headless.postinst
+++ b/linux/debian/jamulus-headless.postinst
@@ -6,7 +6,7 @@ set -e
 
 adduser --system --quiet --home /nonexistent --no-create-home jamulus
 
-mkdir /etc/jamulus
-touch /etc/jamulus/welcome.html
+sudo mkdir /etc/jamulus
+sudo touch /etc/jamulus/welcome.html
 
 #DEBHELPER#

--- a/linux/debian/jamulus-headless.service
+++ b/linux/debian/jamulus-headless.service
@@ -16,7 +16,7 @@ IOSchedulingPriority=0
 
 #### Change this to publish this server, set genre, location and other parameters.
 #### See https://jamulus.io/wiki/Command-Line-Options ####
-ExecStart=/usr/bin/jamulus-headless -s -n
+ExecStart=/usr/bin/jamulus-headless -s -n -w /etc/jamulus/welcome.html
 
 Restart=on-failure
 RestartSec=30


### PR DESCRIPTION
With this change, a Debian installation will create an empty /etc/jamulus/welcome.html file and specify it as the welcome file in the systemd default configuration.

https://github.com/orgs/jamulussoftware/discussions/3086#discussioncomment-6248420

## Checklist

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
