### PR TITLE
Randomize and adapt ping intervals in connection dialog to reduce correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# This is a fork to test out anti-correlation strategies, use at your own risk. 
+
+For details see discussion in 
+https://github.com/orgs/jamulussoftware/discussions/3545
+
+This is a client-side only fix: instead of pinging each server at a constant rate and stop when connecting this patch will randomize the frequency and keeps pinging even when the dialog is closed, makeing correlation events harder. It may still be possible at times when there is really no activity on jamulus servers over a long time, so with all randomization you are still the only user...
+
+
+
 [![Homepage picture](https://github.com/jamulussoftware/jamuluswebsite/blob/release/assets/img/jamulusbannersmall.png)](https://jamulus.io)
 
 [![Auto-Build](https://github.com/jamulussoftware/jamulus/actions/workflows/autobuild.yml/badge.svg)](https://github.com/jamulussoftware/jamulus/actions/workflows/autobuild.yml)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-# This is a fork to test out anti-correlation strategies, use at your own risk. 
-
-For details see discussion in 
-https://github.com/orgs/jamulussoftware/discussions/3545
-
-This is a client-side only fix: instead of pinging each server at a constant rate and stop when connecting this patch will randomize the frequency and keeps pinging even when the dialog is closed, makeing correlation events harder. It may still be possible at times when there is really no activity on jamulus servers over a long time, so with all randomization you are still the only user...
-
-
-
 [![Homepage picture](https://github.com/jamulussoftware/jamuluswebsite/blob/release/assets/img/jamulusbannersmall.png)](https://jamulus.io)
 
 [![Auto-Build](https://github.com/jamulussoftware/jamulus/actions/workflows/autobuild.yml/badge.svg)](https://github.com/jamulussoftware/jamulus/actions/workflows/autobuild.yml)

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -880,16 +880,17 @@ void CConnectDlg::OnTimerPing()
             iPingInterval += iRandomOffsetMs;
             iPingInterval = std::max ( iPingInterval, 500 );
 
-            // for now force one ping after the hide phase has elapsed 3500ms
-            // can be removed once the majority of clients is using this
+            // during shutdown: randomly sent a ping for first 15 seconds only, can be removed in the future when this mode is used
+            // by the majority of clients
             if ( TimerKeepPingAfterHide.isActive() )
             {
                 const qint64 iTimeSinceHide = iCurrentTime - iKeepPingAfterHideStartTimestamp;
-                if ( iTimeSinceHide >= 3500 && iLastPingTimestamp < iKeepPingAfterHideStartTimestamp )
-                {
-                    iPingInterval = 0;
+                if ( iTimeSinceHide < 15000 )
+                { 
+                    iPingInterval = 2000 + QRandomGenerator::global()->bounded ( 1000 );
                 }
             }
+
         }
 
 #ifdef PING_STEALTH_MODE_DETAILED_STATS

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -880,12 +880,12 @@ void CConnectDlg::OnTimerPing()
             iPingInterval += iRandomOffsetMs;
             iPingInterval = std::max ( iPingInterval, 500 );
 
-            // during shutdown: randomly sent a ping for first 15 seconds only, can be removed in the future when this mode is used
+            // during shutdown: randomly sent a ping for first 20 to 30 seconds only, can be removed in the future when this mode is used
             // by the majority of clients
             if ( TimerKeepPingAfterHide.isActive() )
             {
                 const qint64 iTimeSinceHide = iCurrentTime - iKeepPingAfterHideStartTimestamp;
-                if ( iTimeSinceHide < 15000 )
+                if ( iTimeSinceHide < (20000 + QRandomGenerator::global()->bounded ( 10000 ) ) )
                 { 
                     iPingInterval = 2000 + QRandomGenerator::global()->bounded ( 1000 );
                 }

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -1,4 +1,4 @@
-﻿/******************************************************************************\
+/******************************************************************************\
  * Copyright (c) 2004-2025
  *
  * Author(s):
@@ -138,7 +138,6 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     // 4: server version
     // 5: minimum ping time (invisible)
     // 6: maximum number of clients (invisible)
-    // 7: last ping timestamp (invisible)
     // (see EConnectListViewColumns in connectdlg.h, which must match the above)
 
     lvwServers->setColumnCount ( LVC_COLUMNS );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -693,7 +693,7 @@ void CConnectDlg::UpdateListFilter()
                     bFilterFound = true;
                 }
 
-                // search children
+				// search children
                 for ( int iCCnt = 0; iCCnt < pCurListViewItem->childCount(); iCCnt++ )
                 {
                     if ( pCurListViewItem->child ( iCCnt )->text ( LVC_NAME ).indexOf ( sFilterText, 0, Qt::CaseInsensitive ) >= 0 )
@@ -829,13 +829,6 @@ void CConnectDlg::OnTimerPing()
             const qint64 iTimeSinceLastPing = iCurrentTime - iLastPingTimestamp;
 
             // Calculate adaptive ping interval based on latency using linear formula:
-            // - Ping < 15ms: ping every timer cycle (skip 0)
-            // - Ping 20ms: ping every 2nd timer cycle (skip 1)
-            // - Ping 25ms: ping every 3rd timer cycle (skip 2)
-            // - Ping 30ms: ping every 4th timer cycle (skip 3)
-            // - Ping 150ms+: ping every 10th timer cycle (skip 9, maximum)
-            // Formula: skip_count = min(9, (ping - 15) / 5)
-            // Interval multiplier = 1 + skip_count
             int iPingInterval;
             if ( iMinPingTime == 0 || iMinPingTime > 99999999 )
             {
@@ -846,15 +839,15 @@ void CConnectDlg::OnTimerPing()
             {
                 // Calculate number of timer cycles to skip based on ping time
                 // Linear mapping: 15ms->0 skips, 20ms->1 skip, 25ms->2 skips, etc.
-                // Capped at 150ms which gives 9 skips (ping every 10th cycle)
-                const int iSkipCount          = std::min ( 9, std::max ( 0, ( iMinPingTime - 15 ) / 5 ) );
+                // Capped at 55ms which gives 8 skips (ping every 9th cycle)
+                const int iSkipCount          = std::min ( 8, std::max ( 0, ( iMinPingTime - 15 ) / 5 ) );
                 const int iIntervalMultiplier = 1 + iSkipCount;
                 iPingInterval                 = PING_UPDATE_TIME_SERVER_LIST_MS * iIntervalMultiplier;
-            }
+              }
 
             // Add randomization as absolute time offset (±500ms) to prevent synchronized pings
             // This avoids regular intervals (e.g., exactly 2500ms every time)
-            const int iRandomOffsetMs = QRandomGenerator::global()->bounded ( 1000 ) - 500; // -500ms to +500ms
+            const int iRandomOffsetMs = QRandomGenerator::global()->bounded ( 500 ) - 250; // -250ms to +250ms
             iPingInterval += iRandomOffsetMs;
 
 #if 1 // Set to 1 to enable detailed ping diagnostics tooltip

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -852,7 +852,7 @@ void CConnectDlg::OnTimerPing()
                 iPingInterval                 = PING_UPDATE_TIME_SERVER_LIST_MS * iIntervalMultiplier;
             }
 
-            // Add randomization as absolute time offset (±500ms) to prevent synchronized pings
+            // Add randomization as absolute time offset ( 500ms) to prevent synchronized pings
             // This avoids regular intervals (e.g., exactly 2500ms every time)
             const int iRandomOffsetMs = QRandomGenerator::global()->bounded ( 1000 ) - 500; // -500ms to +500ms
             iPingInterval += iRandomOffsetMs;
@@ -893,7 +893,7 @@ void CConnectDlg::OnTimerPing()
             QFuture<void> f = QtConcurrent::run ( &CConnectDlg::EmitCLServerListPingMes, this, haServerAddress, bNeedVersion );
             Q_UNUSED ( f );
 #else
-            QtConcurrent::run ( this, &CConnectDlg::EmitCLServerListPingMes, haServerAddress, bNeedVersion, lastPingTime );
+            QtConcurrent::run ( this, &CConnectDlg::EmitCLServerListPingMes, haServerAddress, bNeedVersion );
 #endif
         }
     }

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -48,8 +48,10 @@
 //#define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging
 #define PING_SHUTDOWN_TIME_MS_MIN 45000 // recommend to keep it like this and not lower
 #define PING_SHUTDOWN_TIME_MS_VAR 15000
+// Register QHostAddress as a Qt meta type
+Q_DECLARE_METATYPE ( QHostAddress )
 // Register QQueue<qint64> as Qt metatype for use in QVariant to keep ping stats in UserRole
-Q_DECLARE_METATYPE ( QQueue<qint64> ) 
+Q_DECLARE_METATYPE ( QQueue<qint64> )
 #endif
 
 

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -43,7 +43,6 @@
 // transmitted until it is received
 #define SERV_LIST_REQ_UPDATE_TIME_MS 2000 // ms
 
-#define PING_STEALTH_MODE // prototype to avoid correlation of pings and user activity
 
 #define PING_STEALTH_MODE // prototype to avoid correlation of pings and user activity
 #ifdef PING_STEALTH_MODE

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -86,7 +86,7 @@ protected:
         LVC_LOCATION,           // location
         LVC_VERSION,            // server version
         LVC_PING_MIN_HIDDEN,    // minimum ping time (invisible)
-        LVC_CLIENTS_MAX_HIDDEN, // maximum number of clients (invisible),
+        LVC_CLIENTS_MAX_HIDDEN, // maximum number of clients (invisible)
         LVC_COLUMNS             // total number of columns
     };
 

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -44,13 +44,8 @@
 #define SERV_LIST_REQ_UPDATE_TIME_MS 2000 // ms
 
 // defines the time interval it will keep pinging servers after the dialog was hidden (randomized +/- 20%)
-#define KEEP_PING_RUNNING_AFTER_HIDE_MS (1000*120)
+#define KEEP_PING_RUNNING_AFTER_HIDE_MS ( 1000 * 180 )
 
-#ifdef _DEBUG
-#    define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging
-#endif
-
-Q_DECLARE_METATYPE ( QQueue<qint64> )
 Q_DECLARE_METATYPE ( QHostAddress )
 
 /* Classes ********************************************************************/
@@ -97,7 +92,6 @@ protected:
         USER_ROLE_QHOST_ADDRESS_CACHE,         // QHostAddress: cache QHostAddress, will be updated on first ping
         USER_ROLE_QHOST_PORT_CACHE,            // quint16: cache port number, will be updated on first ping
         USER_ROLE_LAST_PING_TIMESTAMP,         // qint64: timestamp of last ping measurement
-        USER_ROLE_PING_TIMES_QUEUE,            // QQueue<qint64>: for ping stats, will be initialized on first ping
         USER_ROLE_PING_SALT                    // int: random ping salt per server
     };
 
@@ -112,10 +106,7 @@ protected:
     void             RequestServerList();
     void             EmitCLServerListPingMes ( const CHostAddress& haServerAddress, const bool bNeedVersion );
     void             UpdateDirectoryComboBox();
-#ifdef PING_STEALTH_MODE_DETAILED_STATS
-    void pingStealthModeDebugStats();
-#endif
-
+#
     CClientSettings* pSettings;
 
     QTimer       TimerPing;

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -45,8 +45,8 @@
 
 #define PING_STEALTH_MODE
 #ifdef PING_STEALTH_MODE
-#define PING_SHUTDOWN_TIME_MS_MIN 15000
-#define PING_SHUTDOWN_TIME_MS_VAR 15000
+#define PING_SHUTDOWN_TIME_MS_MIN 40000 // needs to be reasonable higher than the 10 x ping timer to have every server at least once pinged
+#define PING_SHUTDOWN_TIME_MS_VAR 20000
 #endif
 
 

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -43,18 +43,15 @@
 // transmitted until it is received
 #define SERV_LIST_REQ_UPDATE_TIME_MS 2000 // ms
 
+// defines the time interval it will keep pinging servers after the dialog was hidden (randomized +/- 20%)
+#define KEEP_PING_RUNNING_AFTER_HIDE_MS 60000
 
-#define PING_STEALTH_MODE // prototype to avoid correlation of pings and user activity
-#ifdef PING_STEALTH_MODE
 #ifdef _DEBUG
-#define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging
-#endif
-#define PING_SHUTDOWN_TIME_MS_MIN 45000 
-#define PING_SHUTDOWN_TIME_MS_VAR 30000
-Q_DECLARE_METATYPE(QQueue<qint64>)
-Q_DECLARE_METATYPE(QHostAddress)
+#    define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging
 #endif
 
+Q_DECLARE_METATYPE ( QQueue<qint64> )
+Q_DECLARE_METATYPE ( QHostAddress )
 
 /* Classes ********************************************************************/
 class CConnectDlg : public CBaseDlg, private Ui_CConnectDlgBase
@@ -93,18 +90,16 @@ protected:
         LVC_COLUMNS             // total number of columns
     };
 
-
     // those are the custom user data fields, all stored in the UserRole of the list view item (LVC_NAME)
     enum EColumnPingNameUserRoles
     {
         USER_ROLE_HOST_ADDRESS = Qt::UserRole, // QString: CHostAddress as string
-        USER_ROLE_QHOST_ADDRESS_CACHE,      // QHostAddress: cache QHostAddress, will be updated on first ping
-        USER_ROLE_QHOST_PORT_CACHE,         // quint16: cache port number, will be updated on first ping
-        USER_ROLE_LAST_PING_TIMESTAMP,      // qint64: timestamp of last ping measurement
-        USER_ROLE_PING_TIMES_QUEUE,         // QQueue<qint64>: for ping stats, will be initialized on first ping
-        USER_ROLE_PING_SALT                 // int: random ping salt per server
+        USER_ROLE_QHOST_ADDRESS_CACHE,         // QHostAddress: cache QHostAddress, will be updated on first ping
+        USER_ROLE_QHOST_PORT_CACHE,            // quint16: cache port number, will be updated on first ping
+        USER_ROLE_LAST_PING_TIMESTAMP,         // qint64: timestamp of last ping measurement
+        USER_ROLE_PING_TIMES_QUEUE,            // QQueue<qint64>: for ping stats, will be initialized on first ping
+        USER_ROLE_PING_SALT                    // int: random ping salt per server
     };
-
 
     virtual void showEvent ( QShowEvent* );
     virtual void hideEvent ( QHideEvent* );
@@ -124,10 +119,8 @@ protected:
     CClientSettings* pSettings;
 
     QTimer       TimerPing;
-#ifdef PING_STEALTH_MODE
     QTimer       TimerKeepPingAfterHide;
     qint64       iKeepPingAfterHideStartTimestamp; // timestamp when keeping pings after hide started
-#endif
     QTimer       TimerReRequestServList;
     QTimer       TimerInitialSort;
     CHostAddress haDirectoryAddress;

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -44,7 +44,7 @@
 #define SERV_LIST_REQ_UPDATE_TIME_MS 2000 // ms
 
 // defines the time interval it will keep pinging servers after the dialog was hidden (randomized +/- 20%)
-#define KEEP_PING_RUNNING_AFTER_HIDE_MS 60000
+#define KEEP_PING_RUNNING_AFTER_HIDE_MS (1000*120)
 
 #ifdef _DEBUG
 #    define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -46,8 +46,8 @@
 #define PING_STEALTH_MODE // prototype to avoid correlation of pings and user activity
 #ifdef PING_STEALTH_MODE
 //#define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging
-#define PING_SHUTDOWN_TIME_MS_MIN 40000 // recommend to keep it like this and not lower
-#define PING_SHUTDOWN_TIME_MS_VAR 20000
+#define PING_SHUTDOWN_TIME_MS_MIN 45000 // recommend to keep it like this and not lower
+#define PING_SHUTDOWN_TIME_MS_VAR 15000
 // Register QQueue<qint64> as Qt metatype for use in QVariant to keep ping stats in UserRole
 Q_DECLARE_METATYPE ( QQueue<qint64> ) 
 #endif

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -45,8 +45,9 @@
 
 #define PING_STEALTH_MODE // prototype to avoid correlation of pings and user activity
 #ifdef PING_STEALTH_MODE
-#define PING_SHUTDOWN_TIME_MS_MIN 30000 // recommend to keep it like this and not lower
-#define PING_SHUTDOWN_TIME_MS_VAR 10000
+//#define PING_STEALTH_MODE_DETAILED_STATS // enable to log detailed ping stats for debugging
+#define PING_SHUTDOWN_TIME_MS_MIN 40000 // recommend to keep it like this and not lower
+#define PING_SHUTDOWN_TIME_MS_VAR 20000
 // Register QQueue<qint64> as Qt metatype for use in QVariant to keep ping stats in UserRole
 Q_DECLARE_METATYPE ( QQueue<qint64> ) 
 #endif
@@ -103,6 +104,9 @@ protected:
     void             RequestServerList();
     void             EmitCLServerListPingMes ( const CHostAddress& haServerAddress, const bool bNeedVersion );
     void             UpdateDirectoryComboBox();
+#ifdef PING_STEALTH_MODE_DETAILED_STATS
+    void pingStealthModeDebugStats();
+#endif
 
     CClientSettings* pSettings;
 
@@ -110,6 +114,7 @@ protected:
 #ifdef PING_STEALTH_MODE
     QTimer       TimerKeepPingAfterHide;
     qint64       iKeepPingAfterHideStartTime; // shutdown ping timer in ms epoch
+    qint64       iKeepPingAfterHideStartTimestamp; // timestamp when keeping pings after hide started
 #endif
     QTimer       TimerReRequestServList;
     QTimer       TimerInitialSort;


### PR DESCRIPTION

**Short description of changes**

To avoid correlation on client behaviour this change will randomize the ping intervals, adaptive to the ping time, nearer servers get pinged more often, distant ones less.

To avoid correlation of "hide connect dialog" (ping immediately stops) and "connected to a server" (user appears on a server) it will keep pinging for approx. 60 seconds after the dialog gets hidden.

In addition:
- introduced enum for UserRole data on LVC_NAME.
- cache host and port on first use, no need to resolve it every time (in UserRole data)

CHANGELOG: Randomized and adaptive ping intervals in connection dialog, keep ping running after some time after dialog gets closed.

**Context: Fixes an issue?**

See https://github.com/orgs/jamulussoftware/discussions/3545

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

**What is missing until this pull request can be merged?**

Unsure if the diagnostic code (currently only in debug builds) can/should be kept in.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
