### PR TITLE
Build CI on ubuntu 20 for Linux

### DIFF
--- a/.github/autobuild/linux_deb.sh
+++ b/.github/autobuild/linux_deb.sh
@@ -75,7 +75,7 @@ setup_cross_compiler() {
     if [[ "${TARGET_ARCH}" == amd64 ]]; then
         return
     fi
-    local GCC_VERSION=7  # 7 is the default on 18.04, there is no reason not to update once 18.04 is out of support
+    local GCC_VERSION=9  # 9 is the default on 20.04, there is no reason not to update once 20.04 is out of support
     sudo apt install -qq -y --no-install-recommends "g++-${GCC_VERSION}-${ABI_NAME}" "qt5-qmake:${TARGET_ARCH}" "qtbase5-dev:${TARGET_ARCH}" "libjack-jackd2-dev:${TARGET_ARCH}" "qtmultimedia5-dev:${TARGET_ARCH}"
     sudo update-alternatives --install "/usr/bin/${ABI_NAME}-g++" g++ "/usr/bin/${ABI_NAME}-g++-${GCC_VERSION}" 10
     sudo update-alternatives --install "/usr/bin/${ABI_NAME}-gcc" gcc "/usr/bin/${ABI_NAME}-gcc-${GCC_VERSION}" 10

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -205,7 +205,7 @@ jobs:
           - config_name:            Linux .deb amd64 (artifacts+codeQL)
             target_os:              linux
             building_on_os:         ubuntu-22.04
-            building_container:     ubuntu:18.04
+            building_container:     ubuntu:20.04
             base_command:           ./.github/autobuild/linux_deb.sh
             run_codeql:             true
             is_main_build_target:   true
@@ -213,14 +213,14 @@ jobs:
           - config_name:            Linux .deb armhf (artifacts)
             target_os:              linux
             building_on_os:         ubuntu-22.04
-            building_container:     ubuntu:18.04
+            building_container:     ubuntu:20.04
             base_command:           TARGET_ARCH=armhf ./.github/autobuild/linux_deb.sh
             run_codeql:             false
 
           - config_name:            Linux .deb arm64 (artifacts)
             target_os:              linux
             building_on_os:         ubuntu-22.04
-            building_container:     ubuntu:18.04
+            building_container:     ubuntu:20.04
             base_command:           TARGET_ARCH=arm64 ./.github/autobuild/linux_deb.sh
             run_codeql:             false
 
@@ -293,7 +293,7 @@ jobs:
           xcode-version:            ${{ matrix.config.xcode_version }}
 
       - name:                       Set up base dependencies in container environment
-        if:                         matrix.config.building_container == 'ubuntu:18.04'
+        if:                         matrix.config.building_container == 'ubuntu:20.04'
         run:                        |
           set -eu
           apt-get -qq update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ We support the following platforms and versions:
 
 - **Windows 10** or later
 - **macOS 10.10** or later
-- **Ubuntu 18.04** or later, **Debian 10** or later, most Linux flavors with recent enough Qt versions
+- **Ubuntu 20.04** or later, **Debian 11** or later, most Linux flavors with recent enough Qt versions. (Currently, it may still build on Ubuntu 18.04 and Debian 10, but the binaries built by Github will not run on those versions)
 
 _While Android and iOS aren't officially supported, please don't break their builds._
 

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -14,10 +14,9 @@ Vcs-Browser: https://github.com/jamulussoftware/jamulus
 
 Package: jamulus
 Architecture: any
-# Define dependencies explicitly for the best compatibility across all supported Ubuntu/Debian versions.
-# The automatism would otherwise select package names or versions which are not available on some systems,
-# especially when run in the Github Ubuntu 18.04 build environment.
-Depends: libc6 (>= 2.17), libstdc++6 (>= 5.2), libgcc1 (>= 1:3.0), libjack-jackd2-0 (>= 1.9.5~dfsg-14) | libjack-0.116, libqt5core5a (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5xml5 (>= 5.9.5), libqt5gui5 (>= 5.9.5) | libqt5gui5-gles (>= 5.9.5), libqt5widgets5 (>= 5.9.5), libqt5multimedia5 (>= 5.9.5)
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
 Recommends: qjackctl
 Description: Low latency Audio Server/Client
  Jamulus is for playing, rehearsing, or just jamming with your friends, your band
@@ -31,7 +30,10 @@ Description: Low latency Audio Server/Client
 
 Package: jamulus-headless
 Architecture: any
-Depends: libc6 (>= 2.17), libstdc++6 (>= 5.2), libgcc1 (>= 1:3.0), libqt5core5a (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5xml5 (>= 5.9.5)
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+ adduser,
 Description: Low latency Audio Server (headless)
  This package contains a Jamulus binary built for headless operation
  (without GUI library dependencies) and a jamulus-headless systemd service.

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -5,10 +5,18 @@ DEB_TARGET_GNU_TYPE := $(shell dpkg-architecture -qDEB_TARGET_GNU_TYPE)
 DEB_HOST_GNU_TYPE := $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 DEB_BUILD_GNU_TYPE := $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 
+# DEB_BUILD_GNU_TYPE is the system running the build (this system)
+# DEB_HOST_GNU_TYPE is the system jamulus is being built for (the target)
+# DEB_TARGET_GNU_TYPE is only relevant when building cross-compilers
+$(info DEB_BUILD_GNU_TYPE=$(DEB_BUILD_GNU_TYPE) DEB_HOST_GNU_TYPE=$(DEB_HOST_GNU_TYPE) DEB_TARGET_GNU_TYPE=$(DEB_TARGET_GNU_TYPE))
+
 ifeq ($(DEB_BUILD_GNU_TYPE),$(DEB_HOST_GNU_TYPE))
 	QMAKE := qmake
 else
-	QMAKE := "/usr/lib/$(DEB_BUILD_GNU_TYPE)/qt5/bin/qmake" -qtconf "/usr/lib/$(DEB_TARGET_GNU_TYPE)/qt5/qt.conf" -spec "/usr/lib/$(DEB_TARGET_GNU_TYPE)/qt5/mkspecs/$(DEB_TARGET_GNU_TYPE)-g++" LIBS+="-lstdc++ -lm"
+	# For an unknown reason, when called from this makefile in Ubuntu 20.04,
+	# qmake needs an option between qmake and -qtconf, else it gives an error.
+	# We use -makefile, which is the default mode anyway, and this avoids the issue.
+	QMAKE := qmake -makefile -qtconf "/usr/lib/$(DEB_HOST_GNU_TYPE)/qt5/qt.conf" -spec "/usr/lib/$(DEB_HOST_GNU_TYPE)/qt5/mkspecs/$(DEB_HOST_GNU_TYPE)-g++" LIBS+="-lstdc++ -lm"
 endif
 
 %:


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

These are the changes needed for the CI to build the three Linux artefacts using Ubuntu 20.04 instead of the EOL 18.04

CHANGELOG: Autobuild: Build Linux releases on Ubuntu 20.04 instead of 18.04

**Context: Fixes an issue?**

This is needed before dependabot #3168 can be applied successfully. `checkout@v4` will not run on Ubuntu 18.
It also has the advantage that Ubuntu 20.04 uses Qt 5.12 (U18.04 uses Qt 5.9), which will make it easier to progress #2393

**Does this change need documentation? What needs to be documented and how?**

The release notes should make it clear what versions of OS are compatible: Ubuntu >= 20, Debian >= 11

**Status of this Pull Request**

Ready to merge

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
