### PR TITLE
Show both build and runtime versions of Qt

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -594,7 +594,8 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
 
     // libraries used by this compilation
     txvLibraries->setText ( tr ( "This app uses the following libraries, resources or code snippets:" ) + "<p>" +
-                            tr ( "Qt cross-platform application framework" ) + QString ( " %1" ).arg ( QT_VERSION_STR ) +
+                            tr ( "Qt cross-platform application framework" ) + QString ( " %1 " ).arg ( QT_VERSION_STR ) + tr ( "(build)" ) +
+                            QString ( ", %1 " ).arg ( qVersion() ) + tr ( "(runtime)" ) +
                             ", <i><a href=\"https://www.qt.io\">https://www.qt.io</a></i>"
                             "</p>"
                             "<p>"
@@ -1726,7 +1727,8 @@ QString GetVersionAndNameStr ( const bool bDisplayInGui )
 
         strVersionText += "\n *** " + QCoreApplication::tr ( "This app uses the following libraries, resources or code snippets:" );
         strVersionText += "\n *** ";
-        strVersionText += "\n *** " + QCoreApplication::tr ( "Qt cross-platform application framework" ) + QString ( " %1" ).arg ( QT_VERSION_STR );
+        strVersionText += "\n *** " + QCoreApplication::tr ( "Qt cross-platform application framework" ) + QString ( " %1 " ).arg ( QT_VERSION_STR ) +
+                          QCoreApplication::tr ( "(build)" ) + QString ( ", %1 " ).arg ( qVersion() ) + QCoreApplication::tr ( "(runtime)" );
         strVersionText += "\n *** <https://www.qt.io>";
         strVersionText += "\n *** ";
         strVersionText += "\n *** Opus Interactive Audio Codec";


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Displays both the version of Qt the executable was built with, and the version currently running via the dynamic libraries. These are available from `QT_VERSION_STR` and `qVersion()` respectively.

`jamulus --version` now shows something like:
```
 *** This app uses the following libraries, resources or code snippets:
 *** 
 *** Qt cross-platform application framework 5.9.5 (build), 5.15.2 (runtime)
 *** <https://www.qt.io>
```
**About Jamulus.. / Libraries** shows the same information.


CHANGELOG: Client/Server: Display Qt versions for both build and runtime.

**Context: Fixes an issue?**

Fixes: #3230 

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Tested and ready to merge.

**What is missing until this pull request can be merged?**

Just review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
