### PR TITLE
Add ctrlmidich option for "own channel" regardless of number

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1351,6 +1351,16 @@ void CAudioMixerBoard::SetFaderLevel ( const int iChannelIdx, const int iValue )
             vecpChanFader[static_cast<size_t> ( iChannelIdx )]->SetFaderLevel ( iValue );
         }
     }
+    // Proposed change: if iChannelIdx is -1 and our own channel ID is a valid index
+    // then we adjust our own fader level:
+    if((iChannelIdx == -1) && iMyChannelID != INVALID_INDEX)
+    {
+        if ( vecpChanFader[static_cast<size_t> ( iMyChannelID )]->IsVisible() )
+        {
+            //printf("debug: set our own fader(%d) level to %d\n", iMyChannelID, iValue);
+            vecpChanFader[static_cast<size_t> ( iMyChannelID )]->SetFaderLevel ( iValue );
+        }
+    }
 }
 
 void CAudioMixerBoard::SetPanValue ( const int iChannelIdx, const int iValue )

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1343,22 +1343,16 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
 
 void CAudioMixerBoard::SetFaderLevel ( const int iChannelIdx, const int iValue )
 {
+    // If iChannelIdx is I_MY_CHANNEL and our own channel ID is a valid index
+    // then we adjust our own fader level
+    const int iTheChannelIdx = ( iChannelIdx == I_MY_CHANNEL ) ? iMyChannelID : iChannelIdx;
+
     // only apply new fader level if channel index is valid and the fader is visible
-    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS ) )
+    if ( ( iTheChannelIdx >= 0 ) && ( iTheChannelIdx < MAX_NUM_CHANNELS ) )
     {
-        if ( vecpChanFader[static_cast<size_t> ( iChannelIdx )]->IsVisible() )
+        if ( vecpChanFader[static_cast<size_t> ( iTheChannelIdx )]->IsVisible() )
         {
-            vecpChanFader[static_cast<size_t> ( iChannelIdx )]->SetFaderLevel ( iValue );
-        }
-    }
-    // Proposed change: if iChannelIdx is -1 and our own channel ID is a valid index
-    // then we adjust our own fader level:
-    if((iChannelIdx == -1) && iMyChannelID != INVALID_INDEX)
-    {
-        if ( vecpChanFader[static_cast<size_t> ( iMyChannelID )]->IsVisible() )
-        {
-            //printf("debug: set our own fader(%d) level to %d\n", iMyChannelID, iValue);
-            vecpChanFader[static_cast<size_t> ( iMyChannelID )]->SetFaderLevel ( iValue );
+            vecpChanFader[static_cast<size_t> ( iTheChannelIdx )]->SetFaderLevel ( iValue );
         }
     }
 }

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1343,53 +1343,56 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
 
 void CAudioMixerBoard::SetFaderLevel ( const int iChannelIdx, const int iValue )
 {
-    // If iChannelIdx is I_MY_CHANNEL and our own channel ID is a valid index
-    // then we adjust our own fader level
-    const int iTheChannelIdx = ( iChannelIdx == I_MY_CHANNEL ) ? iMyChannelID : iChannelIdx;
+    const int iRealChannelIdx = getRealChannelIdx ( iChannelIdx );
 
     // only apply new fader level if channel index is valid and the fader is visible
-    if ( ( iTheChannelIdx >= 0 ) && ( iTheChannelIdx < MAX_NUM_CHANNELS ) )
+    if ( ( iRealChannelIdx >= 0 ) && ( iRealChannelIdx < MAX_NUM_CHANNELS ) )
     {
-        if ( vecpChanFader[static_cast<size_t> ( iTheChannelIdx )]->IsVisible() )
+        if ( vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->IsVisible() )
         {
-            vecpChanFader[static_cast<size_t> ( iTheChannelIdx )]->SetFaderLevel ( iValue );
+            vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->SetFaderLevel ( iValue );
         }
     }
 }
 
 void CAudioMixerBoard::SetPanValue ( const int iChannelIdx, const int iValue )
 {
+    const int iRealChannelIdx = getRealChannelIdx ( iChannelIdx );
+
     // only apply new pan value if channel index is valid and the panner is visible
-    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS ) && bDisplayPans )
+    if ( ( iRealChannelIdx >= 0 ) && ( iRealChannelIdx < MAX_NUM_CHANNELS ) && bDisplayPans )
     {
-        if ( vecpChanFader[static_cast<size_t> ( iChannelIdx )]->IsVisible() )
+        if ( vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->IsVisible() )
         {
-            vecpChanFader[static_cast<size_t> ( iChannelIdx )]->SetPanValue ( iValue );
+            vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->SetPanValue ( iValue );
         }
     }
 }
 
 void CAudioMixerBoard::SetFaderIsSolo ( const int iChannelIdx, const bool bIsSolo )
 {
-    // only apply solo if channel index is valid and the fader is visible
-    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS ) )
+    const int iRealChannelIdx = getRealChannelIdx ( iChannelIdx );
 
