### PR TITLE
Add dark mode checker depending on Qt version

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -1479,9 +1479,16 @@ void CClientDlg::SetMixerBoardDeco ( const ERecorderState newRecorderState, cons
         }
         else
         {
-            if ( palette().color ( QPalette::Window ) == QColor::fromRgbF ( 0.196078, 0.196078, 0.196078, 1 ) )
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+            // for Qt 6.5.0 or later, we use the inbuilt cross platform color scheme picker.
+            if ( QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark )
+#else
+            // for earlier versions, check darkmode as proposed in https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+            const QPalette defaultPalette;
+            if ( defaultPalette.color ( QPalette::WindowText ).lightness() > defaultPalette.color ( QPalette::Window ).lightness() )
+#endif
             {
-                // Dark mode on macOS/Linux needs a light color
+                // Dark mode needs a light color
 
                 sTitleStyle += "color: rgb(220,220,220); }";
             }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -42,6 +42,9 @@
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 )
 #    include <QVersionNumber>
 #endif
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+#    include <QStyleHints>
+#endif
 #include "global.h"
 #include "util.h"
 #include "client.h"


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Solves darkmode color issue in mixer dialog:
Connected:
![Server label in dark mode Windows connected](https://github.com/user-attachments/assets/619e4bb8-11e3-4ee5-a125-25dd135659dc)
Disconnected:
![Server label in dark mode Windows disconnected](https://github.com/user-attachments/assets/37c3c90f-0345-44d9-be86-13c0ac470786)

<!-- Explain what your PR does -->

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes: #3395 

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready for review. Working
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Review
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
