### PR TITLE
Use Qt::QueuedConnection for language message box to avoid hang on iOS

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -642,7 +642,12 @@ CHelpMenu::CHelpMenu ( const bool bIsClient, QWidget* parent ) : QMenu ( tr ( "&
 // Language combo box ----------------------------------------------------------
 CLanguageComboBox::CLanguageComboBox ( QWidget* parent ) : QComboBox ( parent ), iIdxSelectedLanguage ( INVALID_INDEX )
 {
-    QObject::connect ( this, static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ), this, &CLanguageComboBox::OnLanguageActivated );
+    // This requires a Qt::QueuedConnection on iOS due to https://bugreports.qt.io/browse/QTBUG-64577
+    QObject::connect ( this,
+                       static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
+                       this,
+                       &CLanguageComboBox::OnLanguageActivated,
+                       Qt::QueuedConnection );
 }
 
 void CLanguageComboBox::Init ( QString& strSelLanguage )


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Due to https://bugreports.qt.io/browse/QTBUG-64577 on iOS a Qt::QueuedConnection is necessary on the message box shown if the language changes. Otherwise, the message box would never show up and changing the language would hang the app.

CHANGELOG: iOS: Fix app hang if the language was changed

**Context: Fixes an issue?**

Related to: #3406

**Does this change need documentation? What needs to be documented and how?**

No
**Status of this Pull Request**

Ready for review. Tested on iOS 17 and Debian. Both show the message as expected.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Nothing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
