### PR TITLE
Add debug_and_release to use separate build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ libs/NSIS/nsProcess.dll
 windows/NSIS
 libs/NSIS/nsProcess/Release/
 debug/
+debug-*/
 release/
+release-*/
 build/
 deploy/
 build-gui/
@@ -48,6 +50,7 @@ linux/jamulus.desktop
 linux/jamulus-server.desktop
 .xcode
 Debug-iphoneos/
+Release-iphoneos/
 Jamulus.xcodeproj
 jamulus_plugin_import.cpp
 .github_release_changelog.md

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -29,7 +29,8 @@ contains(VERSION, .*dev.*) {
 CONFIG += qt \
     thread \
     lrelease \
-    embed_translations
+    embed_translations \
+    debug_and_release
 
 QT += network \
     xml \

--- a/mac/deploy_mac.sh
+++ b/mac/deploy_mac.sh
@@ -55,7 +55,7 @@ build_app() {
             "QMAKE_APPLE_DEVICE_ARCHS=${target_arch}" "QT_ARCH=${target_arch}" \
             "${@:2}"
         make -f "${build_path}/Makefile" -C "${build_path}" -j "${job_count}"
-        target_name=$(sed -nE 's/^QMAKE_TARGET *= *(.*)$/\1/p' "${build_path}/Makefile")
+        target_name=$(sed -nE 's/^QMAKE_TARGET *= *(.*)$/\1/p' "${build_path}/Makefile.Release")
         if [[ ${#target_archs_array[@]} -gt 1 ]]; then
             # When building for multiple architectures, move the binary to a safe place to avoid overwriting/cleaning by the other passes.
             mv "${build_path}/${target_name}.app/Contents/MacOS/${target_name}" "${deploy_path}/${target_name}.arch_${target_arch}"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Adds the `debug_and_release` option to the `CONFIG` in `Jamulus.pro`. This tells `qmake` to generate separate Makefiles for Debug and Release, each using a separate sub-directory (`debug/` and `release/` respectively) for build-generated files such as `*.o` and others, instead of building them in the project root.

The user can then invoke `make` or `make release` (the default) to build a release version, or `make debug` (explicitly) to build a debug version.

This `debug_and_release` option was already the default for Windows builds, but not for other architectures.

It was necessary also to change `mac/deploy_mac.sh` to search in `Makefile.Release` instead of `Makefile` when looking for the value of `QMAKE_TARGET`.

<!-- Explain what your PR does -->

CHANGELOG: Build: Place build files in separate directories instead of project root.

**Context: Fixes an issue?**
Fixes #3092
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
Maybe in compilation instructions, if there are any parts that would need to change as a result. Maybe not.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready to test
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Review and test
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
