### PR TITLE
Test for Ubuntu and Ubuntu version

### DIFF
--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -20,9 +20,10 @@ fi;
 
 if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
     echo "Your apt version is incompatible. You may not be able install this repository. "
-    echo "See issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
+    echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
+    echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
     echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
-    echo "Do you wish to install anyway?"
+    echo "Do you wish to attempt to install the repository anyway?"
     select yn in "Yes" "No"; do
         case $yn in
             Yes ) 

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -26,7 +26,7 @@ else
 fi;
 
 if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.4" | bc -l) )); then
-    echo "Apt version incompatible."
+    echo "Apt version incompatible. Cannot install repository, but you can use the .deb package to manually install."
     exit 1
 fi;
 

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -11,8 +11,8 @@ fi
 # Issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095
 
 if APT_VERSION="$(apt --version)"; then
-    APT_MAJOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 1)
-    APT_MINOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 2)
+    APT_MAJOR=$(echo "$APT_VERSION"| cut -d' ' -f 2 | cut -d'.' -f 1)
+    APT_MINOR=$(echo "$APT_VERSION"| cut -d' ' -f 2 | cut -d'.' -f 2)
 else
     echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
     exit 1

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -27,14 +27,14 @@ if (($(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l))); then
     echo "(not recommended, as you might need to fix your apt configuration)"
     select yn in "Yes" "No"; do
         case $yn in
-           Yes)
-              echo "Proceeding with override. You have been warned!"
-              break
-              ;;
+            Yes)
+                echo "Proceeding with override. You have been warned!"
+                break
+                ;;
             No)
-              echo "Exiting."
-              exit 0
-              ;;
+                echo "Exiting."
+                exit 0
+                ;;
         esac
     done
 fi

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -18,7 +18,7 @@ else
     exit 1
 fi
 
-if (($(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l))); then
+if [[ ${APT_MAJOR} -lt 2 || ( ${APT_MAJOR} -eq 2 && ${APT_MINOR} -lt 2 ) ]]; then
     echo "Your apt version is incompatible. You may not be able install this repository. "
     echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
     echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -33,7 +33,7 @@ if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
             ;;
             No ) 
             echo "Exiting."
-            exit 1
+            exit 0
             ;;
         esac
     done

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -11,9 +11,9 @@ fi
 
 apt --version > /dev/null
 if [[ $? -eq 0 ]]; then
-    APT_VERSION=`apt --version`
-    APT_MAJOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 1)
-    APT_MINOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 2)
+    APT_VERSION=$(apt --version)
+    APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
+    APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
     echo "Apt version: ${APT_VERSION}"
 else
     echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -44,7 +44,7 @@ KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc
 GITHUB_REPOSITORY="jamulussoftware/jamulus"
 
 echo "Setting up Jamulus repo at ${REPO_FILE}..."
-echo "deb https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/ ./" >${REPO_FILE}
+echo "deb https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/ ./" > ${REPO_FILE}
 echo "Installing Jamulus GPG key at ${KEY_FILE}..."
 curl --fail --show-error -sLo "${KEY_FILE}" https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/key.asc
 

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -7,8 +7,6 @@ if [[ ${EUID} -ne 0 ]]; then
      exit 1
 fi
 
-# Test for Ubuntu version
-
 if [ -x "$(command -v lsb_release)" ]; then
     ISUBUNTU=`lsb_release -is`
 else
@@ -17,22 +15,26 @@ else
 fi;
 
 if [[ $ISUBUNTU == "Ubuntu" ]]; then
-
     UBUNTU_VERSION=`lsb_release -sr`
     echo "Ubuntu version: ${UBUNTU_VERSION}"
-
     SUBSTRING=$(echo $UBUNTU_VERSION| cut -d'.' -f 1)
+else
+    echo "This is not Ubuntu"
+    # Could test for Debian here, or issue a prompt Continue at your own risk y/N?
+    exit 1
+fi;
 
