### PR TITLE
Fixes 3318: Anchor check for CHANGELOG tag

### DIFF
--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -183,7 +183,7 @@ check_or_add_pr() {
     fi
     local title_suggestion_in_pr
     title_suggestion_in_pr=$(gh pr view "$id" --json body,comments,reviews --jq '(.body), (.comments[] .body), (.reviews[] .body)' |
-        grep -oP '\bCHANGELOG:\s*\K([^\\]{5,})' | tail -n1 | sanitize_title || true)
+        grep -oP '^\bCHANGELOG:\s*\K([^\\]{5,})' | tail -n1 | sanitize_title || true)
     if [[ "${title_suggestion_in_pr}" ]]; then
         title="${title_suggestion_in_pr}"
         if [[ "${title_suggestion_in_pr}" == "SKIP" ]]; then


### PR DESCRIPTION
**Short description of changes**

Anchors the check for the "C H A N G E L O G" tag so it must be at the start of the line (with permitted leading whitespace, although I'm not sure we should allow it).

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes: #3318

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Checked and it runs okay.

**What is missing until this pull request can be merged?**

Ready for review / merge.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
