### PR TITLE
Update CONTRIBUTING.md for min Qt version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,16 +60,17 @@ We support the following platforms and versions:
 
 - **Windows 10** or later
 - **macOS 10.10** or later
-- **Ubuntu 20.04** or later, **Debian 11** or later, most Linux flavors with recent enough Qt versions. (Currently, it may still build on Ubuntu 18.04 and Debian 10, but the binaries built by Github will not run on those versions)
+- **Ubuntu 20.04** or later, **Debian 11** or later, most Linux flavors with recent enough Qt versions. (Currently, it may still build on Ubuntu 18.04 and Debian 10, but the binaries built by Github will not run on those versions.)
 
 _While Android and iOS aren't officially supported, please don't break their builds._
 
-Please try to avoid breaking any build by introducing platform-specific code. Check to see if any newly introduced Qt calls, parameters, properties or constants are available in the minimum supported Qt version, which is currently **5.9**. Note that code _style_ in a file may be Qt 4.x. While you should normally stick to existing style, if you make large-scale modifications, updating to Qt 5.9 style is recommended.
+Please try to avoid breaking any build by introducing platform-specific code. Check the Github builds all worked before raising a pull request.
+Check to see if any newly introduced Qt calls, parameters, properties or constants are available in the minimum supported Qt version, which is currently **5.12.2**. Note that code _style_ in a file may be Qt 4.x. While you should normally stick to existing style, if you make large-scale modifications, updating to Qt 5.12.2 style is recommended.
 Maintain C++11 compatibility throughout the code.
 
 ### Dependencies
 
-If your code requires new dependencies, ensure that they are available on all supported platforms and that their inclusion has been discussed and approved.
+If your code requires new dependencies, ensure that they are available on all supported platforms and that their inclusion has been discussed and approved. Include the `AUTOBUILD: Please build all targets` tag in your pull request to confirm Github builds for all supported platforms are successful.
 
 ### User experience
 


### PR DESCRIPTION
**Short description of changes**

Updates CONTRIBUTING.md for the minimum Qt version.  Plus minor formatting and extended comment on checking builds and on new dependencies.

On a side note: I was wondering if we should note that Qt5 is no longer "officially supported" by Qt...  The online installer no longer offers it at all (we _really_ need to move everything to Qt6, I just wish it was better at cross-platform visual support.)  The closest I can find is
https://launchpad.net/~beineri/+archive/ubuntu/opt-qt-5.12.2-bionic
for Ubuntu -- I guess someone will be packaging it still for Debian.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes 3322

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready for review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above