### PR TITLE
Fix crash on closing iOS chat dialog

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -61,12 +61,11 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
 
     pMenu->addMenu ( pEditMenu );
 #if defined( Q_OS_IOS )
-    QAction* action = pMenu->addAction ( tr ( "&Close" ) );
-    connect ( action, SIGNAL ( triggered() ), this, SLOT ( close() ) );
+    QAction* closeAction = pMenu->addAction ( tr ( "&Close" ) );
 #endif
 
 #if defined( ANDROID ) || defined( Q_OS_ANDROID )
-    pEditMenu->addAction ( tr ( "&Close" ), this, SLOT ( close() ), QKeySequence ( Qt::CTRL + Qt::Key_W ) );
+    pEditMenu->addAction ( tr ( "&Close" ), this, SLOT ( OnCloseClicked() ), QKeySequence ( Qt::CTRL + Qt::Key_W ) );
 #endif
 
     // Now tell the layout about the menu
@@ -78,6 +77,10 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
     QObject::connect ( butSend, &QPushButton::clicked, this, &CChatDlg::OnSendText );
 
     QObject::connect ( txvChatWindow, &QTextBrowser::anchorClicked, this, &CChatDlg::OnAnchorClicked );
+
+#if defined( Q_OS_IOS )
+    QObject::connect ( closeAction, &QAction::triggered, this, &CChatDlg::OnCloseClicked );
+#endif
 }
 
 void CChatDlg::OnLocalInputTextTextChanged ( const QString& strNewText )
@@ -149,3 +152,18 @@ void CChatDlg::OnAnchorClicked ( const QUrl& Url )
         }
     }
 }
+
+#if defined( Q_OS_IOS ) || defined( ANDROID ) || defined( Q_OS_ANDROID )
+void CChatDlg::OnCloseClicked()
+{
+    // on mobile add a close button or menu entry
+#    if defined( Q_OS_IOS )
+    // On Qt6, iOS crashes if we call close() due to unknown reasons, therefore we just hide() the dialog. A Qt bug is suspected.
+    // Checkout https://github.com/jamulussoftware/jamulus/pull/3413
+    hide();
+#    endif
+#    if defined( ANDROID ) || defined( Q_OS_ANDROID )
+    close();
+#    endif
+}
+#endif

--- a/src/chatdlg.h
+++ b/src/chatdlg.h
@@ -54,6 +54,9 @@ public slots:
     void OnLocalInputTextTextChanged ( const QString& strNewText );
     void OnClearChatHistory();
     void OnAnchorClicked ( const QUrl& Url );
+#if defined( Q_OS_IOS ) || defined( ANDROID ) || defined( Q_OS_ANDROID )
+    void OnCloseClicked();
+#endif
 
 signals:
     void NewLocalInputText ( QString strNewText );


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Using close() instead of hide() would crash the app as soon as one taps at the screen after closing the chat dialog. Due to a null pointer dereference (?).
I do **not** understand why the app crashes. Probably it's a qt bug.

```
ASSERT failure in QCoreApplication::sendEvent: "Unexpected null receiver", file /Users/qt/work/qt/qtbase/src/corelib/kernel/qcoreapplication.cpp, line 1587

Can't show file for stack frame : <DBGLLDBStackFrame: 0x7fcf61f51120> - stackNumber:3 - name:qAbort. The file path does not exist on the file system: /Users/qt/work/qt/qtbase/src/corelib/global/qglobal.cpp
```

https://qtcentre.org/threads/5572-QCoreApplication-postEvent-Unexpected-null-receiver (?)

CHANGELOG: iOS: Fix crash on Qt6 after closing the chat window.

**Context: Fixes an issue?**

Related to: https://github.com/jamulussoftware/jamulus/issues/3406
**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready for review.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Discussion. This is a hot fix...
## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
