### PR TITLE
Build: Fix windows for qt6.8.1

### DIFF
--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -53,7 +53,7 @@ $Qt64Version = "6.8.1"
 $AqtinstallVersion = "3.1.21"
 $JackVersion = "1.9.22"
 $Msvc32Version = "win32_msvc2019"
-$Msvc64Version = "win64_msvc2019_64"
+$Msvc64Version = "win64_msvc2022_64"
 $JomVersion = "1.1.2"
 
 # Compose JACK download urls

--- a/.github/autobuild/windows.ps1
+++ b/.github/autobuild/windows.ps1
@@ -49,7 +49,7 @@ $DownloadCacheDir = 'C:\AutobuildCache'
 # The following version pinnings are semi-automatically checked for
 # updates. Verify .github/workflows/bump-dependencies.yaml when changing those manually:
 $Qt32Version = "5.15.2"
-$Qt64Version = "6.7.3"
+$Qt64Version = "6.8.1"
 $AqtinstallVersion = "3.1.21"
 $JackVersion = "1.9.22"
 $Msvc32Version = "win32_msvc2019"

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -227,7 +227,7 @@ jobs:
           - config_name:            MacOS (artifacts)
             target_os:              macos
             building_on_os:         macos-14
-            base_command:           QT_VERSION=6.7.3 SIGN_IF_POSSIBLE=1 TARGET_ARCHS="x86_64 arm64" ./.github/autobuild/mac.sh
+            base_command:           QT_VERSION=6.8.1 SIGN_IF_POSSIBLE=1 TARGET_ARCHS="x86_64 arm64" ./.github/autobuild/mac.sh
             # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
             run_codeql:             false
             # Latest Xcode which runs on macos-14:

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -78,7 +78,7 @@ Download and install Qt e.g via the [official open source installer](https://www
 
 **Note:**
 - Use the free GPLv2 license for Open Source development, not the commercial "universal installer"
-- Select Components during installation: Expand the Qt section, find the matching version, preferrably **Qt 5.15.2**, and add the compiler components for your compiler, e.g., `MSVC 2019 32-bit/64-bit` for Visual Studio 2019
+- Select Components during installation: Expand the Qt section, find the matching version.  To match the Github builds, you will need to check the versions in `windows/deploy_windows.ps2`.  This gives both the Qt and MSVC versions (e.g. 6.8.1 and msvc2022_64 for a 64bit release).
 
 If you build with *JACK* support, install JACK via choco: `choco install --no-progress -y jack`
 

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -1,9 +1,9 @@
 param (
     # Replace default path with system Qt installation folder if necessary
     [string] $QtInstallPath32 = "C:\Qt\5.15.2",
-    [string] $QtInstallPath64 = "C:\Qt\5.15.2",
+    [string] $QtInstallPath64 = "C:\Qt\6.8.1",
     [string] $QtCompile32 = "msvc2019",
-    [string] $QtCompile64 = "msvc2019_64",
+    [string] $QtCompile64 = "msvc2022_64",
     # Important:
     # - Do not update ASIO SDK without checking for license-related changes.
     # - Do not copy (parts of) the ASIO SDK into the Jamulus source tree without


### PR DESCRIPTION
**Short description of changes**

See https://github.com/jamulussoftware/jamulus/pull/3407 for discussion.

This includes the ci bump commit on the branch, currently.

CHANGELOG: SKIP

**Context: Fixes an issue?**

See https://github.com/jamulussoftware/jamulus/pull/3407 for discussion.

Leaves the iOS build broken.  There doesn't seem to be any way to pin versions in the "Bump versions" workflow.

I've a [branch here](https://github.com/jamulussoftware/jamulus/compare/main...revert-ios-to-qt6_7_3-until-ffmpeg-fixed) which reverts the iOS change but the "Bump versions" will just come and bump it again.  (Build [here](https://github.com/jamulussoftware/jamulus/actions/runs/12526188602/job/34938486672).)

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Fixes the Windows builds.

**What is missing until this pull request can be merged?**

No.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
