### PR TITLE
Add profile checkbox to enable/disable tooltips

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -84,11 +84,13 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     lbrInputLevelL->setAccessibleName ( strInpLevHAccText );
     lbrInputLevelL->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelL->setToolTip ( strInpLevHTT );
+    lbrInputLevelL->installEventFilter ( this ); // install event filter for tooltips
     lbrInputLevelL->setEnabled ( false );
     lbrInputLevelR->setWhatsThis ( strInpLevH );
     lbrInputLevelR->setAccessibleName ( strInpLevHAccText );
     lbrInputLevelR->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelR->setToolTip ( strInpLevHTT );
+    lbrInputLevelR->installEventFilter ( this ); // install event filter for tooltips
     lbrInputLevelR->setEnabled ( false );
 
     // connect/disconnect button
@@ -153,6 +155,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                                 "you will not have much fun using %1." )
                                .arg ( APP_NAME ) +
                            TOOLTIP_COM_END_TEXT );
+    ledDelay->installEventFilter ( this ); // install event filter for tooltips
 
     ledDelay->setAccessibleName ( tr ( "Delay status LED indicator" ) );
 
@@ -184,6 +187,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     ledBuffers->setToolTip ( tr ( "If this LED indicator turns red, "
                                   "the audio stream is interrupted." ) +
                              TOOLTIP_COM_END_TEXT );
+    ledBuffers->installEventFilter ( this ); // install event filter for tooltips
 
     ledBuffers->setAccessibleName ( tr ( "Local Jitter Buffer status LED indicator" ) );
 
@@ -1515,4 +1519,16 @@ void CClientDlg::SetPingTime ( const int iPingTime, const int iOverallDelayMs, c
 
     // set current LED status
     ledDelay->SetLight ( eOverallDelayLEDColor );
+}
+
+bool CClientDlg::eventFilter ( QObject* obj, QEvent* event )
+{
+    if ( event->type() == QEvent::ToolTip )
+    {
+        // return true to suppress tooltip, false to allow it
+        return !pSettings->bShowToolTips;
+    }
+
+    // continue with normal processing for other events
+    return QObject::eventFilter ( obj, event );
 }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -121,6 +121,8 @@ protected:
     virtual void dropEvent ( QDropEvent* Event ) { ManageDragNDrop ( Event, false ); }
     void         UpdateDisplay();
 
+    bool eventFilter ( QObject* obj, QEvent* event );
+
     CClientSettingsDlg ClientSettingsDlg;
     CChatDlg           ChatDlg;
     CConnectDlg        ConnectDlg;

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -397,6 +397,11 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                         "A second sound device may be required to hear the alerts." ) );
     chbAudioAlerts->setAccessibleName ( tr ( "Audio Alerts check box" ) );
 
+    // show tooltips
+    chbShowToolTips->setWhatsThis ( "<b>" + tr ( "Show ToolTips" ) + ":</b> " +
+                                    tr ( "Enable or disable the showing of ToolTips when the mouse points to certain items." ) );
+    chbShowToolTips->setAccessibleName ( tr ( "Show ToolTips check box" ) );
+
     // init driver button
 #if defined( _WIN32 ) && !defined( WITH_JACK )
     butDriverSetup->setText ( tr ( "ASIO Device Settings" ) );
@@ -479,6 +484,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     // init audio alerts
     chbAudioAlerts->setCheckState ( pSettings->bEnableAudioAlerts ? Qt::Checked : Qt::Unchecked );
+
+    // init show tooltips
+    chbShowToolTips->setCheckState ( pSettings->bShowToolTips ? Qt::Checked : Qt::Unchecked );
 
     // update feedback detection
     chbDetectFeedback->setCheckState ( pSettings->bEnableFeedbackDetection ? Qt::Checked : Qt::Unchecked );
@@ -644,6 +652,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     QObject::connect ( chbDetectFeedback, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnFeedbackDetectionChanged );
 
     QObject::connect ( chbAudioAlerts, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnAudioAlertsChanged );
+
+    QObject::connect ( chbShowToolTips, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnShowToolTipsChanged );
 
     // line edits
     QObject::connect ( edtNewClientLevel, &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnNewClientLevelEditingFinished );
@@ -997,6 +1007,8 @@ void CClientSettingsDlg::OnMeterStyleActivated ( int iMeterStyleIdx )
 }
 
 void CClientSettingsDlg::OnAudioAlertsChanged ( int value ) { pSettings->bEnableAudioAlerts = value == Qt::Checked; }
