### PR TITLE
Manage client-side channels locally, own channel always 0

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -361,8 +361,7 @@ void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )
         Q_ASSERT ( iActiveChannels == iNumConnectedClients );
     }
 
-    // TODO Does vecChanInfo need to be ordered by client channel ID instead of server channel ID?
-    // check if this is actually necessary, and whether it affects the level meters
+    // pass the received list onwards, now containing client channel IDs
 
     emit ConClientListMesReceived ( vecChanInfo );
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -286,7 +286,10 @@ void CClient::OnMuteStateHasChangedReceived ( int iServerChanID, bool bIsMuted )
     // map iChanID from server channel ID to client channel ID
     int iChanID = FindClientChannel ( iServerChanID, false );
 
-    emit MuteStateHasChangedReceived ( iChanID, bIsMuted );
+    if ( iChanID != INVALID_INDEX )
+    {
+        emit MuteStateHasChangedReceived ( iChanID, bIsMuted );
+    }
 }
 
 void CClient::OnCLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList )
@@ -321,8 +324,9 @@ void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )
             // server channel ID of this entry
             const int iServerChannelID = vecChanInfo[i].iChanID;
 
-            // find matching client channel ID, creating new if necessary
-            const int iClientChannelID = FindClientChannel ( iServerChannelID, true );
+            // find matching client channel ID, creating new if necessary,
+            // update channel number to be client-side
+            vecChanInfo[i].iChanID = FindClientChannel ( iServerChannelID, true );
 
             // discard any lower server channels that are no longer in our local list
             while ( iSrvIdx < iServerChannelID )
@@ -337,10 +341,8 @@ void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )
                 iSrvIdx++;
             }
 
-            // now should have matching server channel IDs
-            vecChanInfo[i].iChanID = iClientChannelID; // update channel number to be client-side
-            i++;                                       // next list entry
-            iSrvIdx++;                                 // next local server channel
+            i++;       // next list entry
+            iSrvIdx++; // next local server channel
         }
 
         // have now run out of active channels, discard any remaining from our local list
@@ -1476,7 +1478,7 @@ void CClient::ClearClientChannels()
         clientChannelIDs[i] = INVALID_INDEX;
     }
 
-    qInfo() << "> Client channel list cleared";
+    // qInfo() << "> Client channel list cleared";
 }
 
 void CClient::FreeClientChannel ( const int iServerChannelID )
@@ -1497,10 +1499,12 @@ void CClient::FreeClientChannel ( const int iServerChannelID )
 
     iActiveChannels -= 1;
 
+    /*
     qInfo() << qUtf8Printable ( QString ( "> Freed client ch %1 for server ch %2; chan count = %3" )
                                     .arg ( iClientChannelID )
                                     .arg ( iServerChannelID )
                                     .arg ( iActiveChannels ) );
+     */
 }
 
 // find, and optionally create, a client channel for the supplied server channel ID
@@ -1544,10 +1548,12 @@ int CClient::FindClientChannel ( const int iServerChannelID, const bool bCreateI
 
                 iActiveChannels += 1;
 
+                /*
                 qInfo() << qUtf8Printable ( QString ( "> Alloc client ch %1 for server ch %2; chan count = %3" )
                                                 .arg ( iClientChannelID )
                                                 .arg ( iServerChannelID )
                                                 .arg ( iActiveChannels ) );
+                 */
 
                 return iClientChannelID; // new client channel ID
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1574,6 +1574,9 @@ int CClient::FindClientChannel ( const int iServerChannelID, const bool bCreateI
 //
 // The list size is checked against the current number of active channels to guard against
 // any unexpected temporary mismatch in size due to potential out-of-order message delivery.
+//
+// This function returns true if the list has been processed and should be passed on,
+// or false if it was the wrong size and should be discarded.
 
 bool CClient::ReorderLevelList ( CVector<uint16_t>& vecLevelList )
 {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -307,6 +307,7 @@ void CClient::OnCLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint
 void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )
 {
     // TODO translate from server channel IDs to client channel IDs
+    // ALSO here is where we allocate and free client channels as required
 
     // Upon receiving a new client list, we have to reset oldGain and newGain
     // entries for unused channels. This ensures that a disconnected channel
@@ -331,6 +332,8 @@ void CClient::OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo )
             oldGain[iId] = newGain[iId] = 1;
         }
     }
+
+    // TODO vecChanInfo needs to be ordered by client channel ID instead of server channel ID
 
     emit ConClientListMesReceived ( vecChanInfo );
 }
@@ -444,7 +447,7 @@ void CClient::SetRemoteChanGain ( const int iId, const float fGain, const bool b
     // here the timer was not active:
     // send the actual gain and reset the range of channel IDs to empty
     oldGain[iId] = newGain[iId] = fGain;
-    Channel.SetRemoteChanGain ( iId, fGain );
+    Channel.SetRemoteChanGain ( iId, fGain );   // TODO translate client channel to server channel ID
 
     StartDelayTimer();
 }
