### PR TITLE
 Add JSON-RPC access to directories and server lists (without connect/disconnect methods)

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -129,57 +129,6 @@ Results:
 | result.version | string | The Jamulus version. |
 
 
-### jamulus/pollServerList
-
-Request list of servers in a directory
-
-Parameters:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| params.directory | string | socket address of directory to query, e.g. anygenre1.jamulus.io:22124. |
-
-Results:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| result | string | "ok" or "error" if bad arguments. |
-
-
-### jamulusclient/connect
-
-Disconnect client from server
-
-Parameters:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| params.address | string | Server socket address (ip_addr:port). |
-
-Results:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| result | string | Always "ok". |
-
-
-### jamulusclient/disconnect
-
-Disconnect client from server
-
-Parameters:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| params | object | No parameters (empty object). |
-
-Results:
-
-| Name | Type | Description |
-| --- | --- | --- |
-| result | string | Always "ok". |
-
-
 ### jamulusclient/getChannelInfo
 
 Returns the client's profile information.
@@ -197,9 +146,11 @@ Results:
 | result.id | number | The channel ID. |
 | result.name | string | The musician’s name. |
 | result.skillLevel | string | The musician’s skill level (beginner, intermediate, expert, or null). |
+| result.countryId | number | The musician’s country ID (see QLocale::Country). |
 | result.country | string | The musician’s country. |
 | result.city | string | The musician’s city. |
-| result.instrument | number | The musician’s instrument. |
+| result.instrumentId | number | The musician’s instrument ID (see CInstPictures::GetTable). |
+| result.instrument | string | The musician’s instrument. |
 | result.skillLevel | string | Your skill level (beginner, intermediate, expert, or null). |
 
 
@@ -235,6 +186,23 @@ Results:
 | Name | Type | Description |
 | --- | --- | --- |
 | result.clients | array | The client list. See jamulusclient/clientListReceived for the format. |
+
+
+### jamulusclient/pollServerList
+
+Request list of servers in a directory.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.directory | string | Socket address of directory to query. Example: anygenre1.jamulus.io:22124 |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | "ok" or "error" if bad arguments. |
 
 
 ### jamulusclient/sendChatText
@@ -495,8 +463,10 @@ Parameters:
 | params.clients[*].id | number | The channel ID. |
 | params.clients[*].name | string | The musician’s name. |
 | params.clients[*].skillLevel | string | The musician’s skill level (beginner, intermediate, expert, or null). |
+| params.clients[*].countryId | number | The musician’s country ID (see QLocale::Country). |
 | params.clients[*].country | string | The musician’s country. |
 | params.clients[*].city | string | The musician’s city. |
+| params.clients[*].instrumentId | number | The musician’s instrument ID (see CInstPictures::GetTable). |
 | params.clients[*].instrument | string | The musician’s instrument. |
 
 
@@ -524,13 +494,13 @@ Parameters:
 
 ### jamulusclient/recorderState
 
-Emitted when the client is connected to a server who's recorder state changes.
+Emitted when the client is connected to a server whose recorder state changes.
 
 Parameters:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| params.state | number | The recorder state |
+| params.state | number | The recorder state. |
 
 
 ### jamulusclient/serverInfoReceived
@@ -541,9 +511,9 @@ Parameters:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| params.address | string | The server socket address |
-| params.pingtime | number | The round-trip ping time in ms |
-| params.numClients | number | The quantity of clients connected to the server |
+| params.address | string | The server socket address. |
+| params.pingtime | number | The round-trip ping time, in milliseconds. |
+| params.numClients | number | The number of clients connected to the server. |
 
 
 ### jamulusclient/serverListReceived
@@ -555,9 +525,10 @@ Parameters:
 | Name | Type | Description |
 | --- | --- | --- |
 | params.servers | array | The server list. |
-| params.servers[*].address | string | Socket address (ip_address:port) |
-| params.servers[*].name | string | Server name |
-| params.servers[*].country | string | Server country |
-| params.servers[*].city | string | Server city |
+| params.servers[*].address | string | Socket address (ip_address:port). |
+| params.servers[*].name | string | Server name. |
+| params.servers[*].countryId | number | Server country ID (see QLocale::Country). |
+| params.servers[*].country | string | Server country. |
+| params.servers[*].city | string | Server city. |
 
 