+
+void CClientSettingsDlg::OnShowToolTipsChanged ( int value ) { pSettings->bShowToolTips = value == Qt::Checked; }
 
 void CClientSettingsDlg::OnAutoJitBufStateChanged ( int value )
 {

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -106,16 +106,21 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     lblNetBuf->setWhatsThis ( strJitterBufferSize );
     lblNetBuf->setToolTip ( strJitterBufferSizeTT );
+    lblNetBuf->installEventFilter ( this ); // install event filter for tooltips
     grbJitterBuffer->setWhatsThis ( strJitterBufferSize );
     grbJitterBuffer->setToolTip ( strJitterBufferSizeTT );
+    grbJitterBuffer->installEventFilter ( this ); // install event filter for tooltips
     sldNetBuf->setWhatsThis ( strJitterBufferSize );
     sldNetBuf->setAccessibleName ( tr ( "Local jitter buffer slider control" ) );
     sldNetBuf->setToolTip ( strJitterBufferSizeTT );
+    sldNetBuf->installEventFilter ( this ); // install event filter for tooltips
     sldNetBufServer->setWhatsThis ( strJitterBufferSize );
     sldNetBufServer->setAccessibleName ( tr ( "Server jitter buffer slider control" ) );
     sldNetBufServer->setToolTip ( strJitterBufferSizeTT );
+    sldNetBufServer->installEventFilter ( this ); // install event filter for tooltips
     chbAutoJitBuf->setAccessibleName ( tr ( "Auto jitter buffer check box" ) );
     chbAutoJitBuf->setToolTip ( strJitterBufferSizeTT );
+    chbAutoJitBuf->installEventFilter ( this ); // install event filter for tooltips
 
 #if !defined( WITH_JACK )
     // sound card device
@@ -143,6 +148,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                     "driver, make sure to connect the ASIO inputs in the kX DSP settings "
                                     "panel." ) +
                                TOOLTIP_COM_END_TEXT );
+    cbxSoundcard->installEventFilter ( this ); // install event filter for tooltips
 #    endif
 
     // sound card input/output channel mapping
@@ -249,17 +255,21 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     rbtBufferDelayPreferred->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayPreferred->setAccessibleName ( tr ( "64 samples setting radio button" ) );
     rbtBufferDelayPreferred->setToolTip ( strSndCrdBufDelayTT );
+    rbtBufferDelayPreferred->installEventFilter ( this ); // install event filter for tooltips
     rbtBufferDelayDefault->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayDefault->setAccessibleName ( tr ( "128 samples setting radio button" ) );
     rbtBufferDelayDefault->setToolTip ( strSndCrdBufDelayTT );
+    rbtBufferDelayDefault->installEventFilter ( this ); // install event filter for tooltips
     rbtBufferDelaySafe->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelaySafe->setAccessibleName ( tr ( "256 samples setting radio button" ) );
     rbtBufferDelaySafe->setToolTip ( strSndCrdBufDelayTT );
+    rbtBufferDelaySafe->installEventFilter ( this ); // install event filter for tooltips
 
 #if defined( _WIN32 ) && !defined( WITH_JACK )
     butDriverSetup->setWhatsThis ( strSndCardDriverSetup );
     butDriverSetup->setAccessibleName ( tr ( "ASIO Device Settings push button" ) );
     butDriverSetup->setToolTip ( strSndCardDriverSetupTT );
+    butDriverSetup->installEventFilter ( this ); // install event filter for tooltips
 #endif
 
     // fancy skin
@@ -398,9 +408,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     chbAudioAlerts->setAccessibleName ( tr ( "Audio Alerts check box" ) );
 
     // show tooltips
-    chbShowToolTips->setWhatsThis ( "<b>" + tr ( "Show ToolTips" ) + ":</b> " +
-                                    tr ( "Enable or disable the showing of ToolTips when the mouse points to certain items." ) );
-    chbShowToolTips->setAccessibleName ( tr ( "Show ToolTips check box" ) );
+    chbShowToolTips->setWhatsThis ( "<b>" + tr ( "Show tool tips" ) + ":</b> " +
+                                    tr ( "Enable or disable the showing of tool tips when the mouse points to certain items." ) );
+    chbShowToolTips->setAccessibleName ( tr ( "Show tool tips check box" ) );
 
     // init driver button
 #if defined( _WIN32 ) && !defined( WITH_JACK )
@@ -1227,4 +1237,16 @@ void CClientSettingsDlg::OnAudioPanValueChanged ( int value )
 {
     pClient->SetAudioInFader ( value );
     UpdateAudioFaderSlider();
+}
+
+bool CClientSettingsDlg::eventFilter ( QObject* obj, QEvent* event )
+{
+    if ( event->type() == QEvent::ToolTip )
+    {
+        // return true to suppress tooltip, false to allow it
+        return !pSettings->bShowToolTips;
+    }
+
+    // continue with normal processing for other events
+    return QObject::eventFilter ( obj, event );
 }

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -71,6 +71,8 @@ protected:
 
     virtual void showEvent ( QShowEvent* );
 
