### PR TITLE
Revert pip "--break-system-packages"

### DIFF
--- a/.github/workflows/coding-style-check.yml
+++ b/.github/workflows/coding-style-check.yml
@@ -58,6 +58,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install pylint
-      run: pip install --user "pylint < 3.0" --break-system-packages
+      run: pip install --user "pylint < 3.0"
     - name: Check Python files with pylint
       run: find ./tools -name '*.py' -print -exec pylint {} +


### PR DESCRIPTION
**Short description of changes**

Reverts addition of `--break-system-packages` to `pip` install for `pylint3`.

CHANGELOG: SKIP

**Context: Fixes an issue?**

We appear to have flaky updates around `pip`.  See #3408.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

If it builds, it builds.

**What is missing until this pull request can be merged?**

It needs to build.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

AUTOBUILD: Please build all targets
