### PR TITLE
Move Qt macOS installation to home directory to fix gtar issue

### DIFF
--- a/.github/autobuild/mac.sh
+++ b/.github/autobuild/mac.sh
@@ -26,7 +26,7 @@
 
 set -eu
 
-QT_DIR=/opt/qt
+QT_DIR=~/qt
 # The following version pinnings are semi-automatically checked for
 # updates. Verify .github/workflows/bump-dependencies.yaml when changing those manually:
 AQTINSTALL_VERSION=3.1.21

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -321,7 +321,7 @@ jobs:
         uses:                       actions/cache@v4
         with:
           path: |
-            /opt/qt
+            ~/qt
             ~/Library/Cache/jamulus-homebrew-bottles
           key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/mac.sh', 'mac/deploy_mac.sh') }}-${{ matrix.config.base_command }}
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Moves the macOS Qt installation to `~/qt` as it seems that the home directory is cachable. `/opt/` which would be the more standard compliant option would result in a permission error. I have Qt installed in my home directory on my mac test machine and it worked so far.
<!-- Explain what your PR does -->

CHANGELOG: SKIP
**Context: Fixes an issue?**
Fixes: https://github.com/jamulussoftware/jamulus/issues/3373
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready for review
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