--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -129,6 +129,57 @@ Results:
 | result.version | string | The Jamulus version. |
 
 
+### jamulus/pollServerList
+
+Request list of servers in a directory
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.directory | string | socket address of directory to query, e.g. anygenre1.jamulus.io:22124. |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | "ok" or "error" if bad arguments. |
+
+
+### jamulusclient/connect
+
+Disconnect client from server
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.address | string | Server socket address (ip_addr:port). |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | Always "ok". |
+
+
+### jamulusclient/disconnect
+
+Disconnect client from server
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params | object | No parameters (empty object). |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | Always "ok". |
+
+
 ### jamulusclient/getChannelInfo
 
 Returns the client's profile information.
@@ -146,9 +197,9 @@ Results:
 | result.id | number | The channel ID. |
 | result.name | string | The musician’s name. |
 | result.skillLevel | string | The musician’s skill level (beginner, intermediate, expert, or null). |
-| result.countryId | number | The musician’s country ID (see QLocale::Country). |
+| result.country | string | The musician’s country. |
 | result.city | string | The musician’s city. |
-| result.instrumentId | number | The musician’s instrument ID (see CInstPictures::GetTable). |
+| result.instrument | number | The musician’s instrument. |
 | result.skillLevel | string | Your skill level (beginner, intermediate, expert, or null). |
 
 
@@ -444,9 +495,9 @@ Parameters:
 | params.clients[*].id | number | The channel ID. |
 | params.clients[*].name | string | The musician’s name. |
 | params.clients[*].skillLevel | string | The musician’s skill level (beginner, intermediate, expert, or null). |
-| params.clients[*].countryId | number | The musician’s country ID (see QLocale::Country). |
+| params.clients[*].country | string | The musician’s country. |
 | params.clients[*].city | string | The musician’s city. |
-| params.clients[*].instrumentId | number | The musician’s instrument ID (see CInstPictures::GetTable). |
+| params.clients[*].instrument | string | The musician’s instrument. |
 
 
 ### jamulusclient/connected
@@ -469,5 +520,44 @@ Parameters:
 | Name | Type | Description |
 | --- | --- | --- |
 | params | object | No parameters (empty object). |
+
+
+### jamulusclient/recorderState
+
+Emitted when the client is connected to a server who's recorder state changes.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.state | number | The recorder state |
+
+
+### jamulusclient/serverInfoReceived
+
+Emitted when a server info is received.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.address | string | The server socket address |
+| params.pingtime | number | The round-trip ping time in ms |
+| params.numClients | number | The quantity of clients connected to the server |
+
+
+### jamulusclient/serverListReceived
+
+Emitted when the server list is received.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.servers | array | The server list. |
+| params.servers[*].address | string | Socket address (ip_address:port) |
+| params.servers[*].name | string | Server name |
+| params.servers[*].country | string | Server country |
+| params.servers[*].city | string | Server city |
 
 

--- a/src/client.h
+++ b/src/client.h
@@ -286,7 +286,10 @@ public:
         Channel.GetBufErrorRates ( vecErrRates, dLimit, dMaxUpLimit );
     }
 
+    //### TODO: BEGIN ###//
+    // Refactor this to use signal/slot mechanism. https://github.com/jamulussoftware/jamulus/pull/3479/files#r1976382416
     CProtocol* getConnLessProtocol() { return &ConnLessProtocol; }
+    //### TODO: END ###//
 
     // settings
     CChannelCoreInfo ChannelInfo;

--- a/src/client.h
+++ b/src/client.h
@@ -286,6 +286,8 @@ public:
         Channel.GetBufErrorRates ( vecErrRates, dLimit, dMaxUpLimit );
     }
 
+    CProtocol* getConnLessProtocol() { return &ConnLessProtocol; }
+
     // settings
     CChannelCoreInfo ChannelInfo;
     QString          strClientName;

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -53,9 +53,9 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
     /// @param {number} params.clients[*].id - The channel ID.
     /// @param {string} params.clients[*].name - The musician’s name.
     /// @param {string} params.clients[*].skillLevel - The musician’s skill level (beginner, intermediate, expert, or null).
-    /// @param {number} params.clients[*].countryId - The musician’s country ID (see QLocale::Country).
+    /// @param {string} params.clients[*].country - The musician’s country.
     /// @param {string} params.clients[*].city - The musician’s city.