+    bool eventFilter ( QObject* obj, QEvent* event );
+
     CClient*         pClient;
     CClientSettings* pSettings;
     QTimer           TimerStatus;

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -97,6 +97,7 @@ public slots:
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnMeterStyleActivated ( int iMeterStyleIdx );
     void OnAudioAlertsChanged ( int value );
+    void OnShowToolTipsChanged ( int value );
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnAliasTextChanged ( const QString& strNewName );
     void OnInstrumentActivated ( int iCntryListItem );
@@ -116,6 +117,7 @@ signals:
     void GUIDesignChanged();
     void MeterStyleChanged();
     void AudioAlertsChanged();
+    void ShowToolTipsChanged();
     void AudioChannelsChanged();
     void CustomDirectoriesChanged();
     void NumMixerPanelRowsChanged ( int value );

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -276,6 +276,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <widget class="QLabel" name="lblShowToolTips">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </item>
                 <item>
@@ -319,6 +326,13 @@
                    <widget class="QCheckBox" name="chbAudioAlerts">
                     <property name="text">
                      <string>Audio Alerts</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="chbShowToolTips">
+                    <property name="text">
+                     <string>Show Tooltips</string>
                     </property>
                    </widget>
                   </item>
@@ -1358,6 +1372,7 @@
   <tabstop>cbxLanguage</tabstop>
   <tabstop>spnMixerRows</tabstop>
   <tabstop>chbAudioAlerts</tabstop>
+  <tabstop>chbShowToolTips</tabstop>
   <tabstop>cbxSoundcard</tabstop>
   <tabstop>butDriverSetup</tabstop>
   <tabstop>cbxLInChan</tabstop>

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -332,7 +332,7 @@
                   <item>
                    <widget class="QCheckBox" name="chbShowToolTips">
                     <property name="text">
-                     <string>Show Tooltips</string>
+                     <string>Show tool tips</string>
                     </property>
                    </widget>
                   </item>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -289,6 +289,12 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         bEnableAudioAlerts = bValue;
     }
 
+    // show tooltips
+    if ( GetFlagIniSet ( IniXMLDocument, "client", "showtooltips", bValue ) )
+    {
+        bShowToolTips = bValue;
+    }
+
     // name
     pClient->ChannelInfo.strName = FromBase64ToString (
         GetIniSetting ( IniXMLDocument, "client", "name_base64", ToBase64 ( QCoreApplication::translate ( "CMusProfDlg", "No Name" ) ) ) );
@@ -651,6 +657,9 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument, bool is
 
     // audio alerts
     SetFlagIniSet ( IniXMLDocument, "client", "enableaudioalerts", bEnableAudioAlerts );
+
+    // show tooltips
+    SetFlagIniSet ( IniXMLDocument, "client", "showtooltips", bShowToolTips );
 
     // name
     PutIniSetting ( IniXMLDocument, "client", "name_base64", ToBase64 ( pClient->ChannelInfo.strName ) );

--- a/src/settings.h
+++ b/src/settings.h
@@ -157,6 +157,7 @@ public:
         eDirectoryType ( AT_DEFAULT ),
         bEnableFeedbackDetection ( true ),
         bEnableAudioAlerts ( false ),
+        bShowToolTips ( true ),
         vecWindowPosSettings(), // empty array
         vecWindowPosChat(),     // empty array
         vecWindowPosConnect(),  // empty array
@@ -191,6 +192,7 @@ public:
     int              iCustomDirectoryIndex; // index of selected custom directory
     bool             bEnableFeedbackDetection;
     bool             bEnableAudioAlerts;
+    bool             bShowToolTips;
 
     // window position/state settings
     QByteArray vecWindowPosSettings;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds a checkbox to the My Profile dialog to enable tooltips to be enabled or disabled. The setting is stored in the `.ini` file. A Qt event filter consumes the tooltip event if tooltips are disabled, preventing the tooltip from being shown.

CHANGELOG: Client: add a checkbox to My Profile to enable/disable tooltips.

**Context: Fixes an issue?**

The PR #3252 adds additional tooltips to the Connect dialog, some of which are quite wordy. While these tooltips will be useful to new or occasional users of Jamulus, they can quickly become annoying to experienced users who have no need of the wordy reminder, particularly within the server list. Allowing tooltips to be disabled caters for both types of user.

**Does this change need documentation? What needs to be documented and how?**

Any Wiki page that has a screenshot and description of the the My Profile page should be updated.

**Status of this Pull Request**

Tested and working.

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