+    // only apply solo if channel index is valid and the fader is visible
+    if ( ( iRealChannelIdx >= 0 ) && ( iRealChannelIdx < MAX_NUM_CHANNELS ) )
     {
-        if ( vecpChanFader[static_cast<size_t> ( iChannelIdx )]->IsVisible() )
+        if ( vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->IsVisible() )
         {
-            vecpChanFader[static_cast<size_t> ( iChannelIdx )]->SetFaderIsSolo ( bIsSolo );
+            vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->SetFaderIsSolo ( bIsSolo );
         }
     }
 }
 
 void CAudioMixerBoard::SetFaderIsMute ( const int iChannelIdx, const bool bIsMute )
 {
+    const int iRealChannelIdx = getRealChannelIdx ( iChannelIdx );
+
     // only apply mute if channel index is valid and the fader is visible
-    if ( ( iChannelIdx >= 0 ) && ( iChannelIdx < MAX_NUM_CHANNELS ) )
+    if ( ( iRealChannelIdx >= 0 ) && ( iRealChannelIdx < MAX_NUM_CHANNELS ) )
     {
-        if ( vecpChanFader[static_cast<size_t> ( iChannelIdx )]->IsVisible() )
+        if ( vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->IsVisible() )
         {
-            vecpChanFader[static_cast<size_t> ( iChannelIdx )]->SetFaderIsMute ( bIsMute );
+            vecpChanFader[static_cast<size_t> ( iRealChannelIdx )]->SetFaderIsMute ( bIsMute );
         }
     }
 }

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -288,6 +288,15 @@ protected:
     template<unsigned int slotId>
     inline void connectFaderSignalsToMixerBoardSlots();
 
+    // When handling MIDI controllers for adjusting Jamulus channel controls,
+    // each channel is assigned by the server.  As a user's Jamulus channel
+    // will vary on each server connection, to enable the assignment of MIDI
+    // controllers to the user's own Jamulus channel, the constant I_MY_CHANNEL
+    // is passed into the methods used to handle the requests.  This method then
+    // maps I_MY_CHANNEL to the current value of the user's Jamulus channel,
+    // held in iMyChannel.
+    inline int getRealChannelIdx ( const int iChannelIdx ) const { return iChannelIdx == I_MY_CHANNEL ? iMyChannelID : iChannelIdx; }
+
 signals:
     void ChangeChanGain ( int iId, float fGain, bool bIsMyOwnFader );
     void ChangeChanPan ( int iId, float fPan );

--- a/src/client.h
+++ b/src/client.h
@@ -272,6 +272,8 @@ public:
         Channel.GetBufErrorRates ( vecErrRates, dLimit, dMaxUpLimit );
     }
 
