### PR TITLE
Add deprecation warning for `-m` option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,6 +342,9 @@ int main ( int argc, char** argv )
         // HTML status file ----------------------------------------------------
         if ( GetStringArgument ( argc, argv, i, "-m", "--htmlstatus", strArgument ) )
         {
+            qWarning() << qUtf8Printable (
+                QString ( "- The HTML status file option (\"--htmlstatus\" or \"-m\") is deprecated and will be removed soon. Please use JSON-RPC "
+                          "instead.  See https://github.com/jamulussoftware/jamulus/blob/main/docs/JSON-RPC.md" ) );
             strHTMLStatusFileName = strArgument;
             qInfo() << qUtf8Printable ( QString ( "- HTML status file name: %1" ).arg ( strHTMLStatusFileName ) );
             CommandLineOptions << "--htmlstatus";
@@ -1111,7 +1114,7 @@ QString UsageArguments ( char** argv )
            "  -F, --fastupdate        use 64 samples frame size mode\n"
            "  -l, --log               enable logging, set file name\n"
            "  -L, --licence           show an agreement window before users can connect\n"
-           "  -m, --htmlstatus        enable HTML status file, set file name\n"
+           "  -m, --htmlstatus        deprecated, please use JSON-RPC instead\n"
            "  -o, --serverinfo        registration info for this Server.  Format:\n"
            "                          [name];[city];[country as two-letter ISO country code or Qt5 QLocale ID]\n"
            "      --serverpublicip    public IP address for this Server.  Needed when\n"


### PR DESCRIPTION
Adds a deprecation warning if the server is started with `-m`.



<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: Server: The `-m`/`--htmlstatus` option is considered deprecated and has been replaced by JSON RPC's `jamulusserver/getClients` method. The `-m` option will be removed in future.

**Context: Fixes an issue?**

Related to: https://github.com/jamulussoftware/jamulus/issues/3362

**Does this change need documentation? What needs to be documented and how?**

Yes. Part of https://github.com/jamulussoftware/jamulus/issues/3362

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Approval.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
