### PR TITLE
Refactor UpdateDisplay() to call UpdateUploadRate()

### DIFF
--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -1063,25 +1063,31 @@ void CClientSettingsDlg::OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton
     UpdateDisplay();
 }
 
+/// @method
+/// @brief Sets upstream rate label to current upload rate if the client is connected, else resets label
 void CClientSettingsDlg::UpdateUploadRate()
 {
-    // update upstream rate information label
-    lblUpstreamValue->setText ( QString().setNum ( pClient->GetUploadRateKbps() ) );
-    lblUpstreamUnit->setText ( "kbps" );
-}
-
-void CClientSettingsDlg::UpdateDisplay()
-{
-    // update slider controls (settings might have been changed)
-    UpdateJitterBufferFrame();
-    UpdateSoundCardFrame();
-
-    if ( !pClient->IsRunning() )
+    // update upstream rate information label if needed
+    if ( pClient->IsConnected() )
+    {
+        lblUpstreamValue->setText ( QString().setNum ( pClient->GetUploadRateKbps() ) );
+        lblUpstreamUnit->setText ( "kbps" );
+    }
+    else
     {
         // clear text labels with client parameters
         lblUpstreamValue->setText ( "---" );
         lblUpstreamUnit->setText ( "" );
     }
+}
+
+/// @method
+/// @brief Updates slider controls (settings might have been changed) and upstream rate information label
+void CClientSettingsDlg::UpdateDisplay()
+{
+    UpdateJitterBufferFrame();
+    UpdateSoundCardFrame();
+    UpdateUploadRate();
 }
 
 void CClientSettingsDlg::UpdateDirectoryComboBox()


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Refactor UpdateDispay() method. This was extracted from https://github.com/jamulussoftware/jamulus/pull/2550
and is related to: https://github.com/jamulussoftware/jamulus/pull/3364/files/21815c1a0708979fe0414c30e0294feaa7632be3#r1759185427

It makes sense to call UpdateUploadRate() from UpdateDisplay() since it gets same functionality to the same place.

Not sure, if the condition is correct, as we do not check if pClient is running, but rather it is connected now.

CHANGELOG: SKIP

**Context: Fixes an issue?**

No.

**Does this change need documentation? What needs to be documented and how?**

No. This even adds documentation

**Status of this Pull Request**

Ready for review
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review. Tested locally by disconnecting and connecting via GUI and changing Audio quality and enabling/disabling small network buffers. Network rate shows correctly. Also checked by starting Jamulus with `-c` flag and seems to do what it should do: Label shows correct data if connected and `---` if not connected.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