+    bool IsMIDIEnabled() { return Sound.IsMIDIEnabled(); }
+
     // settings
     CChannelCoreInfo ChannelInfo;
     QString          strClientName;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -28,7 +28,6 @@
 CClientDlg::CClientDlg ( CClient*         pNCliP,
                          CClientSettings* pNSetP,
                          const QString&   strConnOnStartupAddress,
-                         const QString&   strMIDISetup,
                          const bool       bNewShowComplRegConnList,
                          const bool       bShowAnalyzerConsole,
                          const bool       bMuteStream,
@@ -219,7 +218,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     MainMixerBoard->SetNumMixerPanelRows ( pSettings->iNumMixerPanelRows );
 
     // Pass through flag for MIDICtrlUsed
-    MainMixerBoard->SetMIDICtrlUsed ( !strMIDISetup.isEmpty() );
+    MainMixerBoard->SetMIDICtrlUsed ( pClient->IsMIDIEnabled() );
 
     // reset mixer board
     MainMixerBoard->HideAll();

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -77,7 +77,6 @@ public:
     CClientDlg ( CClient*         pNCliP,
                  CClientSettings* pNSetP,
                  const QString&   strConnOnStartupAddress,
-                 const QString&   strMIDISetup,
                  const bool       bNewShowComplRegConnList,
                  const bool       bShowAnalyzerConsole,
                  const bool       bMuteStream,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -953,7 +953,6 @@ int main ( int argc, char** argv )
                 CClientDlg ClientDlg ( &Client,
                                        &Settings,
                                        strConnOnStartupAddress,
-                                       strMIDISetup,
                                        bShowComplRegConnList,
                                        bShowAnalyzerConsole,
                                        bMuteStream,

--- a/src/sound/soundbase.cpp
+++ b/src/sound/soundbase.cpp
@@ -33,6 +33,7 @@ char const sMidiCtlChar[] = {
     /* [EMidiCtlType::Solo]        = */ 's',
     /* [EMidiCtlType::Mute]        = */ 'm',
     /* [EMidiCtlType::MuteMyself]  = */ 'o',
+    /* [EMidiCtlType::OurFader]    = */ 'z', // Proposed addition: a new enum value for "our fader"
     /* [EMidiCtlType::None]        = */ '\0' };
 
 /* Implementation *************************************************************/
@@ -370,6 +371,13 @@ void CSoundBase::ParseMIDIMessage ( const CVector<uint8_t>& vMIDIPaketBytes )
                             // consider offset for the faders
 
                             emit ControllerInFaderLevel ( cCtrl.iChannel, iFaderLevel );
+                        }
+                        break;
+                        case OurFader:
+                        {
+                            // special message about our own fader - emit a fader level whatever-it-is-called with channel id -1
+                            const int iFaderLevel = static_cast<int> ( static_cast<double> ( iValue ) / 127*AUD_MIX_FADER_MAX );
+                            emit ControllerInFaderLevel ( -1, iFaderLevel);
                         }
                         break;
                         case Pan:

--- a/src/sound/soundbase.cpp
+++ b/src/sound/soundbase.cpp
@@ -363,21 +363,16 @@ void CSoundBase::ParseMIDIMessage ( const CVector<uint8_t>& vMIDIPaketBytes )
                         switch ( cCtrl.eType )
                         {
                         case Fader:
+                        case OurFader:
                         {
                             // we are assuming that the controller number is the same
                             // as the audio fader index and the range is 0-127
                             const int iFaderLevel = static_cast<int> ( static_cast<double> ( iValue ) / 127 * AUD_MIX_FADER_MAX );
+                            const int iTheChannel = cCtrl.eType == OurFader ? I_MY_CHANNEL : cCtrl.iChannel;
 
                             // consider offset for the faders
 
-                            emit ControllerInFaderLevel ( cCtrl.iChannel, iFaderLevel );
-                        }
-                        break;
-                        case OurFader:
-                        {
-                            // special message about our own fader - emit a fader level whatever-it-is-called with channel id -1
-                            const int iFaderLevel = static_cast<int> ( static_cast<double> ( iValue ) / 127*AUD_MIX_FADER_MAX );
-                            emit ControllerInFaderLevel ( I_MY_CHANNEL, iFaderLevel);
+                            emit ControllerInFaderLevel ( iTheChannel, iFaderLevel );
                         }
                         break;
                         case Pan:

--- a/src/sound/soundbase.cpp
+++ b/src/sound/soundbase.cpp
@@ -377,7 +377,7 @@ void CSoundBase::ParseMIDIMessage ( const CVector<uint8_t>& vMIDIPaketBytes )
                         {
                             // special message about our own fader - emit a fader level whatever-it-is-called with channel id -1
                             const int iFaderLevel = static_cast<int> ( static_cast<double> ( iValue ) / 127*AUD_MIX_FADER_MAX );
-                            emit ControllerInFaderLevel ( -1, iFaderLevel);
+                            emit ControllerInFaderLevel ( I_MY_CHANNEL, iFaderLevel);
                         }
                         break;
                         case Pan:

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -32,6 +32,7 @@
 #endif
 #include "../global.h"
 #include "../util.h"
+#define I_MY_CHANNEL -1
 
 // TODO better solution with enum definition
 // problem: in signals it seems not to work to use CSoundBase::ESndCrdResetType

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -115,6 +115,8 @@ public:
     // in a callback function it has to be public -> better solution
     void EmitReinitRequestSignal ( const ESndCrdResetType eSndCrdResetType ) { emit ReinitRequest ( eSndCrdResetType ); }
 
+    bool IsMIDIEnabled() { return iCtrlMIDIChannel != INVALID_MIDI_CH; }
+
 protected:
     virtual QString  LoadAndInitializeDriver ( QString, bool ) { return ""; }
     virtual void     UnloadCurrentDriver() {}

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -50,7 +50,7 @@ enum EMidiCtlType
     Solo,
     Mute,
     MuteMyself,
-    OurFader, // Proposed addition: a MidiCtrlType for our own fader level
+    MyChannel,
     None
 };
 
@@ -160,7 +160,19 @@ protected:
     QMutex MutexAudioProcessCallback;
     QMutex MutexDevProperties;
 
-    QString                strSystemDriverTechniqueName;
+    QString strSystemDriverTechniqueName;
+
+    // This is used as a lookup table for parsing option letters, mapping
+    // a single character to an EMidiCtlType. Has to follow order of EMidiCtlType.
+    const QString sMidiCtl = QString ( "f"  // [EMidiCtlType::Fader]
+                                       "p"  // [EMidiCtlType::Pan]
+                                       "s"  // [EMidiCtlType::Solo]
+                                       "m"  // [EMidiCtlType::Mute]
+                                       "o"  // [EMidiCtlType::MuteMyself]
+                                       "z"  // [EMidiCtlType::MyChannel]
+                                       "\0" // [EMidiCtlType::None]
+    );
+
     int                    iCtrlMIDIChannel;
     QVector<CMidiCtlEntry> aMidiCtls;
 

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -49,6 +49,7 @@ enum EMidiCtlType
     Solo,
     Mute,
     MuteMyself,
+    OurFader, // Proposed addition: a MidiCtrlType for our own fader level
     None
 };
 


### PR DESCRIPTION
**Short description of changes**

From @AndersGoran.

This adds a `;z` option to `--ctrlmidich` parsing that adds control of the client channel, regardless of its channel number.  This applies to all the channel-specific controls used.  It takes up one extra MIDI controller number for each.

CHANGELOG: Add ctrlmidich option for "own channel" regardless of number

**Context: Fixes an issue?**

Raised in https://github.com/orgs/jamulussoftware/discussions/2220#discussioncomment-10811813

**Does this change need documentation? What needs to be documented and how?**

Yes, but it needs reviewing to see if this is how we want to do it first.

**Status of this Pull Request**

Proof of concept.

**What is missing until this pull request can be merged?**

Needs reviewing and considering whether "own client id" concept should apply to all controls (e.g. use `;z` as a switch to bump lock the first CC number for each control to "own client id").

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