-    if [[ $SUBSTRING -lt 22 ]]; then
+
+if [[ $SUBSTRING -lt 22 ]]; then
 cat << EOM
 WARNING: Ubuntu versions less that 22.04 have a bug in their apt version for signed repositories.
 Not adding jamulus repo. Either install the deb file manually [see https://jamulus.io/wiki/Installation-for-Linux]
 or update your system to at least Ubuntu 22.04
 EOM
     exit 1
-    fi;
 fi;
 
+# We have an acceptable Ubuntu version, continuing
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
 KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -3,41 +3,40 @@
 # This script installs a Jamulus repository to Debian based systems
 
 if [[ ${EUID} -ne 0 ]]; then
-    echo "Error: This script must be run as root."
-    exit 1
+	echo "Error: This script must be run as root."
+	exit 1
 fi
 
 # Check for apt version >= 2.2.0 (if found, assuming Debian-based compatible with repo)
 # Issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095
 
 if APT_VERSION="$(apt --version)"; then
-    APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
-    APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
+	APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
+	APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
 else
-    echo "This script is only compatible with Debian based distributions which have apt."
-    echo "It seems apt is not available. Please check that your OS is supported."
-    exit 1
+	echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
+	exit 1
 fi
 
 if (($(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l))); then
-    echo "Your apt version is incompatible. You may not be able install this repository. "
-    echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
-    echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
-    echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
-    echo "Do you wish to attempt to install the repository anyway?"
-    echo "(not recommended, as you might need to fix your apt configuration)"
-    select yn in "Yes" "No"; do
-        case $yn in
-        Yes)
-            echo "Proceeding with override. You have been warned!"
-            break
-            ;;
-        No)
-            echo "Exiting."
-            exit 0
-            ;;
-        esac
-    done
+	echo "Your apt version is incompatible. You may not be able install this repository. "
+	echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
+	echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
+	echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
+	echo "Do you wish to attempt to install the repository anyway?"
+	echo "(not recommended, as you might need to fix your apt configuration)"
+	select yn in "Yes" "No"; do
+		case $yn in
+		Yes)
+			echo "Proceeding with override. You have been warned!"
+			break
+			;;
+		No)
+			echo "Exiting."
+			exit 0
+			;;
+		esac
+	done
 fi
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
@@ -51,8 +50,8 @@ curl --fail --show-error -sLo "${KEY_FILE}" https://github.com/${GITHUB_REPOSITO
 
 CURL_EXITCODE=$?
 if [[ ${CURL_EXITCODE} -ne 0 ]]; then
-    echo "Error: Download of gpg key failed. Please try again later."
-    exit ${CURL_EXITCODE}
+	echo "Error: Download of gpg key failed. Please try again later."
+	exit ${CURL_EXITCODE}
 fi
 
 echo "Running apt update..."

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -9,12 +9,9 @@ fi
 
 # Check for apt version >= 2.4.0 (if found, assuming Debian-based compatible with repo)
 
-apt --version > /dev/null
-if [[ $? -eq 0 ]]; then
-    APT_VERSION=$(apt --version)
-    APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
-    APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
-    echo "Apt version: ${APT_VERSION}"
+if APT_VERSION="$(apt --version)"; then
+    APT_MAJOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 1)
+    APT_MINOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 2)
 else
     echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
     exit 1

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -8,9 +8,14 @@ if [[ ${EUID} -ne 0 ]]; then
 fi
 
 # Test for Ubuntu version
-ISUBUNTU=`lsb_release -is`
 
-if [[ $ISUBUNTU -eq "Ubuntu" ]]; then
+if [ -x "$(command -v lsb_release)" ]; then
+    ISUBUNTU=`lsb_release -is`
+else
+    echo "lsb_release not found. Cannot determine Linux distribution (or this is not Linux)."
+fi;
+
+if [[ $ISUBUNTU == "Ubuntu" ]]; then
 
     UBUNTU_VERSION=`lsb_release -sr`
     echo "Ubuntu version: ${UBUNTU_VERSION}"
