### PR TITLE
Replace deprecated Q_OS_MACX with Q_OS_MACOS

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -44,7 +44,7 @@
 #if defined( _WIN32 ) && !defined( JACK_ON_WINDOWS )
 #    include "sound/asio/sound.h"
 #else
-#    if ( defined( Q_OS_MACX ) ) && !defined( JACK_REPLACES_COREAUDIO )
+#    if ( defined( Q_OS_MACOS ) ) && !defined( JACK_REPLACES_COREAUDIO )
 #        include "sound/coreaudio-mac/sound.h"
 #    else
 #        if defined( Q_OS_IOS )

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -943,7 +943,7 @@ void CClientDlg::SetMyWindowTitle ( const int iNumClients )
 
     setWindowTitle ( strWinTitle );
 
-#if defined( Q_OS_MACX )
+#if defined( Q_OS_MACOS )
     // for MacOS only we show the number of connected clients as a
     // badge label text if more than one user is connected
     if ( iNumClients > 1 )

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -53,7 +53,7 @@
 #include "connectdlg.h"
 #include "analyzerconsole.h"
 #include "ui_clientdlgbase.h"
-#if defined( Q_OS_MACX )
+#if defined( Q_OS_MACOS )
 #    include "mac/badgelabel.h"
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@
 #ifdef ANDROID
 #    include <QtAndroidExtras/QtAndroid>
 #endif
-#if defined( Q_OS_MACX )
+#if defined( Q_OS_MACOS )
 #    include "mac/activity.h"
 extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 #endif
@@ -60,7 +60,7 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 int main ( int argc, char** argv )
 {
 
-#if defined( Q_OS_MACX )
+#if defined( Q_OS_MACOS )
     // Mnemonic keys are default disabled in Qt for MacOS. The following function enables them.
     // Qt will not show these with underline characters in the GUI on MacOS. (#1873)
     qt_set_sequence_auto_mnemonic ( true );
@@ -74,7 +74,7 @@ int main ( int argc, char** argv )
 
     // initialize all flags and string which might be changed by command line
     // arguments
-#if ( defined( SERVER_BUNDLE ) && defined( Q_OS_MACX ) ) || defined( SERVER_ONLY )
+#if ( defined( SERVER_BUNDLE ) && defined( Q_OS_MACOS ) ) || defined( SERVER_ONLY )
     // if we are on MacOS and we are building a server bundle or requested build with serveronly, start Jamulus in server mode
     bool bIsClient = false;
     qInfo() << "- Starting in server mode by default (due to compile time option)";
@@ -585,7 +585,7 @@ int main ( int argc, char** argv )
 
 // clicking on the Mac application bundle, the actual application
 // is called with weird command line args -> do not exit on these
-#if !( defined( Q_OS_MACX ) )
+#if !( defined( Q_OS_MACOS ) )
         exit ( 1 );
 #endif
     }
@@ -850,7 +850,7 @@ int main ( int argc, char** argv )
     pApp->addLibraryPath ( QString ( ApplDir.absolutePath() ) );
 #endif
 
-#if defined( Q_OS_MACX )
+#if defined( Q_OS_MACOS )
     // On OSX we need to declare an activity to ensure the process doesn't get
     // throttled by OS level Nap, Sleep, and Thread Priority systems.
     CActivity activity;
@@ -1065,7 +1065,7 @@ int main ( int argc, char** argv )
         }
     }
 
-#if defined( Q_OS_MACX )
+#if defined( Q_OS_MACOS )
     activity.EndActivity();
 #endif
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This PR replaces all instances of `Q_OS_MACX` with `Q_OS_MACOS`

CHANGELOG: Replace deprecated Q_OS_MACX with Q_OS_MACOS (Jamulus now requires building with Qt >= 5.7.1)

**Context: Fixes an issue?**

The `#define` of `Q_OS_MACOS` was introduced in Qt 5.7.1, to replace `Q_OS_MACX`. The latter was still defined for backward-compatibility. Starting with Qt 6.5.2, using `Q_OS_MACX` produces a deprecation warning, for example:

```
In file included from ../src/settings.cpp:25:
In file included from ../src/settings.h:36:
../src/client.h:47:20: warning: macro 'Q_OS_MACX' has been marked as deprecated: use Q_OS_MACOS instead [-Wdeprecated-pragma]
#    if ( defined( Q_OS_MACX ) ) && !defined( JACK_REPLACES_COREAUDIO )
                   ^
/usr/local/opt/qt/6.6.1/macos/lib/QtCore.framework/Headers/qsystemdetection.h:167:65: note: macro marked 'deprecated' here
#    pragma clang deprecated(Q_OS_MACX, "use Q_OS_MACOS instead")
                                                                ^
1 warning generated.
```

A similar change was made in Qt itself at https://codereview.qt-project.org/c/qt/qtbase/+/307095/2

**Does this change need documentation? What needs to be documented and how?**

Probably not.

**Status of this Pull Request**

Ready to merge,

**What is missing until this pull request can be merged?**

Just review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
