### PR TITLE
Where available, use the commit time rather than commit id, for sort

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -15,7 +15,7 @@ contains(CONFIG, "noupcasename") {
 # allow detailed version info for intermediate builds (#475)
 contains(VERSION, .*dev.*) {
     exists(".git/config") {
-        GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty) # the match should never match
+        GIT_DESCRIPTION=$$system(git describe --match=xxxxxxxxxxxxxxxxxxxx --always --abbrev --dirty):$$system(git show -s "--pretty=format:%ct") # commit_id(-dirty):seconds_since_epoch
         VERSION = "$$VERSION"-$$GIT_DESCRIPTION
         message("building version \"$$VERSION\" (intermediate in git repository)")
     } else {

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -33,7 +33,7 @@ static QString mapVersionStr ( const QString& versionStr )
     QString x = ">"; // default suffix is later (git, dev, nightly, etc)
 
     // Regex for SemVer: major.minor.patch-suffix
-    QRegularExpression      semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*)$)" );
+    QRegularExpression      semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*):?(.*)$)" );
     QRegularExpressionMatch match = semVerRegex.match ( versionStr );
 
     if ( !match.hasMatch() )
@@ -45,6 +45,7 @@ static QString mapVersionStr ( const QString& versionStr )
     int     minor  = match.captured ( 2 ).toInt();
     int     patch  = match.captured ( 3 ).toInt();
     QString suffix = match.captured ( 4 ); // may be empty
+    QString tstamp = match.captured ( 5 ); // may be empty
 
     if ( suffix.isEmpty() )
     {
@@ -66,7 +67,7 @@ static QString mapVersionStr ( const QString& versionStr )
               .arg ( minor, 3, 10, QLatin1Char ( '0' ) )
               .arg ( patch, 3, 10, QLatin1Char ( '0' ) )
               .arg ( x )
-              .arg ( suffix );
+              .arg ( tstamp.isEmpty() ? suffix : tstamp );
 
     return key;
 }
@@ -184,13 +185,13 @@ CConnectDlg::CConnectDlg ( CClientSettings* pNSetP, const bool bNewShowCompleteR
     lvwServers->setColumnWidth ( LVC_NAME, 200 );
     lvwServers->setColumnWidth ( LVC_PING, 130 );
     lvwServers->setColumnWidth ( LVC_CLIENTS, 100 );
-    lvwServers->setColumnWidth ( LVC_VERSION, 110 );
+    lvwServers->setColumnWidth ( LVC_VERSION, 150 );
 #else
     lvwServers->setColumnWidth ( LVC_NAME, 180 );
     lvwServers->setColumnWidth ( LVC_PING, 75 );
     lvwServers->setColumnWidth ( LVC_CLIENTS, 70 );
     lvwServers->setColumnWidth ( LVC_LOCATION, 220 );
-    lvwServers->setColumnWidth ( LVC_VERSION, 95 );
+    lvwServers->setColumnWidth ( LVC_VERSION, 135 );
 #endif
     lvwServers->clear();
 
@@ -1024,7 +1025,7 @@ void CConnectDlg::SetServerVersionResult ( const CHostAddress& InetAddr, const Q
 
     if ( pCurListViewItem )
     {
-        pCurListViewItem->setText ( LVC_VERSION, strVersion );
+        pCurListViewItem->setText ( LVC_VERSION, GetDisplayVersion ( strVersion ) );
 
         // and store sortable mapped version number
         pCurListViewItem->setData ( LVC_VERSION, Qt::UserRole, mapVersionStr ( strVersion ) );

--- a/src/global.h
+++ b/src/global.h
@@ -73,7 +73,7 @@ LED bar:      lbr
 
 // version and application name (use version from qt prject file)
 #undef VERSION
-#define VERSION  APP_VERSION
+#define VERSION  GetDisplayVersion ( APP_VERSION )
 #define APP_NAME "Jamulus"
 
 // Windows registry key name of auto run entry for the server
@@ -374,3 +374,5 @@ bool GetNumericArgument ( int     argc,
                           double  rRangeStart,
                           double  rRangeStop,
                           double& rValue );
+
+inline QString GetDisplayVersion ( QString str ) { return str.contains ( ':' ) ? str.mid ( 0, str.lastIndexOf ( ':' ) ) : str; }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -1573,10 +1573,10 @@ void CProtocol::CreateVersionAndOSMes()
     int iPos = 0; // init position pointer
 
     // get the version number string
-    const QString strVerion = VERSION;
+    const QString strVersion = APP_VERSION;
 
     // convert version string to utf-8
-    const QByteArray strUTF8Version = strVerion.toUtf8();
+    const QByteArray strUTF8Version = strVersion.toUtf8();
 
     // size of current message body
     const int iEntrLen = 1 +                        // operating system
@@ -1864,7 +1864,7 @@ void CProtocol::CreateCLRegisterServerExMes ( const CHostAddress& InetAddr, cons
     const QByteArray strUTF8LInetAddr = LInetAddr.InetAddr.toString().toUtf8();
     const QByteArray strUTF8Name      = ServerInfo.strName.toUtf8();
     const QByteArray strUTF8City      = ServerInfo.strCity.toUtf8();
-    const QByteArray strUTF8Version   = QString ( VERSION ).toUtf8();
+    const QByteArray strUTF8Version   = QString ( APP_VERSION ).toUtf8();
 
     // size of current message body
     const int iEntrLen = 2 +                           // server internal port number
@@ -2296,10 +2296,10 @@ void CProtocol::CreateCLVersionAndOSMes ( const CHostAddress& InetAddr )
     int iPos = 0; // init position pointer
 
     // get the version number string
-    const QString strVerion = VERSION;
+    const QString strVersion = APP_VERSION;
 
     // convert version string to utf-8
-    const QByteArray strUTF8Version = strVerion.toUtf8();
+    const QByteArray strUTF8Version = strVersion.toUtf8();
 
     // size of current message body
     const int iEntrLen = 1 +                        // operating system


### PR DESCRIPTION
**Short description of changes**

As discussed elsewhere, I'd like the `--showallservers` sort to use the _commit time_ rather than _commit id_, where it's available.  This means changing the `APP_VERSION` to add the git timestamp to the end and then splitting that off for display purposes.  The define `DISPLAY` thus becomes a call to a method that does the trim.

CHANGELOG: Client: Use the commit time rather than commit id for --showallservers version sort

**Context: Fixes an issue?**

No.

**Does this change need documentation? What needs to be documented and how?**

When the docs for the sort on Version are written, they'd need to take this into account.

**Status of this Pull Request**

Tested locally.

**What is missing until this pull request can be merged?**

Nothing _broke_ -- existing servers sort exactly the same way as before as they have no timestamp.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above