@@ -460,7 +463,7 @@ void CClient::OnTimerRemoteChanGain()
         {
             // send new gain and record as old gain
             float fGain = oldGain[iId] = newGain[iId];
-            Channel.SetRemoteChanGain ( iId, fGain );
+            Channel.SetRemoteChanGain ( iId, fGain );   // TODO translate client channel to server channel ID
             bSent = true;
         }
     }
@@ -489,6 +492,11 @@ void CClient::StartDelayTimer()
     {
         TimerGain.start ( iCurPingTime * 2 );
     }
+}
+
+void CClient::SetRemoteChanPan ( const int iId, const float fPan )
+{
+    Channel.SetRemoteChanPan ( iId, fPan ); // TODO translate client channel to server channel ID
 }
 
 bool CClient::SetServerAddr ( QString strNAddr )
@@ -868,12 +876,14 @@ void CClient::OnControllerInMuteMyself ( bool bMute )
 
 void CClient::OnClientIDReceived ( int iChanID )
 {
+    // TODO allocate and map client-side channel 0
+
     // for headless mode we support to mute our own signal in the personal mix
     // (note that the check for headless is done in the main.cpp and must not
     // be checked here)
     if ( bMuteMeInPersonalMix )
     {
-        SetRemoteChanGain ( iChanID, 0, false );
+        SetRemoteChanGain ( iChanID, 0, false );    // TODO this will need client channel ID
     }
 
     emit ClientIDReceived ( iChanID );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1478,8 +1478,7 @@ void CClient::ClearClientChannels()
     for ( int i = 0; i < MAX_NUM_CHANNELS; i++ )
     {
         clientChannels[i].iServerChannelID = INVALID_INDEX;
-        clientChannels[i].iJoinSequence    = 0;
-        // TODO reset any other fields in CClientChannel
+        // all other fields will be initialised on channel allocation
 
         clientChannelIDs[i] = INVALID_INDEX;
     }
@@ -1537,11 +1536,18 @@ int CClient::FindClientChannel ( const int iServerChannelID, const bool bCreateI
         // search clientChannels[] for a free client channel
         for ( iClientChannelID = 0; iClientChannelID < MAX_NUM_CHANNELS; iClientChannelID++ )
         {
-            if ( clientChannels[iClientChannelID].iServerChannelID == INVALID_INDEX )
+            CClientChannel* clientChan = &clientChannels[iClientChannelID];
+
+            if ( clientChan->iServerChannelID == INVALID_INDEX )
             {
-                clientChannels[iClientChannelID].iServerChannelID = iServerChannelID;
-                clientChannels[iClientChannelID].iJoinSequence    = ++iJoinSequence;
-                clientChannelIDs[iServerChannelID]                = iClientChannelID;
+                clientChan->iServerChannelID = iServerChannelID;
+                clientChan->iJoinSequence    = ++iJoinSequence;
+
+                clientChan->oldGain = clientChan->newGain = 1.0f;
+
+                clientChan->level = 0;
+
+                clientChannelIDs[iServerChannelID] = iClientChannelID;
 
                 iActiveChannels += 1;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1558,6 +1558,24 @@ int CClient::FindClientChannel ( const int iServerChannelID, const bool bCreateI
     return INVALID_INDEX;
 }
 
+// When the client receives a channel level list from the server, the list contains one value
+// for each currently-active channel, ordered by the channel ID assigned by the server.
+// The values will correspond to the active channels in the last client list that was sent.
+// This list is passed up to the mixer board, which will interpret the values in the order
+// of channels that it knows about.
+//
+// Since CClient is now translating server channel IDs to local client channel IDs before
+// passing the client list up to the mixer board, it is also necessary to re-order the values
+// in the level list so that they are in order of mapped client channel ID.
+// This function performs that re-ordering by scanning the server channels in order, once,
+// for active channels, and storing the level value in the corresponding client channel.
+// Then the function scans the client channels in order, fetching the level values and putting
+// them back into vecLevelList in order of client channel. The mixer board will then display
+// the levels against the correct channels.
+//
+// The list size is checked against the current number of active channels to guard against
+// any unexpected temporary mismatch in size due to potential out-of-order message delivery.
+
 bool CClient::ReorderLevelList ( CVector<uint16_t>& vecLevelList )
 {
     QMutexLocker locker ( &MutexChannels );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -927,6 +927,15 @@ void CClient::OnControllerInMuteMyself ( bool bMute )
 
 void CClient::OnClientIDReceived ( int iServerChanID )
 {
+    // if we have just connected to a running server, iActiveChannels will be 0
+    // if iActiveChannels is not 0, the server must have been restarted on the fly
+    // in that case, channels might have changed, so clear our list to get it afresh.
+    if ( iActiveChannels != 0 )
+    {
+        qInfo() << "> Server restarted?";
+        ClearClientChannels();
+    }
+
     // allocate and map client-side channel 0
     int iChanID = FindClientChannel ( iServerChanID, true ); // should always return channel 0
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1569,7 +1569,7 @@ int CClient::FindClientChannel ( const int iServerChannelID, const bool bCreateI
 // This list is passed up to the mixer board, which will interpret the values in the order
 // of channels that it knows about.
 //
-// Since CClient is now translating server channel IDs to local client channel IDs before
+// Since CClient is translating server channel IDs to local client channel IDs before
 // passing the client list up to the mixer board, it is also necessary to re-order the values
 // in the level list so that they are in order of mapped client channel ID.
 // This function performs that re-ordering by scanning the server channels in order, once,

--- a/src/client.h
+++ b/src/client.h
@@ -109,6 +109,7 @@ class CClientChannel
 {
 public:
     int iServerChannelID; // unused channels will contain INVALID_INDEX
+    int iJoinSequence;    // order of joining of session participants
 
     // can store here other information about an active channel
 };
@@ -313,8 +314,8 @@ protected:
     // unused channels will contain INVALID_INDEX
     int clientChannelIDs[MAX_NUM_CHANNELS];
 
-    // number of active channels
-    int    iActiveChannels;
+    int    iActiveChannels; // number of active channels
+    int    iJoinSequence;   // order of joining of session participants
     QMutex MutexChannels;
 
     // audio encoder/decoder

--- a/src/client.h
+++ b/src/client.h
@@ -305,6 +305,7 @@ protected:
     void ClearClientChannels();
     void FreeClientChannel ( const int iServerChannelID );
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
+    bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
 
     // only one channel is needed for client application
     CChannel  Channel;

--- a/src/client.h
+++ b/src/client.h
@@ -429,8 +429,8 @@ protected slots:
     void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
     void OnControllerInMuteMyself ( bool bMute );
-    void OnClientIDReceived ( int iChanID );
-    void OnMuteStateHasChangedReceived ( int iChanID, bool bIsMuted );
+    void OnClientIDReceived ( int iServerChanID );
+    void OnMuteStateHasChangedReceived ( int iServerChanID, bool bIsMuted );
     void OnCLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
     void OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );
 

--- a/src/client.h
+++ b/src/client.h
@@ -104,6 +104,15 @@
 #define OPUS_NUM_BYTES_STEREO_HIGH_QUALITY_DBLE_FRAMESIZE   165
 
 /* Classes ********************************************************************/
+
+class CClientChannel
+{
+public:
+    int iServerChannelID; // unused channels will contain INVALID_INDEX
+
+    // can store here other information about an active channel
+};
+
 class CClient : public QObject
 {
     Q_OBJECT
@@ -288,9 +297,25 @@ protected:
     int  EvaluatePingMessage ( const int iMs );
     void CreateServerJitterBufferMessage();
 
+    void ClearClientChannels();
+    void FreeClientChannel ( const int iServerChannelID );
+    int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
+
     // only one channel is needed for client application
     CChannel  Channel;
     CProtocol ConnLessProtocol;
+
+    // client channels, indexed by client channel ID,
+    // containing server channel ID (INVALID_INDEX if free)
+    CClientChannel clientChannels[MAX_NUM_CHANNELS];
+
+    // client channel IDs, indexed by server channel ID
+    // unused channels will contain INVALID_INDEX
+    int clientChannelIDs[MAX_NUM_CHANNELS];
+
+    // number of active channels
+    int    iActiveChannels;
+    QMutex MutexChannels;
 
     // audio encoder/decoder
     OpusCustomMode*        Opus64Mode;

--- a/src/client.h
+++ b/src/client.h
@@ -111,6 +111,10 @@ public:
     int iServerChannelID; // unused channels will contain INVALID_INDEX
     int iJoinSequence;    // order of joining of session participants
 
+    float oldGain, newGain; // for rate-limiting sending of gain messages
+
+    uint16_t level; // last value of level meter received for channel
+
     // can store here other information about an active channel
 };
 

--- a/src/client.h
+++ b/src/client.h
@@ -404,6 +404,8 @@ protected slots:
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );
     void OnControllerInMuteMyself ( bool bMute );
     void OnClientIDReceived ( int iChanID );
+    void OnMuteStateHasChangedReceived ( int iChanID, bool bIsMuted );
+    void OnCLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
     void OnConClientListMesReceived ( CVector<CChannelInfo> vecChanInfo );
 
 signals:

--- a/src/client.h
+++ b/src/client.h
@@ -244,7 +244,7 @@ public:
     void OnTimerRemoteChanGain();
     void StartDelayTimer();
 
-    void SetRemoteChanPan ( const int iId, const float fPan ) { Channel.SetRemoteChanPan ( iId, fPan ); }
+    void SetRemoteChanPan ( const int iId, const float fPan );
 
     void SetInputBoost ( const int iNewBoost ) { iInputBoost = iNewBoost; }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -333,7 +333,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QAction* ByCityAction =
         pViewMenu->addAction ( tr ( "Sort Users by &City" ), this, SLOT ( OnSortChannelsByCity() ), QKeySequence ( Qt::CTRL + Qt::Key_T ) );
 
-    QAction* ByServerChannelAction =
+    QAction* ByChannelAction =
         pViewMenu->addAction ( tr ( "Sort Users by Chann&el" ), this, SLOT ( OnSortChannelsByChannel() ), QKeySequence ( Qt::CTRL + Qt::Key_E ) );
 
     OwnFaderFirstAction->setCheckable ( true );
@@ -352,8 +352,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     SortActionGroup->addAction ( ByGroupAction );
     ByCityAction->setCheckable ( true );
     SortActionGroup->addAction ( ByCityAction );
-    ByServerChannelAction->setCheckable ( true );
-    SortActionGroup->addAction ( ByServerChannelAction );
+    ByChannelAction->setCheckable ( true );
+    SortActionGroup->addAction ( ByChannelAction );
 
     // initialize sort type setting (i.e., recover stored setting)
     switch ( pSettings->eChannelSortType )
@@ -371,7 +371,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
         ByCityAction->setChecked ( true );
         break;
     case ST_BY_SERVER_CHANNEL:
-        ByServerChannelAction->setChecked ( true );
+        ByChannelAction->setChecked ( true );
         break;
     default: // ST_NO_SORT
         NoSortAction->setChecked ( true );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -333,10 +333,10 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QAction* ByCityAction =
         pViewMenu->addAction ( tr ( "Sort Users by &City" ), this, SLOT ( OnSortChannelsByCity() ), QKeySequence ( Qt::CTRL + Qt::Key_T ) );
 
-    QAction* ByServerChannelAction = pViewMenu->addAction ( tr ( "Sort Users by Se&rver Channel" ),
+    QAction* ByServerChannelAction = pViewMenu->addAction ( tr ( "Sort Users by Chann&el" ),
                                                             this,
                                                             SLOT ( OnSortChannelsByChannel() ),
-                                                            QKeySequence ( Qt::CTRL + Qt::Key_R ) );
+                                                            QKeySequence ( Qt::CTRL + Qt::Key_E ) );
 
     OwnFaderFirstAction->setCheckable ( true );
     OwnFaderFirstAction->setChecked ( pSettings->bOwnFaderFirst );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -333,10 +333,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QAction* ByCityAction =
         pViewMenu->addAction ( tr ( "Sort Users by &City" ), this, SLOT ( OnSortChannelsByCity() ), QKeySequence ( Qt::CTRL + Qt::Key_T ) );
 
-    QAction* ByServerChannelAction = pViewMenu->addAction ( tr ( "Sort Users by Chann&el" ),
-                                                            this,
-                                                            SLOT ( OnSortChannelsByChannel() ),
-                                                            QKeySequence ( Qt::CTRL + Qt::Key_E ) );
+    QAction* ByServerChannelAction =
+        pViewMenu->addAction ( tr ( "Sort Users by Chann&el" ), this, SLOT ( OnSortChannelsByChannel() ), QKeySequence ( Qt::CTRL + Qt::Key_E ) );
 
     OwnFaderFirstAction->setCheckable ( true );
     OwnFaderFirstAction->setChecked ( pSettings->bOwnFaderFirst );


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Manages the allocation of client-side channels independently of server-side channels, and maps between
the two at the boundary between CClient and the lower-level CChannel and CProtocol.

All layers above (e.g. CClientDlg and the audio mixer board) will use client-side channels transparently.

When talking to a server version 3.5.5 or newer, the client is told its own server channel, and will always map
this to client channel 0. This allows the user of a MIDI device or JSON-RPC client to know that channel 0 will always control
the user's own audio channel.

In addition, when connecting to a server that only has a small number of high-numbered channels remaining
after many users have left, those channels will automatically be mapped to lower client channel numbers and
so will be controllable using local MIDI faders.

CHANGELOG: Client: allocate channel numbers locally and always give user own channel of 0

**Context: Fixes an issue?**

Resolves #3423 and supersedes both #3419 and #3394

**Does this change need documentation? What needs to be documented and how?**

Most operation is unchanged from before, but it is worth mentioning that the user's own channel will always be
number 0 unless connected to a server older than 3.5.5

**Status of this Pull Request**

Tested and working, ready for review.

**What is missing until this pull request can be merged?**

Testing on multiple platforms.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