@@ -23,9 +28,10 @@ WARNING: Ubuntu versions less that 22.04 have a bug in their apt version for sig
 Not adding jamulus repo. Either install the deb file manually [see https://jamulus.io/wiki/Installation-for-Linux]
 or update your system to at least Ubuntu 22.04
 EOM
-    exit 1 
+    exit 1
     fi;
 fi;
+
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
 KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -21,7 +21,7 @@ else
 fi;
 
 if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.4" | bc -l) )); then
-    echo "Apt version incompatible. Cannot install repository, but you can use the .deb package to manually install."
+    echo "Your apt version is incompatible. You cannot install this repository. Please update your OS or use the .deb package from the Website to manually install Jamulus."
     exit 1
 fi;
 

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -14,6 +14,22 @@ else
     exit 1
 fi;
 
+apt --version > /dev/null
+if [[ $? -eq 0 ]]; then
+    APT_VERSION=`apt --version`
+    APT_MAJOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 1)
+    APT_MINOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 2)
+    echo "Apt version: ${APT_VERSION}"
+else
+    echo "Apt is not available."
+    exit 1
+fi;
+
+if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.4" | bc -l) )); then
+    echo "Apt version incompatible."
+    exit 1
+fi;
+
 if [[ $ISUBUNTU == "Ubuntu" ]]; then
 
     UBUNTU_VERSION=`lsb_release -sr`

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -7,6 +7,26 @@ if [[ ${EUID} -ne 0 ]]; then
      exit 1
 fi
 
+# Test for Ubuntu version
+ISUBUNTU=`lsb_release -is`
+
+if [[ $ISUBUNTU -eq "Ubuntu" ]]; then
+
+    UBUNTU_VERSION=`lsb_release -sr`
+    echo "Ubuntu version: ${UBUNTU_VERSION}"
+
+    SUBSTRING=$(echo $UBUNTU_VERSION| cut -d'.' -f 1)
+
+    if [[ $SUBSTRING -lt 22 ]]; then
+cat << EOM
+WARNING: Ubuntu versions less that 22.04 have a bug in their apt version for signed repositories.
+Not adding jamulus repo. Either install the deb file manually [see https://jamulus.io/wiki/Installation-for-Linux]
+or update your system to at least Ubuntu 22.04
+EOM
+    exit 1 
+    fi;
+fi;
+
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
 KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc
 GITHUB_REPOSITORY="jamulussoftware/jamulus"

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -16,7 +16,7 @@ if [[ $? -eq 0 ]]; then
     APT_MINOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 2)
     echo "Apt version: ${APT_VERSION}"
 else
-    echo "Apt is not available."
+    echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
     exit 1
 fi;
 

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -3,22 +3,23 @@
 # This script installs a Jamulus repository to Debian based systems
 
 if [[ ${EUID} -ne 0 ]]; then
-     echo "Error: This script must be run as root."
-     exit 1
+    echo "Error: This script must be run as root."
+    exit 1
 fi
 
 # Check for apt version >= 2.2.0 (if found, assuming Debian-based compatible with repo)
 # Issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095
 
 if APT_VERSION="$(apt --version)"; then
-    APT_MAJOR=$(echo "$APT_VERSION"| cut -d' ' -f 2 | cut -d'.' -f 1)
-    APT_MINOR=$(echo "$APT_VERSION"| cut -d' ' -f 2 | cut -d'.' -f 2)
+    APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
+    APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
 else
-    echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
+    echo "This script is only compatible with Debian based distributions which have apt."
+    echo "It seems apt is not available. Please check that your OS is supported."
     exit 1
-fi;
+fi
 
-if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
+if (($(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l))); then
     echo "Your apt version is incompatible. You may not be able install this repository. "
     echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
     echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
@@ -27,31 +28,31 @@ if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
     echo "(not recommended, as you might need to fix your apt configuration)"
     select yn in "Yes" "No"; do
         case $yn in
-            Yes ) 
+        Yes)
             echo "Proceeding with override. You have been warned!"
             break
             ;;
-            No ) 
+        No)
             echo "Exiting."
             exit 0
             ;;
         esac
     done
-fi;
+fi
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
 KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc
 GITHUB_REPOSITORY="jamulussoftware/jamulus"
 
 echo "Setting up Jamulus repo at ${REPO_FILE}..."
