### PR TITLE
Always give own channel MIDI number 0

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1246,6 +1246,8 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
             iFaderNumber[vecChanInfo[iFader].iChanID] = static_cast<int> ( iFader );
         }
 
+        const int iMyChannelID = pClient->GetMyChannelID();
+
         // Hide all unused faders and initialize used ones
         for ( size_t iChanID = 0; iChanID < MAX_NUM_CHANNELS; iChanID++ )
         {
@@ -1267,7 +1269,7 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
                 vecpChanFader[iChanID]->Reset();
                 vecAvgLevels[iChanID] = 0.0f;
 
-                if ( static_cast<int> ( iChanID ) == pClient->GetMyChannelID() )
+                if ( static_cast<int> ( iChanID ) == iMyChannelID )
                 {
                     // this is my own fader --> set fader property
                     vecpChanFader[iChanID]->SetIsMyOwnFader();
@@ -1288,8 +1290,7 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
                 // we can adjust the level even if no fader was visible.
                 // The fader level of 100 % is the default in the
                 // server, in that case we do not have to do anything here.
-                if ( ( !bNoFaderVisible ||
-                       ( ( pClient->GetMyChannelID() != INVALID_INDEX ) && ( pClient->GetMyChannelID() != static_cast<int> ( iChanID ) ) ) ) &&
+                if ( ( !bNoFaderVisible || ( ( iMyChannelID != INVALID_INDEX ) && ( iMyChannelID != static_cast<int> ( iChanID ) ) ) ) &&
                      ( pSettings->iNewClientFaderLevel != 100 ) )
                 {
                     // the value is in percent -> convert range
@@ -1395,10 +1396,12 @@ void CAudioMixerBoard::SetAllFaderLevelsToNewClientLevel()
 {
     QMutexLocker locker ( &Mutex );
 
+    const int iMyChannelID = pClient->GetMyChannelID();
+
     for ( size_t i = 0; i < MAX_NUM_CHANNELS; i++ )
     {
         // only apply to visible faders and not to my own channel fader
-        if ( vecpChanFader[i]->IsVisible() && ( static_cast<int> ( i ) != pClient->GetMyChannelID() ) )
+        if ( vecpChanFader[i]->IsVisible() && ( static_cast<int> ( i ) != iMyChannelID ) )
         {
             // the value is in percent -> convert range, also use the group
             // update flag to make sure the group values are all set to the
@@ -1423,11 +1426,13 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
     CVector<CVector<float>> levels;
     levels.resize ( MAX_NUM_FADER_GROUPS + 1 );
 
+    const int iMyChannelID = pClient->GetMyChannelID();
+
     // compute min/max level per group and number of channels per group
     for ( size_t i = 0; i < MAX_NUM_CHANNELS; ++i )
     {
         // only apply to visible faders (and not to my own channel fader)
-        if ( vecpChanFader[i]->IsVisible() && ( static_cast<int> ( i ) != pClient->GetMyChannelID() ) )
+        if ( vecpChanFader[i]->IsVisible() && ( static_cast<int> ( i ) != iMyChannelID ) )
         {
             // map averaged meter output level to decibels
             // (invert CStereoSignalLevelMeter::CalcLogResultForMeter)
@@ -1517,7 +1522,7 @@ void CAudioMixerBoard::AutoAdjustAllFaderLevels()
     for ( size_t i = 0; i < MAX_NUM_CHANNELS; ++i )
     {
         // only apply to visible faders (and not to my own channel fader)
-        if ( vecpChanFader[i]->IsVisible() && ( static_cast<int> ( i ) != pClient->GetMyChannelID() ) )
+        if ( vecpChanFader[i]->IsVisible() && ( static_cast<int> ( i ) != iMyChannelID ) )
         {
             // map averaged meter output level to decibels
             // (invert CStereoSignalLevelMeter::CalcLogResultForMeter)

--- a/src/audiomixerboard.h
+++ b/src/audiomixerboard.h
@@ -56,7 +56,8 @@ public:
     int     GetReceivedInstrument() { return cReceivedChanInfo.iInstrument; }
     QString GetReceivedCity() { return cReceivedChanInfo.strCity; }
     int     GetReceivedChID() { return cReceivedChanInfo.iChanID; }
-    void    SetChannelInfos ( const CChannelInfo& cChanInfo );
+    int     GetReceivedMIDIID() { return cReceivedMIDIID; }
+    void    SetChannelInfos ( const CChannelInfo& cChanInfo, int iMIDIID );
     void    Show() { pFrame->show(); }
     void    Hide() { pFrame->hide(); }
     bool    IsVisible() { return !pFrame->isHidden(); }
@@ -120,6 +121,7 @@ protected:
     QLabel*    plblCountryFlag;
 
     CChannelInfo cReceivedChanInfo;
+    int          cReceivedMIDIID;
 
     bool        bOtherChannelIsSolo;
     bool        bIsMyOwnFader;
@@ -190,6 +192,7 @@ public:
 
     virtual ~CAudioMixerBoard();
 
+    void    SetClientPointer ( CClient* pNClient ) { pClient = pNClient; }
     void    SetSettingsPointer ( CClientSettings* pNSet ) { pSettings = pNSet; }
     void    HideAll();
     void    ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInfo );
@@ -200,8 +203,6 @@ public:
     void    SetDisplayPans ( const bool eNDP );
     void    SetPanIsSupported();
     void    SetRemoteFaderIsMute ( const int iChannelIdx, const bool bIsMute );
-    void    SetMyChannelID ( const int iChannelIdx ) { iMyChannelID = iChannelIdx; }
-    int     GetMyChannelID() const { return iMyChannelID; }
 
     void SetFaderLevel ( const int iChannelIdx, const int iValue );
 
@@ -260,6 +261,7 @@ protected:
     void UpdateSoloStates();
     void UpdateTitle();
 
+    CClient*                pClient;
     CClientSettings*        pSettings;
     CVector<CChannelFader*> vecpChanFader;
     CMixerBoardScrollArea*  pScrollArea;
@@ -267,7 +269,6 @@ protected:
     bool                    bDisplayPans;
     bool                    bIsPanSupported;
     bool                    bNoFaderVisible;
-    int                     iMyChannelID;         // must use int (not size_t) so INVALID_INDEX can be stored
     int                     iRunningNewClientCnt; // integer type is sufficient, will never overrun for its purpose
     int                     iNumMixerPanelRows;
     QString                 strServerName;

--- a/src/client.h
+++ b/src/client.h
@@ -133,6 +133,8 @@ public:
 
     bool IsConnected() { return Channel.IsConnected(); }
 
+    int GetMyChannelID() { return iMyChannelID; }
+
     EGUIDesign GetGUIDesign() const { return eGUIDesign; }
     void       SetGUIDesign ( const EGUIDesign eNGD ) { eGUIDesign = eNGD; }
 
@@ -272,6 +274,10 @@ public:
         Channel.GetBufErrorRates ( vecErrRates, dLimit, dMaxUpLimit );
     }
 
+    // convert between MIDI index and real channel index
+    int ChanToMIDI ( const int iChanIdx );
+    int MIDIToChan ( const int iMIDIIdx );
+
     // settings
     CChannelCoreInfo ChannelInfo;
     QString          strClientName;
@@ -291,6 +297,9 @@ protected:
     // only one channel is needed for client application
     CChannel  Channel;
     CProtocol ConnLessProtocol;
+
+    // this client's channel ID sent by the server
+    int iMyChannelID; // must use int (not size_t) so INVALID_INDEX can be stored
 
     // audio encoder/decoder
     OpusCustomMode*        Opus64Mode;
@@ -398,10 +407,11 @@ protected slots:
     void OnCLPingWithNumClientsReceived ( CHostAddress InetAddr, int iMs, int iNumClients );
 
     void OnSndCrdReinitRequest ( int iSndCrdResetType );
-    void OnControllerInFaderLevel ( int iChannelIdx, int iValue );
-    void OnControllerInPanValue ( int iChannelIdx, int iValue );
-    void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
-    void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
+
+    void OnControllerInFaderLevel ( int iMIDIIdx, int iValue );
+    void OnControllerInPanValue ( int iMIDIIdx, int iValue );
+    void OnControllerInFaderIsSolo ( int iMIDIIdx, bool bIsSolo );
+    void OnControllerInFaderIsMute ( int iMIDIIdx, bool bIsMute );
     void OnControllerInMuteMyself ( bool bMute );
     void OnClientIDReceived ( int iChanID );
     void OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -214,7 +214,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // MeterStyle init
     SetMeterStyle ( pClient->GetMeterStyle() );
 
-    // set the settings pointer to the mixer board (must be done early)
+    // pass the client and settings pointers to the mixer board (must be done early)
+    MainMixerBoard->SetClientPointer ( pClient );
     MainMixerBoard->SetSettingsPointer ( pSettings );
     MainMixerBoard->SetNumMixerPanelRows ( pSettings->iNumMixerPanelRows );
 
@@ -486,8 +487,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QObject::connect ( pClient, &CClient::Disconnected, this, &CClientDlg::OnDisconnected );
 
     QObject::connect ( pClient, &CClient::ChatTextReceived, this, &CClientDlg::OnChatTextReceived );
-
-    QObject::connect ( pClient, &CClient::ClientIDReceived, this, &CClientDlg::OnClientIDReceived );
 
     QObject::connect ( pClient, &CClient::MuteStateHasChangedReceived, this, &CClientDlg::OnMuteStateHasChangedReceived );
 

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -223,8 +223,6 @@ public slots:
         ConnectDlg.SetConnClientsList ( InetAddr, vecChanInfo );
     }
 
-    void OnClientIDReceived ( int iChanID ) { MainMixerBoard->SetMyChannelID ( iChanID ); }
-
     void OnMuteStateHasChangedReceived ( int iChanID, bool bIsMuted ) { MainMixerBoard->SetRemoteFaderIsMute ( iChanID, bIsMuted ); }
 
     void OnCLChannelLevelListReceived ( CHostAddress /* unused */, CVector<uint16_t> vecLevelList )

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -168,9 +168,9 @@ protected:
 
 signals:
     void ReinitRequest ( int iSndCrdResetType );
-    void ControllerInFaderLevel ( int iChannelIdx, int iValue );
-    void ControllerInPanValue ( int iChannelIdx, int iValue );
-    void ControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
-    void ControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
+    void ControllerInFaderLevel ( int iMIDIIdx, int iValue );
+    void ControllerInPanValue ( int iMIDIIdx, int iValue );
+    void ControllerInFaderIsSolo ( int iMIDIIdx, bool bIsSolo );
+    void ControllerInFaderIsMute ( int iMIDIIdx, bool bIsMute );
     void ControllerInMuteMyself ( bool bMute );
 };


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Ensure the user's own channel is always given MIDI channel 0, so that the user is always the leftmost fader when using an external MIDI fader bank.

1. Moved my channel ID from the Mixer to the Client, so it is available when headless too.
2. Client's own channel, sent by the server, is always assigned to MIDI number 0, for left-most fader. Server channel numbers less than the user's own channel are bumped up by 1 to get the MIDI channel.
3. Translate between server channel and MIDI number at the client level.

CHANGELOG: Client: always assign MIDI channel 0 to the user's own channel.

**Context: Fixes an issue?**

Raised in https://github.com/orgs/jamulussoftware/discussions/2220#discussioncomment-10811813

This supersedes the solution proposed in #3394, and in particular avoids the use of a duplicate fader. It also needs no change to the `--ctrlmidich` parameter.

It is an implementation of my proposal in https://github.com/jamulussoftware/jamulus/pull/3394#issuecomment-2447827384

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

Only to document that the user's own channel will always be given fader channel 0, and that this is only relevant
when using `--ctrlmidich` to assign an external fader bank.

**Status of this Pull Request**

Tested and ready for review

**What is missing until this pull request can be merged?**

Consensus on the approach and testing on other platforms. Tested on Pi Linux.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