-    /// @param {number} params.clients[*].instrumentId - The musician’s instrument ID (see CInstPictures::GetTable).
+    /// @param {string} params.clients[*].instrument - The musician’s instrument.
     connect ( pClient, &CClient::ConClientListMesReceived, [=] ( CVector<CChannelInfo> vecChanInfo ) {
         QJsonArray arrChanInfo;
         for ( const auto& chanInfo : vecChanInfo )
@@ -64,9 +64,9 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
                 { "id", chanInfo.iChanID },
                 { "name", chanInfo.strName },
                 { "skillLevel", SerializeSkillLevel ( chanInfo.eSkillLevel ) },
-                { "countryId", chanInfo.eCountry },
+                { "country", QLocale::countryToString ( chanInfo.eCountry ) },
                 { "city", chanInfo.strCity },
-                { "instrumentId", chanInfo.iInstrument },
+                { "instrument", CInstPictures::GetName ( chanInfo.iInstrument ) },
             };
             arrChanInfo.append ( objChanInfo );
         }
@@ -94,10 +94,124 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
                                             } );
     } );
 
+    /// @rpc_notification jamulusclient/serverListReceived
+    /// @brief Emitted when the server list is received.
+    /// @param {array} params.servers - The server list.
+    /// @param {string} params.servers[*].address - Socket address (ip_address:port)
+    /// @param {string} params.servers[*].name - Server name
+    /// @param {string} params.servers[*].country - Server country
+    /// @param {string} params.servers[*].city - Server city
+    connect ( pClient->getConnLessProtocol(),
+              &CProtocol::CLServerListReceived,
+              [=] ( CHostAddress /* unused */, CVector<CServerInfo> vecServerInfo ) {
+                  QJsonArray arrServerInfo;
+                  for ( const auto& serverInfo : vecServerInfo )
+                  {
+                      QJsonObject objServerInfo{
+                          { "address", serverInfo.HostAddr.toString() },
+                          { "name", serverInfo.strName },
+                          { "country", QLocale::countryToString ( serverInfo.eCountry ) },
+                          { "city", serverInfo.strCity },
+                      };
+                      arrServerInfo.append ( objServerInfo );
+                      pClient->CreateCLServerListPingMes ( serverInfo.HostAddr );
+                  }
+                  pRpcServer->BroadcastNotification ( "jamulusclient/serverListReceived",
+                                                      QJsonObject{
+                                                          { "servers", arrServerInfo },
+                                                      } );
+              } );
+
+    /// @rpc_notification jamulusclient/serverInfoReceived
+    /// @brief Emitted when a server info is received.
+    /// @param {string} params.address - The server socket address
+    /// @param {number} params.pingtime - The round-trip ping time in ms
+    /// @param {number} params.numClients - The quantity of clients connected to the server
+    connect ( pClient, &CClient::CLPingTimeWithNumClientsReceived, [=] ( CHostAddress InetAddr, int iPingTime, int iNumClients ) {
+        pRpcServer->BroadcastNotification (
+            "jamulusclient/serverInfoReceived",
+            QJsonObject{ { "address", InetAddr.toString() }, { "pingTime", iPingTime }, { "numClients", iNumClients } } );
+    } );
+
     /// @rpc_notification jamulusclient/disconnected
     /// @brief Emitted when the client is disconnected from the server.
     /// @param {object} params - No parameters (empty object).
     connect ( pClient, &CClient::Disconnected, [=]() { pRpcServer->BroadcastNotification ( "jamulusclient/disconnected", QJsonObject{} ); } );
