### PR TITLE
Make about chat show up as fullscreen on iOS

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -71,6 +71,15 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
     // Now tell the layout about the menu
     layout()->setMenuBar ( pMenu );
 
+    //### TODO: BEGIN ###//
+    // Test if the window also needs to be maximized on Android.
+    // Android has not been tested
+#if defined( ANDROID ) || defined( Q_OS_IOS )
+    // for mobile version maximize the window
+    setWindowState ( Qt::WindowMaximized );
+#endif
+    //### TODO: END ###//
+
     // Connections -------------------------------------------------------------
     QObject::connect ( edtLocalInputText, &QLineEdit::textChanged, this, &CChatDlg::OnLocalInputTextTextChanged );
 


### PR DESCRIPTION
Fixes an overflow bug for the about dialog on iOS.

Related to: https://github.com/jamulussoftware/jamulus/pull/3343

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Attempt to show chat dialog as full screen. Doesn't work yet - especially if rotating the screen.

CHANGELOG: CONDENSE WITH https://github.com/jamulussoftware/jamulus/pull/3343
**Context: Fixes an issue?**

Fixes: #3383

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

To be tested. Unfortunately, also the close button on the chat on iOS crashes the application. I think this was documented somewhere and is probably due to a null pointer de-reference.

<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Not sure

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
