### PR TITLE
Make about dialog show up as fullscreen on iOS

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -771,6 +771,15 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
 
     // set window title
     setWindowTitle ( tr ( "About %1" ).arg ( APP_NAME ) );
+
+    //### TODO: BEGIN ###//
+    // Test if the window also needs to be maximized on Android.
+    // Android has not been tested
+#    if defined( ANDROID ) || defined( Q_OS_IOS )
+    // for mobile version maximize the window
+    setWindowState ( Qt::WindowMaximized );
+#    endif
+    //### TODO: END ###//
 }
 
 // Licence dialog --------------------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Fixes an UI overflow bug for the about dialog on iOS.

Related to: #3343
Now - with some potential device rotations the about dialog can be exited on Qt6:
![About dialog iOS](https://github.com/user-attachments/assets/9f6b63db-b461-4d15-a396-6b269208bac8)


<!-- Explain what your PR does -->

CHANGELOG: CONDENSE WITH #3343

**Context: Fixes an issue?**

Related to: #3343

**Does this change need documentation? What needs to be documented and how?**

No
**Status of this Pull Request**

Ready

<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Nothing
## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
