### PR TITLE
Build: Only checkout submodules for android

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -314,7 +314,8 @@ jobs:
       - name:                       Checkout code
         uses:                       actions/checkout@v4
         with:
-          submodules:               true
+          # only Android needs the oboe submodule, so don't fetch it for other builds
+          submodules:               ${{ matrix.config.target_os == 'android' }}
           fetch-depth:              ${{ matrix.config.checkout_fetch_depth || '1' }}
 
       - name:                       Cache Mac dependencies


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->
Only the Android build makes use of the submodule for oboe, so no need to fetch it when building other architectures.

CHANGELOG: Build: checkout of submodules only needed for Android

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
This just avoids unnecessary work in the CI when building targets other than Android.

**Does this change need documentation? What needs to be documented and how?**
I wouldn't have thought so.
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Nothing
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
