### PR TITLE
Make connect dialog show up as fullscreen on iOS

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -157,8 +157,8 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     // setup timers
     TimerInitialSort.setSingleShot ( true ); // only once after list request
 
-#ifdef ANDROID
-    // for the android version maximize the window
+#if defined( ANDROID ) || defined( Q_OS_IOS )
+    // for the Android and iOS version maximize the window
     setWindowState ( Qt::WindowMaximized );
 #endif
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Makes Connect dialog show up in full screen like Android if Qt6 is used. This fixes a severe UI issue on the Qt6 build of Jamulus for iOS which didn't allow to even tap the connect button. Now the connect dialog looks like this in dark mode: (broken styling but usable)
![Fixed Connect Dialog iOS](https://github.com/user-attachments/assets/af21e666-5eff-43bc-b527-eeea64fc9fb4)

<!-- Explain what your PR does -->

CHANGELOG: iOS: Fixed GUI issue preventing the connect dialog to show correctly

**Context: Fixes an issue?**

Related to issues mentioned in https://github.com/jamulussoftware/jamulus/issues/2711

**Does this change need documentation? What needs to be documented and how?**

No
**Status of this Pull Request**
Works based on local build. Didn't test IPA built by GitHub - but this still uses Qt5
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Nothing
## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
