### PR TITLE
Add missing braces for clarity and clang (trivial)

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -875,6 +875,7 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
             directoryType = bValue ? AT_DEFAULT : AT_CUSTOM;
         }
         else
+        {
             //### TODO: END ###//
 
             // if "directorytype" itself is set, use it (note "AT_NONE", "AT_DEFAULT" and "AT_CUSTOM" are min/max directory type here)
@@ -892,15 +893,19 @@ void CServerSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
             }
             //### TODO: END ###//
 
-            else if ( GetNumericIniSet ( IniXMLDocument,
-                                         "server",
-                                         "directorytype",
-                                         static_cast<int> ( AT_NONE ),
-                                         static_cast<int> ( AT_CUSTOM ),
-                                         iValue ) )
+            else
             {
-                directoryType = static_cast<EDirectoryType> ( iValue );
+                if ( GetNumericIniSet ( IniXMLDocument,
+                                        "server",
+                                        "directorytype",
+                                        static_cast<int> ( AT_NONE ),
+                                        static_cast<int> ( AT_CUSTOM ),
+                                        iValue ) )
+                {
+                    directoryType = static_cast<EDirectoryType> ( iValue );
+                }
             }
+        }
 
         //### TODO: BEGIN ###//
         // compatibility to old version < 3.9.0


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->
This is a trivial change to add a pair of braces to `CServerSettings::ReadSettingsFromXML()` in `settings.cpp`, without changing the behaviour of the code.

CHANGELOG: SKIP
<!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Previously, due to the separation of `else` and `if` by comments, `make clang_format` was always getting confused and messing with the indentation.

**Does this change need documentation? What needs to be documented and how?**

No

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready to merge

**What is missing until this pull request can be merged?**

Review by eye and approval.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