-echo "deb https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/ ./" > ${REPO_FILE}
+echo "deb https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/ ./" >${REPO_FILE}
 echo "Installing Jamulus GPG key at ${KEY_FILE}..."
 curl --fail --show-error -sLo "${KEY_FILE}" https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/key.asc
 
 CURL_EXITCODE=$?
 if [[ ${CURL_EXITCODE} -ne 0 ]]; then
-      echo "Error: Download of gpg key failed. Please try again later."
-      exit ${CURL_EXITCODE}
+    echo "Error: Download of gpg key failed. Please try again later."
+    exit ${CURL_EXITCODE}
 fi
 
 echo "Running apt update..."

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -18,7 +18,7 @@ else
     exit 1
 fi;
 
-if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.4" | bc -l) )); then
+if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
     echo "Your apt version is incompatible. You may not be able install this repository. "
     echo "See issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
     echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -3,40 +3,40 @@
 # This script installs a Jamulus repository to Debian based systems
 
 if [[ ${EUID} -ne 0 ]]; then
-	echo "Error: This script must be run as root."
-	exit 1
+    echo "Error: This script must be run as root."
+    exit 1
 fi
 
 # Check for apt version >= 2.2.0 (if found, assuming Debian-based compatible with repo)
 # Issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095
 
 if APT_VERSION="$(apt --version)"; then
-	APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
-	APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
+    APT_MAJOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 1)
+    APT_MINOR=$(echo "$APT_VERSION" | cut -d' ' -f 2 | cut -d'.' -f 2)
 else
-	echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
-	exit 1
+    echo "This script is only compatible with Debian based distributions which have apt, but apt is not available. Please check that your OS is supported."
+    exit 1
 fi
 
 if (($(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l))); then
-	echo "Your apt version is incompatible. You may not be able install this repository. "
-	echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
-	echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
-	echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
-	echo "Do you wish to attempt to install the repository anyway?"
-	echo "(not recommended, as you might need to fix your apt configuration)"
-	select yn in "Yes" "No"; do
-		case $yn in
-		Yes)
-			echo "Proceeding with override. You have been warned!"
-			break
-			;;
-		No)
-			echo "Exiting."
-			exit 0
-			;;
-		esac
-	done
+    echo "Your apt version is incompatible. You may not be able install this repository. "
+    echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
+    echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
+    echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
+    echo "Do you wish to attempt to install the repository anyway?"
+    echo "(not recommended, as you might need to fix your apt configuration)"
+    select yn in "Yes" "No"; do
+        case $yn in
+        Yes)
+            echo "Proceeding with override. You have been warned!"
+            break
+            ;;
+        No)
+            echo "Exiting."
+            exit 0
+            ;;
+        esac
+    done
 fi
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
@@ -50,8 +50,8 @@ curl --fail --show-error -sLo "${KEY_FILE}" https://github.com/${GITHUB_REPOSITO
 
 CURL_EXITCODE=$?
 if [[ ${CURL_EXITCODE} -ne 0 ]]; then
-	echo "Error: Download of gpg key failed. Please try again later."
-	exit ${CURL_EXITCODE}
+    echo "Error: Download of gpg key failed. Please try again later."
+    exit ${CURL_EXITCODE}
 fi
 
 echo "Running apt update..."

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -7,7 +7,7 @@ if [[ ${EUID} -ne 0 ]]; then
      exit 1
 fi
 
-# Check for apt version >= 2.4.0 (if found, assuming Debian-based compatible with repo)
+# Check for apt version >= 2.2.0 (if found, assuming Debian-based compatible with repo)
 # Issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095
 
 if APT_VERSION="$(apt --version)"; then

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -11,19 +11,14 @@ if [ -x "$(command -v lsb_release)" ]; then
     ISUBUNTU=`lsb_release -is`
 else
     echo "lsb_release not found. Cannot determine Linux distribution (or this is not Linux)."
-    exit 1
+#    exit 1
 fi;
 
 if [[ $ISUBUNTU == "Ubuntu" ]]; then
+
     UBUNTU_VERSION=`lsb_release -sr`
     echo "Ubuntu version: ${UBUNTU_VERSION}"
     SUBSTRING=$(echo $UBUNTU_VERSION| cut -d'.' -f 1)
