### PR TITLE
Changelog helper tool updated

### DIFF
--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -39,6 +39,7 @@ export GH_REPO=jamulussoftware/jamulus
 
 PR_LIST_LIMIT=300
 TRANSLATION_ENTRY_TEXT="GUI: Translations have been updated:"
+TRANSLATION_ENTRY_TEXT2="Translations updated from Hosted Weblate"
 declare -A LANGS
 LANGS[de_DE]="German"
 LANGS[fr_FR]="French"
@@ -112,32 +113,35 @@ group_entries() {
     # Prepend a number to known categories in order to make their sorting position consistent:
     category_order=(
         "$TRANSLATION_ENTRY_TEXT"
-        "GUI"
-        "Accessibility"
-        "Client"
-        "Server"
-        "Recorder"
-        "Performance"
-        "CLI"
-        "Bug Fix"
-        "Windows"
-        "Installer"
-        "Linux"
-        "Mac"
-        "Android"
-        "iOS"
-        "Translation"
-        "Doc"
-        "Website"
-        "Github"
-        "Build"
-        "Autobuild"
-        "Code"
-        "Internal"
+        "$TRANSLATION_ENTRY_TEXT2"
+        "GUI:"
+        "Accessibility:"
+        "Client:"
+        "Client/Server:"
+        "Server:"
+        "Recorder:"
+        "Performance:"
+        "CLI:"
+        "Bug Fix:"
+        "Windows:"
+        "Installer:"
+        "Linux:"
+        "Mac:"
+        "Android:"
+        "iOS:"
+        "Translation:"
+        "Doc:"
+        "Website:"
+        "Github:"
+        "Build:"
+        "Autobuild:"
+        "Code:"
+        "Internal:"
     )
     local index=0
     for category in "${category_order[@]}"; do
-        changelog=$(sed -re 's/^(- '"${category}"')/'"${index}"' \1/' <<< "${changelog}")
+        # use | as delimiter, as category may contain /
+        changelog=$(sed -re 's|^(- '"${category}"')|'"${index}"' \1|' <<< "${changelog}")
         index=$((index + 1))
     done
 

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -141,7 +141,8 @@ group_entries() {
     local index=0
     for category in "${category_order[@]}"; do
         # use | as delimiter, as category may contain /
-        changelog=$(sed -re 's|^(- '"${category}"')|'"${index}"' \1|' <<< "${changelog}")
+        # also re-add stripped newline from last line, for correct sorting
+        changelog=$(sed -re 's|^(- '"${category}"')|'"${index}"' \1|' <<< "${changelog}")$'\n'
         index=$((index + 1))
     done
 

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -130,6 +130,7 @@ group_entries() {
         "Mac:"
         "Android:"
         "iOS:"
+        "Dependencies:"
         "Translation:"
         "Doc:"
         "Website:"

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -41,6 +41,10 @@ PR_LIST_LIMIT=300
 TRANSLATION_ENTRY_TEXT="GUI: Translations have been updated:"
 TRANSLATION_ENTRY_TEXT2="Translations updated from Hosted Weblate"
 BUNDLED_QT_UPDATE_TEXT="Build: Updated bundled Qt6"
+# must escape ( and ) so that sed doesn't treat them as magic
+BUNDLED_JACK_UPDATE_TEXT="Build: Updated bundled JACK \\(Windows-only\\)"
+NSIS_UPDATE_TEXT="Build: Updated Windows Installer base \\(NSIS\\)"
+ASIO_UPDATE_TEXT="Build: Updated ASIO SDK \\(Windows-only\\)"
 declare -A LANGS
 LANGS[de_DE]="German"
 LANGS[fr_FR]="French"
@@ -136,6 +140,9 @@ group_entries() {
         "Website:"
         "Github:"
         "$BUNDLED_QT_UPDATE_TEXT"
+        "$BUNDLED_JACK_UPDATE_TEXT"
+        "$NSIS_UPDATE_TEXT"
+        "$ASIO_UPDATE_TEXT"
         "Build:"
         "Autobuild:"
         "Code:"

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -40,6 +40,7 @@ export GH_REPO=jamulussoftware/jamulus
 PR_LIST_LIMIT=300
 TRANSLATION_ENTRY_TEXT="GUI: Translations have been updated:"
 TRANSLATION_ENTRY_TEXT2="Translations updated from Hosted Weblate"
+BUNDLED_QT_UPDATE_TEXT="Build: Updated bundled Qt6"
 declare -A LANGS
 LANGS[de_DE]="German"
 LANGS[fr_FR]="French"
@@ -133,6 +134,7 @@ group_entries() {
         "Doc:"
         "Website:"
         "Github:"
+        "$BUNDLED_QT_UPDATE_TEXT"
         "Build:"
         "Autobuild:"
         "Code:"

--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -117,8 +117,9 @@ group_entries() {
 
     # Prepend a number to known categories in order to make their sorting position consistent:
     category_order=(
-        "$TRANSLATION_ENTRY_TEXT"
+        "Translation:"
         "$TRANSLATION_ENTRY_TEXT2"
+        "$TRANSLATION_ENTRY_TEXT"
         "GUI:"
         "Accessibility:"
         "Client:"
@@ -135,7 +136,6 @@ group_entries() {
         "Android:"
         "iOS:"
         "Dependencies:"
-        "Translation:"
         "Doc:"
         "Website:"
         "Github:"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Add improvements to `tools/changelog-helper.sh`:
- extra grouping categories for Client/Server, Weblate, Qt6 updates and Dependencies.
- fixed a bug where the last item before sorting had its trailing `\n` swallowed, making it join to another entry.

CHANGELOG: Internal: added improvements to changelog-helper.sh

**Context: Fixes an issue?**

Addresses some of the suggestions in #3319, but not all of them. Some would need a substantial re-implementation.

**Does this change need documentation? What needs to be documented and how?**

Not really - internal use only

**Status of this Pull Request**

Ready for review

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
