### PR TITLE
Add version sorting using CMappedTreeWidgetItem

### DIFF
--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -44,6 +44,19 @@
 #define SERV_LIST_REQ_UPDATE_TIME_MS 2000 // ms
 
 /* Classes ********************************************************************/
+
+// Subclass of QTreeWidgetItem that allows LVC_VERSION to sort by the UserRole data value
+class CMappedTreeWidgetItem : public QTreeWidgetItem
+{
+public:
+    explicit CMappedTreeWidgetItem ( QTreeWidget* owner = nullptr );
+
+    bool operator<( const QTreeWidgetItem& other ) const override;
+
+private:
+    QTreeWidget* owner = nullptr;
+};
+
 class CConnectDlg : public CBaseDlg, private Ui_CConnectDlgBase
 {
     Q_OBJECT
@@ -65,7 +78,6 @@ public:
     QString GetSelectedAddress() const { return strSelectedAddress; }
     QString GetSelectedServerName() const { return strSelectedServerName; }
 
-protected:
     // NOTE: This enum must list the columns in the same order
     //       as their column headings in connectdlgbase.ui
     enum EConnectListViewColumns
@@ -80,17 +92,18 @@ protected:
         LVC_COLUMNS             // total number of columns
     };
 
+protected:
     virtual void showEvent ( QShowEvent* );
     virtual void hideEvent ( QHideEvent* );
 
-    QTreeWidgetItem* FindListViewItem ( const CHostAddress& InetAddr );
-    QTreeWidgetItem* GetParentListViewItem ( QTreeWidgetItem* pItem );
-    void             DeleteAllListViewItemChilds ( QTreeWidgetItem* pItem );
-    void             UpdateListFilter();
-    void             ShowAllMusicians ( const bool bState );
-    void             RequestServerList();
-    void             EmitCLServerListPingMes ( const CHostAddress& haServerAddress, const bool bNeedVersion );
-    void             UpdateDirectoryComboBox();
+    CMappedTreeWidgetItem* FindListViewItem ( const CHostAddress& InetAddr );
+    CMappedTreeWidgetItem* GetParentListViewItem ( QTreeWidgetItem* pItem );
+    void                   DeleteAllListViewItemChilds ( QTreeWidgetItem* pItem );
+    void                   UpdateListFilter();
+    void                   ShowAllMusicians ( const bool bState );
+    void                   RequestServerList();
+    void                   EmitCLServerListPingMes ( const CHostAddress& haServerAddress, const bool bNeedVersion );
+    void                   UpdateDirectoryComboBox();
 
     CClientSettings* pSettings;
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Corrects the sorting of the version column in the connect dialog when using --showallservers.
It does this by mapping the version number to a sortable text field and storing that in the `data` field of the widget item.
It also subclasses `QTreeWidgetItem` as `CMappedTreeWidgetItem` in order to provide an override for `operator<`
to sort on the `data` field instead of the `text` field.

Also increases the default column width for the version column.

CHANGELOG: Client: Fix sorting of version number in connect dialog with --showallservers

**Context: Fixes an issue?**

Fixes: #3542

**Does this change need documentation? What needs to be documented and how?**

No, it's just a bugfix.

**Status of this Pull Request**

Tested on RPi Linux. Ready for testing on other platforms.

**What is missing until this pull request can be merged?**

Review.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