-else
-    echo "This is not Ubuntu"
-    # Could test for Debian here, or issue a prompt Continue at your own risk y/N?
-    exit 1
-fi;
-
 
 if [[ $SUBSTRING -lt 22 ]]; then
 cat << EOM
@@ -32,6 +27,17 @@ Not adding jamulus repo. Either install the deb file manually [see https://jamul
 or update your system to at least Ubuntu 22.04
 EOM
     exit 1
+fi;
+
+else
+    echo "This is not Ubuntu, it is ${ISUBUNTU}"
+    echo "Do you wish to install anyway?"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) break;;
+        No ) exit 1;;
+    esac
+done
 fi;
 
 # We have an acceptable Ubuntu version, continuing

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -13,6 +13,7 @@ if [ -x "$(command -v lsb_release)" ]; then
     ISUBUNTU=`lsb_release -is`
 else
     echo "lsb_release not found. Cannot determine Linux distribution (or this is not Linux)."
+    exit 1
 fi;
 
 if [[ $ISUBUNTU == "Ubuntu" ]]; then

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -25,13 +25,17 @@ if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
     echo "Do you wish to install anyway?"
     select yn in "Yes" "No"; do
         case $yn in
-            Yes ) echo "Proceeding with override. You have been warned!"; break;;
-            No ) exit 1;;
+            Yes ) 
+            echo "Proceeding with override. You have been warned!"
+            break
+            ;;
+            No ) 
+            echo "Exiting."
+            exit 1
+            ;;
         esac
     done
 fi;
-
-# We have an acceptable Apt version, continuing
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
 KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -7,12 +7,7 @@ if [[ ${EUID} -ne 0 ]]; then
      exit 1
 fi
 
-if [ -x "$(command -v lsb_release)" ]; then
-    ISUBUNTU=`lsb_release -is`
-else
-    echo "lsb_release not found. Cannot determine Linux distribution (or this is not Linux)."
-    exit 1
-fi;
+# Check for apt version >= 2.4.0 (if found, assuming Debian-based compatible with repo)
 
 apt --version > /dev/null
 if [[ $? -eq 0 ]]; then
@@ -30,33 +25,7 @@ if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.4" | bc -l) )); then
     exit 1
 fi;
 
-if [[ $ISUBUNTU == "Ubuntu" ]]; then
-
-    UBUNTU_VERSION=`lsb_release -sr`
-    echo "Ubuntu version: ${UBUNTU_VERSION}"
-    SUBSTRING=$(echo $UBUNTU_VERSION| cut -d'.' -f 1)
-
-if [[ $SUBSTRING -lt 22 ]]; then
-cat << EOM
-WARNING: Ubuntu versions less that 22.04 have a bug in their apt version for signed repositories.
-Not adding jamulus repo. Either install the deb file manually [see https://jamulus.io/wiki/Installation-for-Linux]
-or update your system to at least Ubuntu 22.04
-EOM
-    exit 1
-fi;
-
-else
-    echo "This is not Ubuntu, it is ${ISUBUNTU}"
-    echo "Do you wish to install anyway?"
-select yn in "Yes" "No"; do
-    case $yn in
-        Yes ) break;;
-        No ) exit 1;;
-    esac
-done
-fi;
-
-# We have an acceptable Ubuntu version, continuing
+# We have an acceptable Apt version, continuing
 
 REPO_FILE=/etc/apt/sources.list.d/jamulus.list
 KEY_FILE=/etc/apt/trusted.gpg.d/jamulus.asc

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -27,14 +27,14 @@ if (($(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l))); then
     echo "(not recommended, as you might need to fix your apt configuration)"
     select yn in "Yes" "No"; do
         case $yn in
-        Yes)
-            echo "Proceeding with override. You have been warned!"
-            break
-            ;;
-        No)
-            echo "Exiting."
-            exit 0
-            ;;
+           Yes)
+              echo "Proceeding with override. You have been warned!"
+              break
+              ;;
+            No)
+              echo "Exiting."
+              exit 0
+              ;;
         esac
     done
 fi

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -24,6 +24,7 @@ if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
     echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
     echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
     echo "Do you wish to attempt to install the repository anyway?"
