### PR TITLE
Provides SRV support for connecting to directories from client or server

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1182,6 +1182,12 @@ contains(CONFIG, "disable_version_check") {
     DEFINES += DISABLE_VERSION_CHECK
 }
 
+# disable SRV resolution in DNS if requested (#3556)
+contains(CONFIG, "disable_srv_dns") {
+    message(The use of SRV records in DNS is disabled.)
+    DEFINES += DISABLE_SRV_DNS
+}
+
 # Enable formatting all code via `make clang_format`.
 # Note: When extending the list of file extensions or when adding new code directories,
 # be sure to update .github/workflows/coding-style-check.yml and .clang-format-ignore as well.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -570,11 +570,7 @@ void CClient::SetRemoteChanPan ( const int iId, const float fPan )
 bool CClient::SetServerAddr ( QString strNAddr )
 {
     CHostAddress HostAddress;
-#ifdef CLIENT_NO_SRV_CONNECT
-    if ( NetworkUtil().ParseNetworkAddress ( strNAddr, HostAddress, bEnableIPv6 ) )
-#else
-    if ( NetworkUtil().ParseNetworkAddressWithSrvDiscovery ( strNAddr, HostAddress, bEnableIPv6 ) )
-#endif
+    if ( NetworkUtil::ParseNetworkAddress ( strNAddr, HostAddress, bEnableIPv6 ) )
     {
         // apply address to the channel
         Channel.SetAddress ( HostAddress );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -588,12 +588,12 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // Send the request to two servers for redundancy if either or both of them
     // has a higher release version number, the reply will trigger the notification.
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
+    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
     {
         pClient->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
+    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
     {
         pClient->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -588,12 +588,14 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // Send the request to two servers for redundancy if either or both of them
     // has a higher release version number, the reply will trigger the notification.
 
-    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
+    // Don't use SRV resolution when resolving update servers.
+
+    if ( NetworkUtil::ParseNetworkAddressBare ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
     {
         pClient->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 
-    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
+    if ( NetworkUtil::ParseNetworkAddressBare ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, bEnableIPv6 ) )
     {
         pClient->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -164,7 +164,13 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
         }
 
         CHostAddress haDirectoryAddress;
+
+        // Allow IPv4 only for communicating with Directories
+#ifdef CLIENT_NO_SRV_CONNECT
         if ( NetworkUtil().ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
+#else
+        if ( NetworkUtil().ParseNetworkAddressWithSrvDiscovery ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
+#endif
         {
             // send the request for the server list
             pClient->CreateCLReqServerListMes ( haDirectoryAddress );

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -166,11 +166,7 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
         CHostAddress haDirectoryAddress;
 
         // Allow IPv4 only for communicating with Directories
-#ifdef CLIENT_NO_SRV_CONNECT
-        if ( NetworkUtil().ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
-#else
-        if ( NetworkUtil().ParseNetworkAddressWithSrvDiscovery ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
-#endif
+        if ( NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
         {
             // send the request for the server list
             pClient->CreateCLReqServerListMes ( haDirectoryAddress );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -324,17 +324,10 @@ void CConnectDlg::RequestServerList()
     // use iCustomDirectoryIndex as an index into the vector.
 
     // Allow IPv4 only for communicating with Directories
-#ifdef CLIENT_NO_SRV_CONNECT
-    if ( NetworkUtil().ParseNetworkAddress (
+    if ( NetworkUtil::ParseNetworkAddress (
              NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
              haDirectoryAddress,
              false ) )
-#else
-    if ( NetworkUtil().ParseNetworkAddressWithSrvDiscovery (
-             NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
-             haDirectoryAddress,
-             false ) )
-#endif
     {
         // send the request for the server list
         emit ReqServerListQuery ( haDirectoryAddress );
@@ -864,7 +857,7 @@ void CConnectDlg::OnTimerPing()
         // try to parse host address string which is stored as user data
         // in the server list item GUI control element
         // the data to be parsed is just IP:port, so no SRV discovery is needed
-        if ( NetworkUtil().ParseNetworkAddress ( pCurListViewItem->data ( LVC_NAME, Qt::UserRole ).toString(), haServerAddress, bEnableIPv6 ) )
+        if ( NetworkUtil::ParseNetworkAddressBare ( pCurListViewItem->data ( LVC_NAME, Qt::UserRole ).toString(), haServerAddress, bEnableIPv6 ) )
         {
             // if address is valid, send ping message using a new thread
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -318,16 +318,23 @@ void CConnectDlg::RequestServerList()
     }
     cbxDirectory->blockSignals ( false );
 
-    // Get the IP address of the directory server (using the ParseNetworAddress
+    // Get the IP address of the directory server (using the ParseNetworkAddress
     // function) when the connect dialog is opened, this seems to be the correct
     // time to do it. Note that in case of custom directories we
     // use iCustomDirectoryIndex as an index into the vector.
 
     // Allow IPv4 only for communicating with Directories
+#ifdef CLIENT_NO_SRV_CONNECT
     if ( NetworkUtil().ParseNetworkAddress (
              NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
              haDirectoryAddress,
              false ) )
+#else
+    if ( NetworkUtil().ParseNetworkAddressWithSrvDiscovery (
+             NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
+             haDirectoryAddress,
+             false ) )
+#endif
     {
         // send the request for the server list
         emit ReqServerListQuery ( haDirectoryAddress );
@@ -856,6 +863,7 @@ void CConnectDlg::OnTimerPing()
 
         // try to parse host address string which is stored as user data
         // in the server list item GUI control element
+        // the data to be parsed is just IP:port, so no SRV discovery is needed
         if ( NetworkUtil().ParseNetworkAddress ( pCurListViewItem->data ( LVC_NAME, Qt::UserRole ).toString(), haServerAddress, bEnableIPv6 ) )
         {
             // if address is valid, send ping message using a new thread

--- a/src/global.h
+++ b/src/global.h
@@ -96,8 +96,8 @@ LED bar:      lbr
 #define MAX_DELAY_PANNING_SAMPLES 64
 
 // default server address and port numbers
-#define DEFAULT_QOS_NUMBER            128 // CS4 (Quality of Service)
-#define DEFAULT_SERVER_ADDRESS        "anygenre1.jamulus.io"
+#define DEFAULT_QOS_NUMBER            128                          // CS4 (Quality of Service)
+#define DEFAULT_SERVER_ADDRESS        "anygenre1.jamulus.io:22124" // default port explicit to avoid unneeded SRV lookup
 #define DEFAULT_PORT_NUMBER           22124
 #define CENTSERV_ANY_GENRE2           "anygenre2.jamulus.io:22224"
 #define CENTSERV_ANY_GENRE3           "anygenre3.jamulus.io:22624"

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -482,12 +482,12 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     // Send the request to two servers for redundancy if either or both of them
     // has a higher release version number, the reply will trigger the notification.
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
+    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
     {
         pServer->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 
-    if ( NetworkUtil().ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
+    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
     {
         pServer->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -482,12 +482,14 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
     // Send the request to two servers for redundancy if either or both of them
     // has a higher release version number, the reply will trigger the notification.
 
-    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
+    // Don't use SRV resolution when resolving update servers.
+
+    if ( NetworkUtil::ParseNetworkAddressBare ( UPDATECHECK1_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
     {
         pServer->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }
 
-    if ( NetworkUtil::ParseNetworkAddress ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
+    if ( NetworkUtil::ParseNetworkAddressBare ( UPDATECHECK2_ADDRESS, UpdateServerHostAddress, pServer->IsIPv6Enabled() ) )
     {
         pServer->CreateCLServerListReqVerAndOSMes ( UpdateServerHostAddress );
     }

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -974,8 +974,13 @@ void CServerListManager::SetRegistered ( const bool bIsRegister )
     // it is an URL of a dynamic IP address, the IP address might have
     // changed in the meanwhile.
     // Allow IPv4 only for communicating with Directories
-    const QString strNetworkAddress      = NetworkUtil::GetDirectoryAddress ( DirectoryType, strDirectoryAddress );
-    const bool    bDirectoryAddressValid = NetworkUtil().ParseNetworkAddress ( strNetworkAddress, DirectoryAddress, false );
+    // Use SRV DNS discovery for directory connections
+    const QString strNetworkAddress = NetworkUtil::GetDirectoryAddress ( DirectoryType, strDirectoryAddress );
+#ifndef CLIENT_NO_SRV_CONNECT
+    const bool bDirectoryAddressValid = NetworkUtil().ParseNetworkAddressWithSrvDiscovery ( strNetworkAddress, DirectoryAddress, false );
+#else
+    const bool bDirectoryAddressValid = NetworkUtil().ParseNetworkAddress ( strNetworkAddress, DirectoryAddress, false );
+#endif
 
     if ( bIsRegister )
     {

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -974,7 +974,7 @@ void CServerListManager::SetRegistered ( const bool bIsRegister )
     // it is an URL of a dynamic IP address, the IP address might have
     // changed in the meanwhile.
     // Allow IPv4 only for communicating with Directories
-    // Use SRV DNS discovery for directory connections
+    // Use SRV DNS discovery for directory connections, fallback to A/AAAA if none.
     const QString strNetworkAddress = NetworkUtil::GetDirectoryAddress ( DirectoryType, strDirectoryAddress );
 #ifndef CLIENT_NO_SRV_CONNECT
     const bool bDirectoryAddressValid = NetworkUtil().ParseNetworkAddressWithSrvDiscovery ( strNetworkAddress, DirectoryAddress, false );

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -805,6 +805,8 @@ bool CServerListManager::Load()
             continue;
         }
 
+        // This uses ParseNetworkAddressBare because it is just parsing ip:host that was saved to the file.
+        // Therefore no SRV lookup is appropriate.
         NetworkUtil::ParseNetworkAddressBare ( slLine[0], haServerHostAddr, bEnableIPv6 );
         int iIdx = IndexOf ( haServerHostAddr );
         if ( iIdx != INVALID_INDEX )

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -805,7 +805,7 @@ bool CServerListManager::Load()
             continue;
         }
 
-        NetworkUtil::ParseNetworkAddress ( slLine[0], haServerHostAddr, bEnableIPv6 );
+        NetworkUtil::ParseNetworkAddressBare ( slLine[0], haServerHostAddr, bEnableIPv6 );
         int iIdx = IndexOf ( haServerHostAddr );
         if ( iIdx != INVALID_INDEX )
         {
@@ -981,12 +981,8 @@ void CServerListManager::SetRegistered ( const bool bIsRegister )
     // changed in the meanwhile.
     // Allow IPv4 only for communicating with Directories
     // Use SRV DNS discovery for directory connections, fallback to A/AAAA if none.
-    const QString strNetworkAddress = NetworkUtil::GetDirectoryAddress ( DirectoryType, strDirectoryAddress );
-#ifndef CLIENT_NO_SRV_CONNECT
-    const bool bDirectoryAddressValid = NetworkUtil().ParseNetworkAddressWithSrvDiscovery ( strNetworkAddress, DirectoryAddress, false );
-#else
-    const bool bDirectoryAddressValid = NetworkUtil().ParseNetworkAddress ( strNetworkAddress, DirectoryAddress, false );
-#endif
+    const QString strNetworkAddress      = NetworkUtil::GetDirectoryAddress ( DirectoryType, strDirectoryAddress );
+    const bool    bDirectoryAddressValid = NetworkUtil::ParseNetworkAddress ( strNetworkAddress, DirectoryAddress, false );
 
     // lock the mutex again now that the address has been resolved.
     locker.relock();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -750,7 +750,7 @@ bool NetworkUtil::ParseNetworkAddressString ( QString strAddress, QHostAddress& 
     return false;
 }
 
-#ifndef CLIENT_NO_SRV_CONNECT
+#ifndef DISABLE_SRV_DNS
 bool NetworkUtil::ParseNetworkAddressSrv ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 )
 {
     // init requested host address with invalid address first
@@ -806,20 +806,22 @@ bool NetworkUtil::ParseNetworkAddressSrv ( QString strAddress, CHostAddress& Hos
     }
     return false;
 }
+#endif
 
-bool NetworkUtil::ParseNetworkAddressWithSrvDiscovery ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 )
+bool NetworkUtil::ParseNetworkAddress ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 )
 {
+#ifndef DISABLE_SRV_DNS
     // Try SRV-based discovery first:
     if ( ParseNetworkAddressSrv ( strAddress, HostAddress, bEnableIPv6 ) )
     {
         return true;
     }
-    // Try regular connect via plain IP or host name lookup (A/AAAA):
-    return ParseNetworkAddress ( strAddress, HostAddress, bEnableIPv6 );
-}
 #endif
+    // Try regular connect via plain IP or host name lookup (A/AAAA):
+    return ParseNetworkAddressBare ( strAddress, HostAddress, bEnableIPv6 );
+}
 
-bool NetworkUtil::ParseNetworkAddress ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 )
+bool NetworkUtil::ParseNetworkAddressBare ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 )
 {
     QHostAddress InetAddr;
     unsigned int iNetPort = DEFAULT_PORT_NUMBER;

--- a/src/util.h
+++ b/src/util.h
@@ -53,7 +53,7 @@
 #include <QElapsedTimer>
 #include <QTextBoundaryFinder>
 #include <QTimer>
-#ifndef CLIENT_NO_SRV_CONNECT
+#ifndef DISABLE_SRV_DNS
 #    include <QDnsLookup>
 #endif
 #ifndef _WIN32
@@ -1055,11 +1055,11 @@ class NetworkUtil
 public:
     static bool ParseNetworkAddressString ( QString strAddress, QHostAddress& InetAddr, bool bEnableIPv6 );
 
-#ifndef CLIENT_NO_SRV_CONNECT
+#ifndef DISABLE_SRV_DNS
     static bool ParseNetworkAddressSrv ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 );
-    static bool ParseNetworkAddressWithSrvDiscovery ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 );
 #endif
     static bool ParseNetworkAddress ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 );
+    static bool ParseNetworkAddressBare ( QString strAddress, CHostAddress& HostAddress, bool bEnableIPv6 );
 
     static QString      FixAddress ( const QString& strAddress );
     static CHostAddress GetLocalAddress();


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Provides SRV DNS support for connecting to directories from a client or a server.
Supports `-e`/`--directoryaddress` for server and custom directories in both client and server GUI.
Also includes a small amount of refactoring for consistency and tidiness.

CHANGELOG: Client/Server: Add SRV support for connecting to directories.

**Context**

Currently one needs to provide both an IP/host and port number to the `-e|--directoryaddress` option if the directory server is not using the default port `22124`. This patch will enable the ability to use preconfigured SRV DNS records by a server to connect to a directory without having to provide a port number. It also supports the custom directories in both server and client GUI.

The patch expands on SRV support in client code already in `main`.

I have created SRV DNS records to test with that point to each of the seven public directory servers provided by the Jamulus team:
- anygenre1.jamulusjams.com
- anygenre2.jamulusjams.com
- anygenre3.jamulusjams.com
- rock.jamulusjams.com
- jazz.jamulusjams.com
- classical.jamulusjams.com
- choral.jamulusjams.com

You can confirm the SRV records using the following:
_Mac/Linux_
```
dig _jamulus._udp.anygenre1.jamulusjams.com srv

;; ANSWER SECTION:
_jamulus._udp.anygenre1.jamulusjams.com. 3600 IN SRV 0 0 22124 anygenre1.jamulus.io.
```
_Windows_
```
nslookup -type=srv _jamulus._udp.anygenre1.jamulusjams.com`

Server:  UnKnown
Address:  10.2.0.1

_jamulus._udp.anygenre1.jamulusjams.com SRV service location:
          priority       = 0
          weight         = 0
          port           = 22124
          svr hostname   = anygenre1.jamulus.io
```

In order to utilize this functionality for the Jamulus public space, the Jamulus team could create the seven SRV records and publish those in the same table that displays the server host/port pairs in https://jamulus.io/wiki/Running-a-Server#registered-mode

**Does this change need documentation? What needs to be documented and how?**

Unsure. According to `--help` output, the option `-c|--connect` doesn't mention anything about SRV support. In that same vein I submit nothing should be added for `-e|--directoryaddress` either.

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
