### PR TITLE
Build: Windows: Fix Github JACK build failures & improve build speed

### DIFF
--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -39,6 +39,10 @@ param(
 # Fail early on all errors
 $ErrorActionPreference = "Stop"
 
+# Invoke-WebRequest is really slow by default because it renders a progress bar.
+# Disabling this, improves vastly performance:
+$ProgressPreference = 'SilentlyContinue'
+
 $QtDir = 'C:\Qt'
 $ChocoCacheDir = 'C:\ChocoCache'
 $DownloadCacheDir = 'C:\AutobuildCache'

--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -183,7 +183,7 @@ Function Ensure-JACK
 
     $JACKInstallPath = "${DownloadCacheDir}\JACK64.exe"
 
-    & $JACKInstallPath $JACKInstallParms
+    Start-Process -Wait $JACKInstallPath -ArgumentList "$JACKInstallParms"
 
     if ( !$? )
     {
@@ -198,7 +198,7 @@ Function Ensure-JACK
 
     $JACKInstallPath = "${DownloadCacheDir}\JACK32.exe"
 
-    & $JACKInstallPath $JACKInstallParms
+    Start-Process -Wait $JACKInstallPath -ArgumentList "$JACKInstallParms"
 
     if ( !$? )
     {

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -21,6 +21,10 @@ param (
 # Fail early on all errors
 $ErrorActionPreference = "Stop"
 
+# Invoke-WebRequest is really slow by default because it renders a progress bar.
+# Disabling this, improves vastly performance:
+$ProgressPreference = 'SilentlyContinue'
+
 # change directory to the directory above (if needed)
 Set-Location -Path "$PSScriptRoot\..\"
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
- **Autobuild: Ensure JACK install completion**
  Previously, the JACK installers were started as ordinary programs. As they are GUI applications, they detach from the console and the powershell build script (and Github Actions) continues. Therefore, once the actual build starts, the JACK installation may not have finished at all. This commit uses Powershell's Start-Process -Wait feature to wait for completion before continuing.

- **Build: Windows: Improve dependency download speed**
  Invoke-WebRequest enables a progress bar by default which slows down the requests a lot. Disabling these makes the build run much faster.
  Source:
  - https://stackoverflow.com/a/43477248
  - Interactive testing


CHANGELOG: SKIP

**Context: Fixes an issue?**
Fixes  #3035.

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->
No.

**Status of this Pull Request**

Ready on CI green.

**What is missing until this pull request can be merged?**
CI.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. (Except for MacOS Legacy which seems to be broken anyway)
-  [x] I've filled all the content above

AUTOBUILD: Please build all targets
