### PR TITLE
Autobuild: Work around CodeQL-induced build failures

### DIFF
--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -120,7 +120,9 @@ build_installer_image() {
 
     # Build installer image
 
-    create-dmg \
+    # This gets rid of CodeQL's virally infecting dylib preloads which break hdiutil's helper
+    # /System/Library/PrivateFrameworks/DiskImages.framework/Resources/diskimages-helper.
+    sudo -u "$USER" create-dmg \
         --volname "${client_target_name} Installer" \
         --background "${resources_path}/installerbackground.png" \
         --window-pos 200 400 \

--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -120,7 +120,15 @@ build_installer_image() {
 
     # Build installer image
 
-    # Using sudo gets rid of CodeQL's virally infecting dylib preloads which break hdiutil's helper
+    # When this script is run on Github's CI with CodeQL enabled, CodeQL adds dynamic library
+    # shims via environment variables, so that it can monitor the compilation of code.
+    # In order for these settings to propagate to compilation called via shell/bash scripts,
+    # the CodeQL libs seem automatically to create the same environment variables in sub-shells,
+    # even when called via 'env'. This was determined by experimentation.
+    # Unfortunately, the CodeQL libraries are not compatible with the hdiutil program called
+    # by create-dmg. In order to prevent the automatic propagation of the environment, we use
+    # sudo to the same user in order to invoke create-dmg with a guaranteed clean environment.
+    #
     # /System/Library/PrivateFrameworks/DiskImages.framework/Resources/diskimages-helper.
     sudo -u "$USER" create-dmg \
         --volname "${client_target_name} Installer" \

--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -120,7 +120,7 @@ build_installer_image() {
 
     # Build installer image
 
-    # This gets rid of CodeQL's virally infecting dylib preloads which break hdiutil's helper
+    # Using sudo gets rid of CodeQL's virally infecting dylib preloads which break hdiutil's helper
     # /System/Library/PrivateFrameworks/DiskImages.framework/Resources/diskimages-helper.
     sudo -u "$USER" create-dmg \
         --volname "${client_target_name} Installer" \


### PR DESCRIPTION
This PR introduces the fix created by @hoffie to prevent CodeQL from interfering with the operation of `create-dmg`/`hdiutil` when the Github CI is building for MacOS.

It uses `sudo` without changing user, to provide isolation of the `create-dmg` step in the build process.

CHANGELOG: Autobuild: Prevent CodeQL-induced build failures for MacOS

**Context: Fixes an issue?**

Fixes: #3207

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready to merge.

**What is missing until this pull request can be merged?**

Just review.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
