### PR TITLE
Add changable bundle id and docs for macOS signing

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -411,7 +411,7 @@ jobs:
         uses:                       lando/notarize-action@4f5869b09386e8336802159031e4189e0919ae20
         with:
           product-path:             deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
-          primary-bundle-id:        io.jamulus.Jamulus
+          primary-bundle-id:         ${{ vars.MAC_BUNDLE_ID }} # Bundle ID for notarization. Set MAC_BUNDLE_ID as repository variable, not secret
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
           appstore-connect-team-id:  ${{ secrets.NOTARIZATION_TEAM_ID }}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -365,13 +365,13 @@ jobs:
         run:                        ${{ matrix.config.base_command }} build
         env:
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
-          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT}}
-          MACOS_CERTIFICATE_PWD:    ${{ secrets.MACOS_CERT_PWD }}
-          MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }}
-          MAC_STORE_APP_CERT:       ${{ secrets.MACAPP_CERT}}
+          MACOS_CERTIFICATE:        ${{ secrets.MACOS_CERT }} # Base64 encoded (Developer ID Application (?)) certificate. See https://help.apple.com/xcode/mac/current/#/dev154b28f09
+          MACOS_CERTIFICATE_PWD:    ${{ secrets.MACOS_CERT_PWD }} # Password protecting MACOS_CERTIFICATE
+          MACOS_CERTIFICATE_ID:     ${{ secrets.MACOS_CERT_ID }} # Certificate ID of MACOS_CERTIFICATE. If unknown, import MACOS_CERT into keychain and check the ID there
+          MAC_STORE_APP_CERT:       ${{ secrets.MACAPP_CERT }}
           MAC_STORE_APP_CERT_PWD:   ${{ secrets.MACAPP_CERT_PWD }}
           MAC_STORE_APP_CERT_ID:    ${{ secrets.MACAPP_CERT_ID }}
-          MAC_STORE_INST_CERT:      ${{ secrets.MACAPP_INST_CERT}}
+          MAC_STORE_INST_CERT:      ${{ secrets.MACAPP_INST_CERT }}
           MAC_STORE_INST_CERT_PWD:  ${{ secrets.MACAPP_INST_CERT_PWD }}
           MAC_STORE_INST_CERT_ID:   ${{ secrets.MACAPP_INST_CERT_ID }}
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
@@ -412,9 +412,9 @@ jobs:
         with:
           product-path:             deploy/${{ steps.get-artifacts.outputs.artifact_1 }}
           primary-bundle-id:         ${{ vars.MAC_BUNDLE_ID }} # Bundle ID for notarization. Set MAC_BUNDLE_ID as repository variable, not secret
-          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-          appstore-connect-team-id:  ${{ secrets.NOTARIZATION_TEAM_ID }}
+          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }} # Apple ID for notarization
+          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }} # App specific password for Apple ID
+          appstore-connect-team-id:  ${{ secrets.NOTARIZATION_TEAM_ID }} # Team ID from App Store Connect
 
       - name:                       Staple macOS Release Build
         if:                         >-
@@ -448,7 +448,7 @@ jobs:
           NOTARIZATION_USERNAME:    ${{ secrets.NOTARIZATION_USERNAME }}
           NOTARIZATION_PASSWORD:    ${{ secrets.NOTARIZATION_PASSWORD }}
           JAMULUS_BUILD_VERSION:    ${{ needs.create_release.outputs.build_version }}
-          APPLE_TEAM_ID:            XXXXXXXXXXX
+          APPLE_TEAM_ID:            ${{ secrets.NOTARIZATION_TEAM_ID }}
 
       - name:                       Perform CodeQL Analysis
         if:                         matrix.config.run_codeql


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds variable for a changable Bundle ID for notarization for macOS. One can add the bundle id here: https://github.com/jamulussoftware/jamulus/settings/variables/actions/new

Also adds some more (basic) documentation which needs improvement as soon as signing works, and some clean up.

CHANGELOG: Autobuild: Use variable for Bundle ID on macOS. This allows to change the bundle ID for macOS notarization on GitHub

**Context: Fixes an issue?**

No. Related to: https://github.com/jamulussoftware/jamulus/issues/3255#issuecomment-2295387824

**Does this change need documentation? What needs to be documented and how?**

Maybe the signing - once it works.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
Ready for review

**What is missing until this pull request can be merged?**
Review (language wise)
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want (should be merged if it doesn't break. I will try signing on my own repo)
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
