### PR TITLE
Initial attempt to get file hashes when git checkout is done

### DIFF
--- a/.github/autobuild/get_build_vars.py
+++ b/.github/autobuild/get_build_vars.py
@@ -103,3 +103,7 @@ if publish_to_release:
     set_github_variable("IS_PRERELEASE", str(is_prerelease).lower())
     set_github_variable("RELEASE_TITLE", release_title)
     set_github_variable("RELEASE_TAG", release_tag)
+
+set_github_variable("CACHE_KEY_MACOS", hashFiles(REPO_PATH + '.github/workflows/autobuild.yml', REPO_PATH + '.github/autobuild/mac.sh', REPO_PATH + 'mac/deploy_mac.sh') )
+set_github_variable("CACHE_KEY_WINDOWS", hashFiles(REPO_PATH + '.github/workflows/autobuild.yml', REPO_PATH + '.github/autobuild/windows.ps1', REPO_PATH + 'windows/deploy_windows.ps1') )
+set_github_variable("CACHE_KEY_ANDROID", hashFiles(REPO_PATH + '.github/workflows/autobuild.yml', REPO_PATH + '.github/autobuild/android.sh') )

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -67,6 +67,9 @@ jobs:
       publish_to_release:           ${{ steps.get-build-vars.outputs.PUBLISH_TO_RELEASE }}
       tag_name:                     ${{ steps.get-build-vars.outputs.RELEASE_TAG }}
       build_version:                ${{ steps.get-build-vars.outputs.BUILD_VERSION }}
+      cache_key_macos:              ${{ steps.get-build-vars.outputs.CACHE_KEY_MACOS }}
+      cache_key_windows:            ${{ steps.get-build-vars.outputs.CACHE_KEY_WINDOWS }}
+      cache_key_android:            ${{ steps.get-build-vars.outputs.CACHE_KEY_ANDROID }}
       build_all_targets:            ${{ steps.decide-build-targets.outputs.build_all_targets }}
     env:
       release_changelog_path:       ./.github_release_changelog.md
@@ -323,7 +326,7 @@ jobs:
           path: |
             ~/qt
             ~/Library/Cache/jamulus-dependencies
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/mac.sh', 'mac/deploy_mac.sh') }}-${{ matrix.config.base_command }}
+          key:                      ${{ matrix.config.target_os }}-${{ steps.get-build-vars.outputs.CACHE_KEY_MACOS }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Windows dependencies
         if:                         matrix.config.target_os == 'windows'
@@ -335,7 +338,7 @@ jobs:
             C:\AutobuildCache
             ${{ github.workspace }}\libs\NSIS\NSIS-source
             ${{ github.workspace }}\libs\ASIOSDK2
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/windows.ps1', 'windows/deploy_windows.ps1') }}-${{ matrix.config.base_command }}
+          key:                      ${{ matrix.config.target_os }}-${{ steps.get-build-vars.outputs.CACHE_KEY_WINDOWS }}-${{ matrix.config.base_command }}
 
       - name:                       Cache Android dependencies
         if:                         matrix.config.target_os == 'android'
@@ -345,7 +348,7 @@ jobs:
             /opt/Qt
             /opt/android/android-sdk
             /opt/android/android-ndk
-          key:                      ${{ matrix.config.target_os }}-${{ hashFiles('.github/workflows/autobuild.yml', '.github/autobuild/android.sh') }}-${{ matrix.config.base_command }}
+          key:                      ${{ matrix.config.target_os }}-${{ steps.get-build-vars.outputs.CACHE_KEY_ANDROID }}-${{ matrix.config.base_command }}
 
       - name:                       Set up build dependencies for ${{ matrix.config.config_name }}
         run:                        ${{ matrix.config.base_command }} setup


### PR DESCRIPTION
**Short description of changes**

Hopefully a fix for:
```
Error: The template is not valid. .github/workflows/autobuild.yml (Line: 326, Col: 37): hashFiles('.github/workflows/autobuild.yml, .github/autobuild/mac.sh, mac/deploy_mac.sh') failed. Fail to hash files under directory '/Users/runner/work/jamulus/jamulus'
```
... but Claude Haiku thinks it's intermittent.  GPT 5 mini came up with roughly this idea.  Ideally it would be done once the check out is confirmed to have completed successfully.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Yes

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Waiting a clean build through Github.

**What is missing until this pull request can be merged?**

Hopefully doesn't break anything...

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