+
+    /// @rpc_notification jamulusclient/recorderState
+    /// @brief Emitted when the client is connected to a server who's recorder state changes.
+    /// @param {number} params.state - The recorder state
+    connect ( pClient, &CClient::RecorderStateReceived, [=] ( const ERecorderState newRecorderState ) {
+        pRpcServer->BroadcastNotification ( "jamulusclient/recorderState", QJsonObject{ { "state", newRecorderState } } );
+    } );
+
+    /// @rpc_method jamulus/pollServerList
+    /// @brief Request list of servers in a directory
+    /// @param {string} params.directory - socket address of directory to query, e.g. anygenre1.jamulus.io:22124.
+    /// @result {string} result - "ok" or "error" if bad arguments.
+    pRpcServer->HandleMethod ( "jamulusclient/pollServerList", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        auto jsonDirectoryIp = params["directory"];
+        if ( !jsonDirectoryIp.isString() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: directory is not a string" );
+            return;
+        }
+
+        CHostAddress haDirectoryAddress;
+        if ( NetworkUtil().ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
+        {
+            // send the request for the server list
+            pClient->CreateCLReqServerListMes ( haDirectoryAddress );
+            response["result"] = "ok";
+        }
+        else
+        {
+            response["error"] =
+                CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: directory is not a valid socket address" );
+        }
+
+        response["result"] = "ok";
+    } );
+
+    /// @rpc_method jamulusclient/connect
+    /// @brief Disconnect client from server
+    /// @param {string} params.address - Server socket address (ip_addr:port).
+    /// @result {string} result - Always "ok".
+    pRpcServer->HandleMethod ( "jamulusclient/connect", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        auto jsonAddr = params["address"];
+        if ( !jsonAddr.isString() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: address is not a string" );
+            return;
+        }
+
+        if ( pClient->SetServerAddr ( jsonAddr.toString() ) )
+        {
+            if ( !pClient->IsRunning() )
+            {
+                pClient->Start();
+            }
+            response["result"] = "ok";
+        }
+        else
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( 1, "Bad server address" );
+        }
+    } );
+
+    /// @rpc_method jamulusclient/disconnect
+    /// @brief Disconnect client from server
+    /// @param {object} params - No parameters (empty object).
+    /// @result {string} result - Always "ok".
+    pRpcServer->HandleMethod ( "jamulusclient/disconnect", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        if ( pClient->IsRunning() )
+        {
+            pClient->Stop();
+        }
+
+        response["result"] = "ok";
+        Q_UNUSED ( params );
+    } );
 
     /// @rpc_method jamulus/getMode
     /// @brief Returns the current mode, i.e. whether Jamulus is running as a server or client.
@@ -125,17 +239,17 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
     /// @result {number} result.id - The channel ID.
     /// @result {string} result.name - The musician’s name.
     /// @result {string} result.skillLevel - The musician’s skill level (beginner, intermediate, expert, or null).
-    /// @result {number} result.countryId - The musician’s country ID (see QLocale::Country).
+    /// @result {string} result.country - The musician’s country.
     /// @result {string} result.city - The musician’s city.
-    /// @result {number} result.instrumentId - The musician’s instrument ID (see CInstPictures::GetTable).
+    /// @result {number} result.instrument - The musician’s instrument.
     /// @result {string} result.skillLevel - Your skill level (beginner, intermediate, expert, or null).
     pRpcServer->HandleMethod ( "jamulusclient/getChannelInfo", [=] ( const QJsonObject& params, QJsonObject& response ) {
         QJsonObject result{
             // TODO: We cannot include "id" here is pClient->ChannelInfo is a CChannelCoreInfo which lacks that field.
             { "name", pClient->ChannelInfo.strName },
-            { "countryId", pClient->ChannelInfo.eCountry },
+            { "country", QLocale::countryToString ( pClient->ChannelInfo.eCountry ) },
             { "city", pClient->ChannelInfo.strCity },
-            { "instrumentId", pClient->ChannelInfo.iInstrument },
+            { "instrument", CInstPictures::GetName ( pClient->ChannelInfo.iInstrument ) },
             { "skillLevel", SerializeSkillLevel ( pClient->ChannelInfo.eSkillLevel ) },
         };
         response["result"] = result;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Modified version of: https://github.com/jamulussoftware/jamulus/pull/3249
* Removed disconnect and connect methods since calling them would break the UI
* Rebased to main

Quoting the initial PR:

> Adds JSON-RPC notification of server lists from directories. Allows polling a directory for this info.

CHANGELOG: Added jamulusclient/pollServerList methods and jamulusclient/receivedServerList notification to JSON-RPC interface.

**Context: Fixes an issue?**

> As discussed [here](https://github.com/orgs/jamulussoftware/discussions/2949#discussioncomment-8882899), it may be advantageous to increase the control and monitoring provided by the JSON-RPC interface. This provides access to server lists on directories.

**Does this change need documentation? What needs to be documented and how?**

> This PR adds the associated documentation of the new method and notification in the JSON-RPC md page.

**Status of this Pull Request**

Ready for final review

**What is missing until this pull request can be merged?**

Nothing.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
