### PR TITLE
Avoid sleeping on windows if connected

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -979,6 +979,11 @@ void CClient::Start()
 
     // start audio interface
     Sound.Start();
+
+#if defined( Q_OS_WINDOWS )
+    // Disable hibernation or display dimming if the app is running on Windows
+    SetThreadExecutionState ( ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED );
+#endif
 }
 
 void CClient::Stop()
@@ -1013,6 +1018,11 @@ void CClient::Stop()
     // reset current signal level and LEDs
     bJitterBufferOK = true;
     SignalLevelMeter.Reset();
+
+#if defined( Q_OS_WINDOWS )
+    // Allow hibernation or display dimming if the app is running again (Windows)
+    SetThreadExecutionState ( ES_CONTINUOUS );
+#endif
 }
 
 void CClient::Init()


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Avoids Windows to go into sleep mode if the client is connected to a server

CHANGELOG: Windows: Avoid screensaver or sleeping if connected to a server

**Context: Fixes an issue?**

Related to: https://github.com/jamulussoftware/jamulus/issues/834

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready for review. A pre-build was tested on Win 11 and it worked as expected: If a connection to the server stands, the device does not sleep. Once it is disconnected, it will sleep.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Testing on another system.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