+    echo "(not recommended, as you might need to fix your apt configuration)"
     select yn in "Yes" "No"; do
         case $yn in
             Yes ) 

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -19,10 +19,12 @@ else
 fi
 
 if [[ ${APT_MAJOR} -lt 2 || ( ${APT_MAJOR} -eq 2 && ${APT_MINOR} -lt 2 ) ]]; then
-    echo "Your apt version is incompatible. You may not be able install this repository. "
-    echo "See: https://github.com/orgs/jamulussoftware/discussions/3180"
+    echo "This repository is not compatible with your apt version."
+    echo "You can install Jamulus manually using the .deb package from "
+    echo "https://github.com/jamulussoftware/jamulus/releases or update your OS."
+    echo "For more information see: https://github.com/orgs/jamulussoftware/discussions/3180"
     echo "Also of interest: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
-    echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
+    echo
     echo "Do you wish to attempt to install the repository anyway?"
     echo "(not recommended, as you might need to fix your apt configuration)"
     select yn in "Yes" "No"; do

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -11,7 +11,7 @@ if [ -x "$(command -v lsb_release)" ]; then
     ISUBUNTU=`lsb_release -is`
 else
     echo "lsb_release not found. Cannot determine Linux distribution (or this is not Linux)."
-#    exit 1
+    exit 1
 fi;
 
 if [[ $ISUBUNTU == "Ubuntu" ]]; then

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -8,6 +8,7 @@ if [[ ${EUID} -ne 0 ]]; then
 fi
 
 # Check for apt version >= 2.4.0 (if found, assuming Debian-based compatible with repo)
+# Issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095
 
 if APT_VERSION="$(apt --version)"; then
     APT_MAJOR=$(echo $APT_VERSION| cut -d' ' -f 2 | cut -d'.' -f 1)
@@ -18,8 +19,16 @@ else
 fi;
 
 if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.4" | bc -l) )); then
-    echo "Your apt version is incompatible. You cannot install this repository. Please update your OS or use the .deb package from the Website to manually install Jamulus."
-    exit 1
+    echo "Your apt version is incompatible. You may not be able install this repository. "
+    echo "See issue: https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1950095"
+    echo "Please update your OS or use the .deb package from the Website to manually install Jamulus."
+    echo "Do you wish to install anyway?"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) echo "Proceeding with override"; break;;
+            No ) exit 1;;
+        esac
+    done
 fi;
 
 # We have an acceptable Apt version, continuing

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -18,7 +18,7 @@ else
     exit 1
 fi
 
-if [[ ${APT_MAJOR} -lt 2 || ( ${APT_MAJOR} -eq 2 && ${APT_MINOR} -lt 2 ) ]]; then
+if [[ ${APT_MAJOR} -lt 2 || (${APT_MAJOR} -eq 2 && ${APT_MINOR} -lt 2)   ]]; then
     echo "This repository is not compatible with your apt version."
     echo "You can install Jamulus manually using the .deb package from "
     echo "https://github.com/jamulussoftware/jamulus/releases or update your OS."

--- a/linux/setup_repo.sh
+++ b/linux/setup_repo.sh
@@ -25,7 +25,7 @@ if (( $(echo "${APT_MAJOR}.${APT_MINOR} < 2.2" | bc -l) )); then
     echo "Do you wish to install anyway?"
     select yn in "Yes" "No"; do
         case $yn in
-            Yes ) echo "Proceeding with override"; break;;
+            Yes ) echo "Proceeding with override. You have been warned!"; break;;
             No ) exit 1;;
         esac
     done


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: Add testing for apt version >=2.4 which should both prove that the system is debian based (using apt and dpkg) and is not the broken 2.0.x branch which cannot validate the repo.

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes: 3198

**Does this change need documentation? What needs to be documented and how?**

No

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Basic proof of concept for setup-repo.sh

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

Has been fully tested on Ubuntu 20.04, 22.04 and MacOS 13.6. 

Would require testing on a couple of Debian boxes. 

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above
