### PR TITLE
#3233 UI: Common method to delete server and custom directory entries

### DIFF
--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -360,13 +360,15 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     // custom directories
     QString strCustomDirectories = "<b>" + tr ( "Custom Directories" ) + ":</b> " +
                                    tr ( "If you need to add additional directories to the Connect dialog Directory drop down, "
-                                        "you can enter the addresses here.<br>"
-                                        "To remove a value, select it, delete the text in the input box, "
-                                        "then move focus out of the control." );
+                                        "you can enter the addresses here.<br>" );
 
     lblCustomDirectories->setWhatsThis ( strCustomDirectories );
     cbxCustomDirectories->setWhatsThis ( strCustomDirectories );
     cbxCustomDirectories->setAccessibleName ( tr ( "Custom Directories combo box" ) );
+
+    butDeleteCustomDirectory->setAccessibleName ( tr ( "Delete custom directory button" ) );
+    butDeleteCustomDirectory->setWhatsThis ( "<b>" + tr ( "Delete Custom Directory" ) + ":</b> " +
+                                             tr ( "Click the button to delete the currently selected custom directory." ) );
 
     // current connection status parameter
     QString strConnStats = "<b>" + tr ( "Audio Upstream Rate" ) + ":</b> " +
@@ -691,12 +693,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                        this,
                        &CClientSettingsDlg::OnMeterStyleActivated );
 
-    QObject::connect ( cbxCustomDirectories->lineEdit(), &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnCustomDirectoriesEditingFinished );
-
-    QObject::connect ( cbxCustomDirectories,
-                       static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
-                       this,
-                       &CClientSettingsDlg::OnCustomDirectoriesEditingFinished );
+    QObject::connect ( cbxCustomDirectories->lineEdit(), &QLineEdit::editingFinished, this, [this] {
+        CClientSettingsDlg::OnCustomDirectoriesChanged ( false );
+    } );
 
     QObject::connect ( cbxLanguage, &CLanguageComboBox::LanguageChanged, this, &CClientSettingsDlg::OnLanguageChanged );
 
@@ -710,6 +709,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     // Driver Setup button is only available for Windows when JACK is not used
     QObject::connect ( butDriverSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverSetupClicked );
 #endif
+
+    QObject::connect ( butDeleteCustomDirectory, &QPushButton::clicked, this, [this] { CClientSettingsDlg::OnCustomDirectoriesChanged ( true ); } );
 
     // misc
     // sliders
@@ -1009,29 +1010,32 @@ void CClientSettingsDlg::OnEnableOPUS64StateChanged ( int value )
 
 void CClientSettingsDlg::OnFeedbackDetectionChanged ( int value ) { pSettings->bEnableFeedbackDetection = value == Qt::Checked; }
 
-void CClientSettingsDlg::OnCustomDirectoriesEditingFinished()
+void CClientSettingsDlg::OnCustomDirectoriesChanged ( bool bDelete )
 {
-    if ( cbxCustomDirectories->currentText().isEmpty() && cbxCustomDirectories->currentData().isValid() )
+    if ( bDelete )
     {
-        // if the user has selected an entry in the combo box list and deleted the text in the input field,
-        // and then focus moves off the control without selecting a new entry,
-        // we delete the corresponding entry in the vector
-        pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()] = "";
-    }
-    else if ( cbxCustomDirectories->currentData().isValid() && pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()].compare (
-                                                                   NetworkUtil::FixAddress ( cbxCustomDirectories->currentText() ) ) == 0 )
-    {
-        // if the user has selected another entry in the combo box list without changing anything,
-        // there is no need to update any list
-        return;
+        if ( !cbxCustomDirectories->currentData().isValid() )
+        {
+            // no selected directory to delete
+            return;
+        }
+        // delete the selected directory
+        pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()] = QString();
     }
     else
     {
+
+        if ( cbxCustomDirectories->currentText().isEmpty() ||
+             ( cbxCustomDirectories->currentData().isValid() && pSettings->vstrDirectoryAddress[cbxCustomDirectories->currentData().toInt()].compare (
+                                                                    NetworkUtil::FixAddress ( cbxCustomDirectories->currentText() ) ) == 0 ) )
+        {
+            // no need to add a already added directory
+            return;
+        }
         // store new address at the top of the list, if the list was already
         // full, the last element is thrown out
         pSettings->vstrDirectoryAddress.StringFiFoWithCompare ( NetworkUtil::FixAddress ( cbxCustomDirectories->currentText() ) );
     }
-
     // update combo box list and inform connect dialog about the new address
     UpdateDirectoryComboBox();
     emit CustomDirectoriesChanged();

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -83,7 +83,7 @@ public slots:
     void OnAutoJitBufStateChanged ( int value );
     void OnEnableOPUS64StateChanged ( int value );
     void OnFeedbackDetectionChanged ( int value );
-    void OnCustomDirectoriesEditingFinished();
+    void OnCustomDirectoriesChanged ( bool bDelete );
     void OnNewClientLevelEditingFinished() { pSettings->iNewClientFaderLevel = edtNewClientLevel->text().toInt(); }
     void OnInputBoostChanged();
     void OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button );

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -1039,11 +1039,40 @@
               </widget>
              </item>
              <item>
-              <widget class="QComboBox" name="cbxCustomDirectories">
-               <property name="editable">
-                <bool>true</bool>
-               </property>
-              </widget>
+              <layout class="QHBoxLayout">
+               <item>
+                <widget class="QComboBox" name="cbxCustomDirectories">
+                 <property name="editable">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="butDeleteCustomDirectory">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Ignored">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>24</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string notr="true">⌫</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
              <item>
               <spacer name="verticalSpacer_4">
@@ -1053,7 +1082,7 @@
                <property name="sizeHint" stdset="0">
                 <size>
                  <width>20</width>
-                 <height>13</height>
+                 <height>40</height>
                 </size>
                </property>
               </spacer>
@@ -1367,6 +1396,7 @@
   <tabstop>sldNetBufServer</tabstop>
   <tabstop>chbSmallNetworkBuffers</tabstop>
   <tabstop>cbxCustomDirectories</tabstop>
+  <tabstop>butDeleteCustomDirectory</tabstop>
   <tabstop>edtNewClientLevel</tabstop>
   <tabstop>cbxInputBoost</tabstop>
   <tabstop>chbDetectFeedback</tabstop>

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -1070,6 +1070,9 @@
                  <property name="text">
                   <string notr="true">⌫</string>
                  </property>
+                 <property name="autoDefault">
+                  <bool>false</bool>
+                 </property>
                 </widget>
                </item>
               </layout>


### PR DESCRIPTION
I added a horizontal box layout which include the box and the delete button. I wrote a fonction to implement the delete button.

It works well when we change the focus with the mouse to add a new directory but I can't make the enter key work : it delete the input and nothing happend. I tried to add the QLineEdit::returnPressed signal but it changed nothing. I struggle to understand the former use of the QComboBox::activated signal since I commented it and nothing seems to have changed.

TODO :
Allowing to add directory via enter key.
Improve spacers in the ui.

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: UI: Add "Delete Entry" button to Advanced Settings, Custom Directories

**Context: Fixes an issue?**

#3233 

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
