### PR TITLE
Convert delete buttons to from QPushButton to QToolButton

### DIFF
--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -366,9 +366,10 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     cbxCustomDirectories->setWhatsThis ( strCustomDirectories );
     cbxCustomDirectories->setAccessibleName ( tr ( "Custom Directories combo box" ) );
 
-    butDeleteCustomDirectory->setAccessibleName ( tr ( "Delete custom directory button" ) );
-    butDeleteCustomDirectory->setWhatsThis ( "<b>" + tr ( "Delete Custom Directory" ) + ":</b> " +
+    tbtDeleteCustomDirectory->setAccessibleName ( tr ( "Delete custom directory button" ) );
+    tbtDeleteCustomDirectory->setWhatsThis ( "<b>" + tr ( "Delete Custom Directory" ) + ":</b> " +
                                              tr ( "Click the button to delete the currently selected custom directory." ) );
+    tbtDeleteCustomDirectory->setText ( u8"\u232B" );
 
     // current connection status parameter
     QString strConnStats = "<b>" + tr ( "Audio Upstream Rate" ) + ":</b> " +
@@ -710,7 +711,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     QObject::connect ( butDriverSetup, &QPushButton::clicked, this, &CClientSettingsDlg::OnDriverSetupClicked );
 #endif
 
-    QObject::connect ( butDeleteCustomDirectory, &QPushButton::clicked, this, [this] { CClientSettingsDlg::OnCustomDirectoriesChanged ( true ); } );
+    // tool buttons
+    QObject::connect ( tbtDeleteCustomDirectory, &QToolButton::clicked, this, [this] { CClientSettingsDlg::OnCustomDirectoriesChanged ( true ); } );
 
     // misc
     // sliders

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -1048,32 +1048,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QPushButton" name="butDeleteCustomDirectory">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Ignored">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>24</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string notr="true">⌫</string>
-                 </property>
-                 <property name="autoDefault">
-                  <bool>false</bool>
-                 </property>
-                </widget>
+                <widget class="QToolButton" name="tbtDeleteCustomDirectory"/>
                </item>
               </layout>
              </item>

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -96,10 +96,11 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     cbxServerAddr->setAccessibleName ( tr ( "Server address edit box" ) );
     cbxServerAddr->setAccessibleDescription ( tr ( "Holds the current server address. It also stores old addresses in the combo box list." ) );
 
-    butDeleteServerAddr->setAccessibleName ( tr ( "Delete server address button" ) );
-    butDeleteServerAddr->setWhatsThis ( "<b>" + tr ( "Delete Server Address" ) + ":</b> " +
+    tbtDeleteServerAddr->setAccessibleName ( tr ( "Delete server address button" ) );
+    tbtDeleteServerAddr->setWhatsThis ( "<b>" + tr ( "Delete Server Address" ) + ":</b> " +
                                         tr ( "Click the button to clear the currently selected server address "
                                              "and delete it from the list of stored servers." ) );
+    tbtDeleteServerAddr->setText ( u8"\u232B" );
 
     UpdateDirectoryComboBox();
 
@@ -185,7 +186,7 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     QObject::connect ( butConnect, &QPushButton::clicked, this, &CConnectDlg::OnConnectClicked );
 
     // tool buttons
-    QObject::connect ( butDeleteServerAddr, &QPushButton::clicked, this, &CConnectDlg::OnDeleteServerAddrClicked );
+    QObject::connect ( tbtDeleteServerAddr, &QToolButton::clicked, this, &CConnectDlg::OnDeleteServerAddrClicked );
 
     // timers
     QObject::connect ( &TimerPing, &QTimer::timeout, this, &CConnectDlg::OnTimerPing );

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -108,28 +108,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="butDeleteServerAddr">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Ignored">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>24</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string notr="true">⌫</string>
-       </property>
-      </widget>
+      <widget class="QToolButton" name="tbtDeleteServerAddr"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
This fixes the width problem on Mac for server in the connect dialog and custom directory in the settings dialog. It does so by making them consistent with the delete buttons in the Server GUI Options dialog, which already use `QToolButton` instead of `QPushButton`.

<!-- Explain what your PR does -->

CHANGELOG: Client: Fixed the display of delete buttons on Mac

**Context: Fixes an issue?**
Fixes #3241 

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No - bug fix only

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready for review

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Testing on all platforms to verify the buttons display correctly, and are consistent with those displayed in the server dialog.

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
