### PR TITLE
Add Japanese translation (ja_JP)

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -52,7 +52,8 @@ contains(CONFIG, "headless") {
 
 # Do not set LRELEASE_DIR explicitly when using embed_translations.
 # It doesn't work with multiple targets or architectures.
-TRANSLATIONS = src/translation/translation_de_DE.ts \
+TRANSLATIONS = src/translation/translation_ja_JP.ts \
+    src/translation/translation_de_DE.ts \
     src/translation/translation_fr_FR.ts \
     src/translation/translation_ko_KR.ts \
     src/translation/translation_pt_PT.ts \

--- a/src/translation/translation_ja_JP.ts
+++ b/src/translation/translation_ja_JP.ts
@@ -72,12 +72,12 @@
     <message>
         <location filename="../util.cpp" line="504"/>
         <source>For details on the contributions check out the %1</source>
-        <translation>貢献の詳細については %1 を確認してください</translation>
+        <translation>コード貢献の詳細については %1 を確認してください</translation>
     </message>
     <message>
         <location filename="../util.cpp" line="505"/>
         <source>Github Contributors list</source>
-        <translation>Github 貢献者リスト</translation>
+        <translation>Github コード貢献者リスト</translation>
     </message>
     <message>
         <location filename="../util.cpp" line="508"/>
@@ -183,7 +183,7 @@
     <message>
         <location filename="../aboutdlgbase.ui" line="134"/>
         <source>&amp;Contributors</source>
-        <translation>貢献者(&amp;C)</translation>
+        <translation>コード貢献者(&amp;C)</translation>
     </message>
     <message>
         <location filename="../aboutdlgbase.ui" line="148"/>

--- a/src/translation/translation_ja_JP.ts
+++ b/src/translation/translation_ja_JP.ts
@@ -1,0 +1,4341 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja_JP">
+<context>
+    <name>CAboutDlg</name>
+    <message>
+        <location filename="../util.cpp" line="392"/>
+        <source>Qt cross-platform application framework</source>
+        <translation>Qt クロスプラットフォームアプリケーションフレームワーク</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="392"/>
+        <source>(build)</source>
+        <translation>(ビルド)</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="393"/>
+        <source>(runtime)</source>
+        <translation>(ランタイム)</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="411"/>
+        <source>Audio reverberation code by Perry R. Cook and Gary P. Scavone</source>
+        <translation>Perry R. Cook および Gary P. Scavone によるオーディオリバーブコード</translation>
+    </message>
+    <message>
+        <source>Some pixmaps are from the</source>
+        <translation type="vanished">一部の画像は</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="369"/>
+        <source>This app enables musicians to perform real-time jam sessions over the internet.</source>
+        <translation>このアプリを使用すると、ミュージシャンがインターネットを介してリアルタイムでジャムセッションを行うことができます。</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="372"/>
+        <source>There is a server which collects  the audio data from each client, mixes the audio data and sends the mix  back to each client.</source>
+        <translation>各クライアントからオーディオデータを収集し、ミキシングして、各クライアントに送り返すサーバーがあります。</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="391"/>
+        <source>This app uses the following libraries, resources or code snippets:</source>
+        <translation>このアプリは以下のライブラリ、リソース、コードスニペットを使用しています:</translation>
+    </message>
+    <message>
+        <source>Country flag icons by Mark James</source>
+        <translation type="vanished">国旗アイコン by Mark James</translation>
+    </message>
+    <message>
+        <source>For details on the contributions check out the </source>
+        <translation type="vanished">貢献の詳細については以下を確認してください </translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="421"/>
+        <source>Flag icons by Mark James</source>
+        <translation>国旗アイコン by Mark James</translation>
+    </message>
+    <message>
+        <source>Some sound samples are from</source>
+        <translation type="vanished">一部のサウンドサンプルは</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="417"/>
+        <source>Some pixmaps are from the %1</source>
+        <translation>一部の画像は %1 から取得しています</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="425"/>
+        <source>Some sound samples are from %1</source>
+        <translation>一部のサウンドサンプルは %1 から取得しています</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="504"/>
+        <source>For details on the contributions check out the %1</source>
+        <translation>貢献の詳細については %1 を確認してください</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="505"/>
+        <source>Github Contributors list</source>
+        <translation>Github 貢献者リスト</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="508"/>
+        <source>Spanish</source>
+        <translation>スペイン語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="512"/>
+        <source>French</source>
+        <translation>フランス語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="517"/>
+        <source>Portuguese</source>
+        <translation>ポルトガル語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="524"/>
+        <source>Dutch</source>
+        <translation>オランダ語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="529"/>
+        <source>Italian</source>
+        <translation>イタリア語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="533"/>
+        <source>German</source>
+        <translation>ドイツ語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="538"/>
+        <source>Polish</source>
+        <translation>ポーランド語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="543"/>
+        <source>Swedish</source>
+        <translation>スウェーデン語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="549"/>
+        <source>Korean</source>
+        <translation>韓国語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="554"/>
+        <source>Slovak</source>
+        <translation>スロバキア語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="557"/>
+        <source>Simplified Chinese</source>
+        <translation>簡体字中国語</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="560"/>
+        <source>Norwegian Bokmål</source>
+        <translation>ノルウェー語（ブークモール）</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="568"/>
+        <source>About %1</source>
+        <translation>%1 について</translation>
+    </message>
+    <message>
+        <source>About </source>
+        <translation type="vanished">について </translation>
+    </message>
+</context>
+<context>
+    <name>CAboutDlgBase</name>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="20"/>
+        <source>About</source>
+        <translation>このアプリについて</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="59"/>
+        <source>TextLabelVersion</source>
+        <translation>TextLabelVersion</translation>
+    </message>
+    <message>
+        <source>Copyright (C) 2005-2025 The Jamulus Development Team</source>
+        <translation type="vanished">Copyright (C) 2005-2025 Jamulus 開発チーム</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="72"/>
+        <source>Copyright © 2005-2025 The Jamulus Development Team</source>
+        <translation>Copyright © 2005-2025 Jamulus 開発チーム</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="106"/>
+        <source>A&amp;bout</source>
+        <translation>情報(&amp;B)</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="120"/>
+        <source>&amp;Libraries</source>
+        <translation>ライブラリ(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="134"/>
+        <source>&amp;Contributors</source>
+        <translation>貢献者(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="148"/>
+        <source>&amp;Translation</source>
+        <translation>翻訳(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../aboutdlgbase.ui" line="198"/>
+        <source>&amp;OK</source>
+        <translation>OK(&amp;O)</translation>
+    </message>
+</context>
+<context>
+    <name>CAnalyzerConsole</name>
+    <message>
+        <location filename="../analyzerconsole.cpp" line="47"/>
+        <source>Analyzer Console</source>
+        <translation>アナライザーコンソール</translation>
+    </message>
+    <message>
+        <location filename="../analyzerconsole.cpp" line="65"/>
+        <source>Error Rate of Each Buffer Size</source>
+        <translation>各バッファサイズのエラー率</translation>
+    </message>
+</context>
+<context>
+    <name>CAudioMixerBoard</name>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="903"/>
+        <source>Personal Mix at the Server</source>
+        <translation>サーバーでのパーソナルミックス</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="904"/>
+        <source>When connected to a server, the controls here allow you to set your local mix without affecting what others hear from you. The title shows the server name and, when known, whether it is actively recording.</source>
+        <translation>サーバーに接続すると、ここのコントロールで他の人に聞こえる音に影響を与えずにローカルミックスを設定できます。タイトルにはサーバー名が表示され、録音中かどうかも表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="977"/>
+        <source>Server</source>
+        <translation>サーバー</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="986"/>
+        <source>T R Y I N G   T O   C O N N E C T</source>
+        <translation>接続中</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="1193"/>
+        <source>RECORDING ACTIVE</source>
+        <translation>録音中</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="1203"/>
+        <source>Personal Mix at: %1</source>
+        <translation>パーソナルミックス: %1</translation>
+    </message>
+</context>
+<context>
+    <name>CChannelFader</name>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="139"/>
+        <source>Channel Level</source>
+        <translation>チャンネルレベル</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="142"/>
+        <source>Input level of the current audio channel at the server</source>
+        <translation>サーバーでの現在のオーディオチャンネルの入力レベル</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="145"/>
+        <source>Mixer Fader</source>
+        <translation>ミキサーフェーダー</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="148"/>
+        <source>Local mix level setting of the current audio channel at the server</source>
+        <translation>サーバーでの現在のオーディオチャンネルのローカルミックスレベル設定</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="151"/>
+        <source>Status Indicator</source>
+        <translation>ステータスインジケーター</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="152"/>
+        <source>Shows a status indication about the client which is assigned to this channel. Supported indicators are:</source>
+        <translation>このチャンネルに割り当てられたクライアントのステータスを表示します。サポートされるインジケーター:</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="155"/>
+        <source>Status indicator label</source>
+        <translation>ステータスインジケーターラベル</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="157"/>
+        <source>Panning</source>
+        <translation>パンニング</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="160"/>
+        <source>Local panning position of the current audio channel at the server</source>
+        <translation>サーバーでの現在のオーディオチャンネルのローカルパン位置</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="162"/>
+        <source>With the Mute checkbox, the audio channel can be muted.</source>
+        <translation>ミュートチェックボックスでオーディオチャンネルをミュートできます。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="163"/>
+        <source>Mute button</source>
+        <translation>ミュートボタン</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="170"/>
+        <source>Solo button</source>
+        <translation>ソロボタン</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="178"/>
+        <source>Fader Tag</source>
+        <translation>フェーダータグ</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="179"/>
+        <source>The fader tag identifies the connected client. The tag name, a picture of your instrument and the flag of your location can be set in the main window.</source>
+        <translation>フェーダータグは接続されたクライアントを識別します。タグ名、楽器の画像、所在地の国旗はメインウィンドウで設定できます。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="188"/>
+        <source>Mixer channel country/region flag</source>
+        <translation>ミキサーチャンネル 国/地域の旗</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="254"/>
+        <source>Grp</source>
+        <translation>グループ</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="140"/>
+        <source>Displays the pre-fader audio level of this channel.  All clients connected to the server will be assigned an audio level, the same value for every client.</source>
+        <translation>このチャンネルのプリフェーダーオーディオレベルを表示します。サーバーに接続されたすべてのクライアントには、同じオーディオレベルが割り当てられます。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="67"/>
+        <source>&amp;No grouping</source>
+        <translation>グループ化なし(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="70"/>
+        <source>Assign to group</source>
+        <translation>グループに割り当て</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="146"/>
+        <source>Adjusts the audio level of this channel. All clients connected to the server will be assigned an audio fader, displayed at each client, to adjust the local mix.</source>
+        <translation>このチャンネルのオーディオレベルを調整します。サーバーに接続されたすべてのクライアントには、ローカルミックスを調整するためのオーディオフェーダーが割り当てられます。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="154"/>
+        <source>Speaker with cancellation stroke: Indicates that another client has muted you.</source>
+        <translation>キャンセル線付きスピーカー: 他のクライアントがあなたをミュートしていることを示します。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="158"/>
+        <source>Sets the pan from Left to Right of the channel. Works only in stereo or preferably mono in/stereo out mode.</source>
+        <translation>チャンネルの左右のパンを設定します。ステレオまたはモノラル入力/ステレオ出力モードでのみ動作します。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="166"/>
+        <source>With the Solo checkbox, the audio channel can be set to solo which means that all other channels except the soloed channel are muted. It is possible to set more than one channel to solo.</source>
+        <translation>ソロチェックボックスでオーディオチャンネルをソロに設定できます。ソロ以外のすべてのチャンネルがミュートされます。複数のチャンネルをソロに設定することも可能です。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="172"/>
+        <source>Group</source>
+        <translation>グループ</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="173"/>
+        <source>With the Grp checkbox, a group of audio channels can be defined. All channel faders in a group are moved in proportional synchronization if any one of the group faders are moved.</source>
+        <translation>Grpチェックボックスでオーディオチャンネルグループを定義できます。グループ内のフェーダーを動かすと、すべてのチャンネルフェーダーが比例同期で移動します。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="176"/>
+        <source>Group button</source>
+        <translation>グループボタン</translation>
+    </message>
+    <message>
+        <source>The fader tag identifies the connected client. The tag name, a picture of your instrument and the flag of your country can be set in the main window.</source>
+        <translation type="vanished">フェーダータグは接続されたクライアントを識別します。タグ名、楽器の画像、国旗はメインウィンドウで設定できます。</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="184"/>
+        <source>Mixer channel instrument picture</source>
+        <translation>ミキサーチャンネル楽器画像</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="186"/>
+        <source>Mixer channel label (fader tag)</source>
+        <translation>ミキサーチャンネルラベル（フェーダータグ）</translation>
+    </message>
+    <message>
+        <source>Mixer channel country flag</source>
+        <translation type="vanished">ミキサーチャンネル国旗</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="224"/>
+        <source>PAN</source>
+        <translation>PAN</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="225"/>
+        <source>MUTE</source>
+        <translation>MUTE</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="226"/>
+        <source>SOLO</source>
+        <translation>SOLO</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="227"/>
+        <source>GRP</source>
+        <translation>GRP</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="238"/>
+        <source>M</source>
+        <translation>M</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="239"/>
+        <source>S</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="240"/>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="796"/>
+        <source>Alias/Name</source>
+        <translation>エイリアス/名前</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="803"/>
+        <source>Instrument</source>
+        <translation>楽器</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="811"/>
+        <source>Location</source>
+        <translation>所在地</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="839"/>
+        <location filename="../audiomixerboard.cpp" line="845"/>
+        <location filename="../audiomixerboard.cpp" line="851"/>
+        <source>Skill Level</source>
+        <translation>スキルレベル</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="872"/>
+        <source>Alias</source>
+        <translation>エイリアス</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="838"/>
+        <source>Beginner</source>
+        <translation>初心者</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="844"/>
+        <source>Intermediate</source>
+        <translation>中級者</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="850"/>
+        <source>Expert</source>
+        <translation>上級者</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="863"/>
+        <source>Musician Profile</source>
+        <translation>ミュージシャンプロフィール</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="48"/>
+        <location filename="../audiomixerboard.cpp" line="162"/>
+        <location filename="../audiomixerboard.cpp" line="252"/>
+        <source>Mute</source>
+        <translation>ミュート</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="44"/>
+        <location filename="../audiomixerboard.cpp" line="237"/>
+        <location filename="../audiomixerboard.cpp" line="251"/>
+        <source>Pan</source>
+        <translation>パン</translation>
+    </message>
+    <message>
+        <location filename="../audiomixerboard.cpp" line="49"/>
+        <location filename="../audiomixerboard.cpp" line="165"/>
+        <location filename="../audiomixerboard.cpp" line="253"/>
+        <source>Solo</source>
+        <translation>ソロ</translation>
+    </message>
+</context>
+<context>
+    <name>CChatDlg</name>
+    <message>
+        <location filename="../chatdlg.cpp" line="34"/>
+        <source>Chat Window</source>
+        <translation>チャットウィンドウ</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="34"/>
+        <source>The chat window shows a history of all chat messages.</source>
+        <translation>チャットウィンドウにはすべてのチャットメッセージの履歴が表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="36"/>
+        <source>Chat history</source>
+        <translation>チャット履歴</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="39"/>
+        <source>Input Message Text</source>
+        <translation>メッセージ入力</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="40"/>
+        <source>Enter the chat message text in the edit box and press enter to send the message to the server which distributes the message to all connected clients. Your message will then show up in the chat window.</source>
+        <translation>入力ボックスにチャットメッセージを入力しEnterキーを押すと、接続しているすべてのクライアントにメッセージを配信するサーバーにメッセージが送信されます。メッセージはチャットウィンドウに表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="44"/>
+        <source>New chat text edit box</source>
+        <translation>新しいチャットテキスト入力ボックス</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="54"/>
+        <source>Type a message here</source>
+        <translation>ここにメッセージを入力</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="58"/>
+        <source>&amp;Edit</source>
+        <translation>編集(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="60"/>
+        <source>Cl&amp;ear Chat History</source>
+        <translation>チャット履歴をクリア(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="64"/>
+        <location filename="../chatdlg.cpp" line="68"/>
+        <source>&amp;Close</source>
+        <translation>閉じる(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../chatdlg.cpp" line="148"/>
+        <source>Do you want to open the link &apos;%1&apos; in your browser?</source>
+        <translation>ブラウザで &apos;%1&apos; のリンクを開きますか？</translation>
+    </message>
+    <message>
+        <source>Do you want to open the link</source>
+        <translation type="vanished">外部ブラウザで</translation>
+    </message>
+    <message>
+        <source>in an external browser?</source>
+        <translation type="vanished">リンクを開きますか？</translation>
+    </message>
+</context>
+<context>
+    <name>CChatDlgBase</name>
+    <message>
+        <location filename="../chatdlgbase.ui" line="20"/>
+        <source>Chat</source>
+        <translation>チャット</translation>
+    </message>
+    <message>
+        <location filename="../chatdlgbase.ui" line="54"/>
+        <source>&amp;Send</source>
+        <translation>送信(&amp;S)</translation>
+    </message>
+</context>
+<context>
+    <name>CClientDlg</name>
+    <message>
+        <location filename="../clientdlg.cpp" line="54"/>
+        <source>Input Level Meter</source>
+        <translation>入力レベルメーター</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="59"/>
+        <source>Make sure not to clip the input signal to avoid distortions of the audio signal.</source>
+        <translation>オーディオ信号の歪みを防ぐため、入力信号がクリップしないようにしてください。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="77"/>
+        <source>Input level meter</source>
+        <translation>入力レベルメーター</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="78"/>
+        <source>Simulates an analog LED level meter.</source>
+        <translation>アナログLEDレベルメーターをシミュレートします。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="95"/>
+        <source>Connect/Disconnect Button</source>
+        <translation>接続/切断ボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="99"/>
+        <source>Connect and disconnect toggle button</source>
+        <translation>接続と切断のトグルボタン</translation>
+    </message>
+    <message>
+        <source>Local Audio Input Fader</source>
+        <translation type="vanished">ローカルオーディオ入力フェーダー</translation>
+    </message>
+    <message>
+        <source>Local audio input fader (left/right)</source>
+        <translation type="vanished">ローカルオーディオ入力フェーダー（左/右）</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="55"/>
+        <source>This shows the level of the two stereo channels for your audio input.</source>
+        <translation>オーディオ入力の2つのステレオチャンネルのレベルを表示します。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="62"/>
+        <source>If the application is connected to a server and you play your instrument/sing into the microphone, the VU meter should flicker. If this is not the case, you have probably selected the wrong input channel (e.g. &apos;line in&apos; instead of the microphone input) or set the input gain too low in the (Windows) audio mixer.</source>
+        <translation>アプリケーションがサーバーに接続されていて、楽器を演奏したりマイクに向かって歌ったりすると、VUメーターが点滅するはずです。そうでない場合は、間違った入力チャンネルを選択している（例：マイク入力ではなくライン入力）か、（Windows）オーディオミキサーで入力ゲインを低く設定しすぎている可能性があります。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="70"/>
+        <source>For proper usage of the application, you should not hear your singing/instrument through the loudspeaker or your headphone when the software is not connected. This can be achieved by muting your input audio channel in the Playback mixer (not the Recording mixer!).</source>
+        <translation>アプリケーションを正しく使用するには、ソフトウェアが接続されていないときにスピーカーやヘッドフォンから自分の歌声や楽器の音が聞こえないようにする必要があります。これは再生ミキサー（録音ミキサーではありません！）で入力オーディオチャンネルをミュートすることで実現できます。</translation>
+    </message>
+    <message>
+        <source>Controls the relative levels of the left and right local audio channels. For a mono signal it acts as a pan between the two channels. For example, if a microphone is connected to the right input channel and an instrument is connected to the left input channel which is much louder than the microphone, move the audio fader in a direction where the label above the fader shows </source>
+        <translation type="vanished">左右のローカルオーディオチャンネルの相対レベルを制御します。モノラル信号の場合、2つのチャンネル間のパンとして機能します。例えば、マイクが右入力チャンネルに接続され、マイクよりもはるかに音量の大きい楽器が左入力チャンネルに接続されている場合、フェーダー上部のラベルに表示される方向にオーディオフェーダーを動かします</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="102"/>
+        <source>Reverb effect</source>
+        <translation>リバーブエフェクト</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="103"/>
+        <source>Reverb can be applied to one local mono audio channel or to both channels in stereo mode. The mono channel selection and the reverb level can be modified. For example, if a microphone signal is fed in to the right audio channel of the sound card and a reverb effect needs to be applied, set the channel selector to right and move the fader upwards until the desired reverb level is reached.</source>
+        <translation>リバーブは1つのローカルモノオーディオチャンネル、またはステレオモードの両方のチャンネルに適用できます。モノチャンネルの選択とリバーブレベルを変更できます。例えば、マイク信号がサウンドカードの右オーディオチャンネルに入力され、リバーブエフェクトを適用する必要がある場合は、チャンネルセレクターを右に設定し、希望のリバーブレベルに達するまでフェーダーを上に動かします。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="114"/>
+        <source>Reverb effect level setting</source>
+        <translation>リバーブエフェクトレベル設定</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="117"/>
+        <source>Reverb Channel Selection</source>
+        <translation>リバーブチャンネル選択</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="118"/>
+        <source>With these radio buttons the audio input channel on which the reverb effect is applied can be chosen. Either the left or right input channel can be selected.</source>
+        <translation>これらのラジオボタンで、リバーブエフェクトを適用するオーディオ入力チャンネルを選択できます。左または右の入力チャンネルを選択できます。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="123"/>
+        <source>Left channel selection for reverb</source>
+        <translation>リバーブ用左チャンネル選択</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="125"/>
+        <source>Right channel selection for reverb</source>
+        <translation>リバーブ用右チャンネル選択</translation>
+    </message>
+    <message>
+        <source>The </source>
+        <translation type="obsolete">The </translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="132"/>
+        <source>Green</source>
+        <translation>緑</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="133"/>
+        <source>The delay is perfect for a jam session.</source>
+        <translation>遅延はジャムセッションに最適な状態です。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="138"/>
+        <source>Yellow</source>
+        <translation>黄</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="144"/>
+        <source>Red</source>
+        <translation>赤</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="152"/>
+        <source>If this LED indicator turns red, you will not have much fun using %1.</source>
+        <translation>このLEDインジケーターが赤に変わると、%1の使用が楽しくなくなるでしょう。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="157"/>
+        <source>Delay status LED indicator</source>
+        <translation>遅延状態LEDインジケーター</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="96"/>
+        <source>Opens a dialog where you can select a server to connect to. If you are connected, pressing this button will end the session.</source>
+        <translation>接続するサーバーを選択できるダイアログを開きます。接続中の場合、このボタンを押すとセッションが終了します。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="128"/>
+        <source>Shows the current audio delay status:</source>
+        <translation>現在のオーディオ遅延状態を表示します：</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="139"/>
+        <source>A session is still possible but it may be harder to play.</source>
+        <translation>セッションは可能ですが、演奏が難しくなる場合があります。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="145"/>
+        <source>The delay is too large for jamming.</source>
+        <translation>ジャムセッションには遅延が大きすぎます。</translation>
+    </message>
+    <message>
+        <source>If this LED indicator turns red, you will not have much fun using the application.</source>
+        <translation type="vanished">このLEDインジケーターが赤に変わると、アプリケーションの使用が楽しくなくなるでしょう。</translation>
+    </message>
+    <message>
+        <source>The buffers status LED shows the current audio/streaming status. If the light is red, the audio stream is interrupted. This is caused by one of the following problems:</source>
+        <translation type="vanished">バッファ状態LEDは現在のオーディオ/ストリーミング状態を表示します。ライトが赤の場合、オーディオストリームが中断されています。これは以下の問題のいずれかによって引き起こされます：</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="170"/>
+        <source>The sound card&apos;s buffer delay (buffer size) is too small (see Settings window).</source>
+        <translation>サウンドカードのバッファ遅延（バッファサイズ）が小さすぎます（設定ウィンドウを参照）。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="174"/>
+        <source>The upload or download stream rate is too high for your internet bandwidth.</source>
+        <translation>アップロードまたはダウンロードストリームレートがインターネット帯域幅に対して高すぎます。</translation>
+    </message>
+    <message>
+        <source>Buffers status LED indicator</source>
+        <translation type="vanished">バッファ状態LEDインジケーター</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="231"/>
+        <location filename="../clientdlg.cpp" line="1267"/>
+        <source>C&amp;onnect</source>
+        <translation>接続(&amp;O)</translation>
+    </message>
+    <message>
+        <source>software upgrade available</source>
+        <translation type="vanished">ソフトウェアアップグレードが利用可能</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="284"/>
+        <source>&amp;File</source>
+        <translation>ファイル(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="311"/>
+        <source>&amp;View</source>
+        <translation>表示(&amp;V)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="286"/>
+        <source>&amp;Connection Setup...</source>
+        <translation>接続設定(&amp;C)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="397"/>
+        <source>My &amp;Profile...</source>
+        <translation>マイプロフィール(&amp;P)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="384"/>
+        <source>C&amp;hat...</source>
+        <translation>チャット(&amp;H)...</translation>
+    </message>
+    <message>
+        <source>&amp;Settings...</source>
+        <translation type="vanished">設定(&amp;S)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="389"/>
+        <source>&amp;Analyzer Console...</source>
+        <translation>アナライザーコンソール(&amp;A)...</translation>
+    </message>
+    <message>
+        <source>Use &amp;Two Rows Mixer Panel</source>
+        <translation type="vanished">2行ミキサーパネルを使用(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="301"/>
+        <source>Clear &amp;All Stored Solo and Mute Settings</source>
+        <translation>保存されたすべてのソロ・ミュート設定をクリア(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="737"/>
+        <source>%1 Directory</source>
+        <translation>%1 ディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="1182"/>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="296"/>
+        <source>E&amp;xit</source>
+        <translation>終了(&amp;X)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="299"/>
+        <source>&amp;Edit</source>
+        <translation>編集(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation type="vanished">中央</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="vanished">R</translation>
+    </message>
+    <message>
+        <source>L</source>
+        <translation type="vanished">L</translation>
+    </message>
+    <message>
+        <source>, where</source>
+        <translation type="vanished">、ここで</translation>
+    </message>
+    <message>
+        <source>is the current attenuation indicator.</source>
+        <translation type="vanished">は現在の減衰インジケーターです。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="128"/>
+        <source>Delay Status LED</source>
+        <translation>遅延状態LED</translation>
+    </message>
+    <message>
+        <source>Buffers Status LED</source>
+        <translation type="vanished">バッファ状態LED</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="166"/>
+        <source>The network jitter buffer is not large enough for the current network/audio interface jitter.</source>
+        <translation>ネットワークジッターバッファが、現在のネットワーク/オーディオインターフェースのジッターに対して十分な大きさではありません。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="178"/>
+        <source>The CPU of the client or server is at 100%.</source>
+        <translation>クライアントまたはサーバーのCPUが100%になっています。</translation>
+    </message>
+    <message>
+        <source>Current Connection Status Parameter</source>
+        <translation type="vanished">現在の接続状態パラメータ</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="192"/>
+        <source>The Ping Time is the time required for the audio stream to travel from the client to the server and back again. This delay is introduced by the network and should be about 20-30 ms. If this delay is higher than about 50 ms, your distance to the server is too large or your internet connection is not sufficient.</source>
+        <translation>Ping時間は、オーディオストリームがクライアントからサーバーへ移動し、戻ってくるまでに必要な時間です。この遅延はネットワークによって発生し、約20〜30msが目安です。この遅延が約50msを超える場合は、サーバーとの距離が遠すぎるか、インターネット接続が十分ではありません。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="199"/>
+        <source>Overall Delay is calculated from the current Ping Time and the delay introduced by the current buffer settings.</source>
+        <translation>全体遅延は、現在のPing時間と現在のバッファ設定による遅延から計算されます。</translation>
+    </message>
+    <message>
+        <source>If this LED indicator turns red, you will not have much fun using the </source>
+        <translation type="vanished">このLEDインジケーターが赤に変わると、ソフトウェアの</translation>
+    </message>
+    <message>
+        <source> software.</source>
+        <translation type="vanished">使用が楽しくなくなるでしょう。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="290"/>
+        <source>&amp;Load Mixer Channels Setup...</source>
+        <translation>ミキサーチャンネル設定を読み込み(&amp;L)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="292"/>
+        <source>&amp;Save Mixer Channels Setup...</source>
+        <translation>ミキサーチャンネル設定を保存(&amp;S)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="337"/>
+        <source>Sort Users by Chann&amp;el</source>
+        <translation>チャンネルでユーザーを並べ替え(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="395"/>
+        <source>Sett&amp;ings</source>
+        <translation>設定(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="399"/>
+        <source>Audio/Network &amp;Settings...</source>
+        <translation>オーディオ/ネットワーク設定(&amp;S)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="401"/>
+        <source>A&amp;dvanced Settings...</source>
+        <translation>詳細設定(&amp;D)...</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="320"/>
+        <source>N&amp;o User Sorting</source>
+        <translation>ユーザー並べ替えなし(&amp;O)</translation>
+    </message>
+    <message>
+        <source>If this LED indicator turns red, you will not have much fun using the %1 software.</source>
+        <translation type="vanished">このLEDインジケーターが赤に変わると、%1ソフトウェアの使用が楽しくなくなるでしょう。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="315"/>
+        <source>O&amp;wn Fader First</source>
+        <translation>自分のフェーダーを先頭に(&amp;W)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="323"/>
+        <source>Sort Users by &amp;Name</source>
+        <translation>名前でユーザーを並べ替え(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="325"/>
+        <source>Sort Users by &amp;Instrument</source>
+        <translation>楽器でユーザーを並べ替え(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="331"/>
+        <source>Sort Users by &amp;Group</source>
+        <translation>グループでユーザーを並べ替え(&amp;G)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="334"/>
+        <source>Sort Users by &amp;City</source>
+        <translation>都市でユーザーを並べ替え(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="303"/>
+        <source>Set All Faders to New Client &amp;Level</source>
+        <translation>すべてのフェーダーを新規クライアントレベルに設定(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="160"/>
+        <source>Local Jitter Buffer Status LED</source>
+        <translation>ローカルジッターバッファ状態LED</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="161"/>
+        <source>The local jitter buffer status LED shows the current audio/streaming status. If the light is red, the audio stream is interrupted. This is caused by one of the following problems:</source>
+        <translation>ローカルジッターバッファ状態LEDは、現在のオーディオ/ストリーミング状態を表示します。ライトが赤の場合、オーディオストリームが中断されています。これは以下の問題のいずれかによって引き起こされます：</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="184"/>
+        <source>If this LED indicator turns red, the audio stream is interrupted.</source>
+        <translation>このLEDインジケーターが赤に変わると、オーディオストリームが中断されています。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="188"/>
+        <source>Local Jitter Buffer status LED indicator</source>
+        <translation>ローカルジッターバッファ状態LEDインジケーター</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="191"/>
+        <source>Current Connection Status</source>
+        <translation>現在の接続状態</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="308"/>
+        <source>Auto-Adjust all &amp;Faders</source>
+        <translation>すべてのフェーダーを自動調整(&amp;F)</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="vanished">設定(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Directory Server</source>
+        <translation type="vanished">ディレクトリサーバー</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="782"/>
+        <location filename="../clientdlg.cpp" line="794"/>
+        <source>Select Channel Setup File</source>
+        <translation>チャンネル設定ファイルを選択</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="942"/>
+        <source>user</source>
+        <translation>ユーザー</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="946"/>
+        <source>users</source>
+        <translation>ユーザー</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="978"/>
+        <source>Connect</source>
+        <translation>接続</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="990"/>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="1000"/>
+        <source>Chat</source>
+        <translation>チャット</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="1076"/>
+        <source>Enable feedback detection</source>
+        <translation>フィードバック検出を有効化</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="1079"/>
+        <source>Audio feedback or loud signal detected.
+
+We muted your channel and activated &apos;Mute Myself&apos;. Please solve the feedback issue first and unmute yourself afterwards.</source>
+        <translation>オーディオフィードバックまたは大きな信号が検出されました。
+
+チャンネルをミュートし、「自分をミュート」を有効にしました。まずフィードバックの問題を解決してから、ミュートを解除してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="1164"/>
+        <source>Your sound card is not working correctly. Please open the settings dialog and check the device selection and the driver settings.</source>
+        <translation>サウンドカードが正しく動作していません。設定ダイアログを開いて、デバイスの選択とドライバーの設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientdlg.cpp" line="1235"/>
+        <source>&amp;Disconnect</source>
+        <translation>切断(&amp;D)</translation>
+    </message>
+</context>
+<context>
+    <name>CClientDlgBase</name>
+    <message>
+        <location filename="../clientdlgbase.ui" line="343"/>
+        <source>Delay</source>
+        <translation>遅延</translation>
+    </message>
+    <message>
+        <source>Buffers</source>
+        <translation type="vanished">バッファ</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="247"/>
+        <source>Input</source>
+        <translation>入力</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="295"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="305"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="330"/>
+        <source>Jitter</source>
+        <translation>ジッター</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="356"/>
+        <source>Ping</source>
+        <translation>Ping</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="400"/>
+        <location filename="../clientdlgbase.ui" line="438"/>
+        <source>ms</source>
+        <translation>ms</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="498"/>
+        <source>&amp;Mute Myself</source>
+        <translation>自分をミュート(&amp;M)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="505"/>
+        <source>&amp;Settings</source>
+        <translation>設定(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="512"/>
+        <source>&amp;Chat</source>
+        <translation>チャット(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="531"/>
+        <source>C&amp;onnect</source>
+        <translation>接続(&amp;O)</translation>
+    </message>
+    <message>
+        <source>Pan</source>
+        <translation type="vanished">パン</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation type="vanished">中央</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="118"/>
+        <source>Reverb</source>
+        <translation>リバーブ</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="202"/>
+        <source>Left</source>
+        <translation>左</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="209"/>
+        <source>Right</source>
+        <translation>右</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="557"/>
+        <source>MUTED (Other people won&apos;t hear you)</source>
+        <translation>ミュート中（他の人には聞こえません）</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="587"/>
+        <source>Set up your audio, connect to a server and start jamming!</source>
+        <translation>オーディオを設定して、サーバーに接続し、ジャムセッションを始めましょう！</translation>
+    </message>
+    <message>
+        <location filename="../clientdlgbase.ui" line="609"/>
+        <source>Update check</source>
+        <translation>アップデートを確認</translation>
+    </message>
+</context>
+<context>
+    <name>CClientSettingsDlg</name>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="75"/>
+        <source>Jitter Buffer Size</source>
+        <translation>ジッターバッファサイズ</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="87"/>
+        <source>The jitter buffer setting is therefore a trade-off between audio quality and overall delay.</source>
+        <translation>ジッターバッファの設定は、オーディオ品質と全体的な遅延のトレードオフです。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="112"/>
+        <source>Local jitter buffer slider control</source>
+        <translation>ローカルジッターバッファスライダーコントロール</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="115"/>
+        <source>Server jitter buffer slider control</source>
+        <translation>サーバージッターバッファスライダーコントロール</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="117"/>
+        <source>Auto jitter buffer check box</source>
+        <translation>自動ジッターバッファチェックボックス</translation>
+    </message>
+    <message>
+        <source>Jitter buffer status LED indicator</source>
+        <translation type="vanished">ジッターバッファ状態LEDインジケーター</translation>
+    </message>
+    <message>
+        <source>Sound Card Device</source>
+        <translation type="vanished">サウンドカードデバイス</translation>
+    </message>
+    <message>
+        <source>The ASIO driver (sound card) can be selected using </source>
+        <translation type="vanished">ASIOドライバー（サウンドカード）は以下を使用して選択できます</translation>
+    </message>
+    <message>
+        <source> under the Windows operating system. Under MacOS/Linux, no sound card selection is possible. If the selected ASIO driver is not valid an error message is shown and the previous valid driver is selected.</source>
+        <translation type="vanished">（Windowsオペレーティングシステム）。MacOS/Linuxではサウンドカードの選択はできません。選択したASIOドライバーが有効でない場合、エラーメッセージが表示され、以前の有効なドライバーが選択されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="129"/>
+        <source>If the driver is selected during an active connection, the connection is stopped, the driver is changed and the connection is started again automatically.</source>
+        <translation>接続中にドライバーを選択すると、接続が停止し、ドライバーが変更され、自動的に再接続されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="133"/>
+        <source>Sound card device selector combo box</source>
+        <translation>サウンドカードデバイス選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="137"/>
+        <source>If the ASIO4ALL driver is used, please note that this driver usually introduces approx. 10-30 ms of additional audio delay. Using a sound card with a native ASIO driver is therefore recommended.</source>
+        <translation>ASIO4ALLドライバーを使用する場合、このドライバーは通常約10〜30msの追加オーディオ遅延が発生することに注意してください。そのため、ネイティブASIOドライバーを持つサウンドカードの使用をお勧めします。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="142"/>
+        <source>If you are using the kX ASIO driver, make sure to connect the ASIO inputs in the kX DSP settings panel.</source>
+        <translation>kX ASIOドライバーを使用している場合は、kX DSP設定パネルでASIO入力を接続してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="149"/>
+        <source>Sound Card Channel Mapping</source>
+        <translation>サウンドカードチャンネルマッピング</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="150"/>
+        <source>If the selected sound card device offers more than one input or output channel, the Input Channel Mapping and Output Channel Mapping settings are visible.</source>
+        <translation>選択したサウンドカードデバイスが複数の入力または出力チャンネルを提供する場合、入力チャンネルマッピングと出力チャンネルマッピングの設定が表示されます。</translation>
+    </message>
+    <message>
+        <source>For each </source>
+        <translation type="vanished">それぞれの</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="162"/>
+        <source>Left input channel selection combo box</source>
+        <translation>左入力チャンネル選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="164"/>
+        <source>Right input channel selection combo box</source>
+        <translation>右入力チャンネル選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="166"/>
+        <source>Left output channel selection combo box</source>
+        <translation>左出力チャンネル選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="168"/>
+        <source>Right output channel selection combo box</source>
+        <translation>右出力チャンネル選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="173"/>
+        <source>Small Network Buffers</source>
+        <translation>小さなネットワークバッファ</translation>
+    </message>
+    <message>
+        <source>If enabled, the support for very small network audio packets is activated. Very small network packets are only actually used if the sound card buffer delay is smaller than </source>
+        <translation type="vanished">有効にすると、非常に小さなネットワークオーディオパケットのサポートが有効化されます。非常に小さなネットワークパケットは、サウンドカードのバッファ遅延が以下より小さい場合にのみ実際に使用されます</translation>
+    </message>
+    <message>
+        <source> samples. The smaller the network buffers, the lower the audio latency. But at the same time the network load increases and the probability of audio dropouts also increases.</source>
+        <translation type="vanished">サンプル。ネットワークバッファが小さいほどオーディオレイテンシーは低くなります。しかし同時にネットワーク負荷が増加し、オーディオドロップアウトの確率も増加します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="180"/>
+        <source>Small network buffers check box</source>
+        <translation>小さなネットワークバッファチェックボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="184"/>
+        <source>Sound Card Buffer Delay</source>
+        <translation>サウンドカードバッファ遅延</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="185"/>
+        <source>The buffer delay setting is a fundamental setting of %1. This setting has an influence on many connection properties.</source>
+        <translation>バッファ遅延の設定は%1の基本的な設定です。この設定は多くの接続プロパティに影響を与えます。</translation>
+    </message>
+    <message>
+        <source>Three buffer sizes are supported</source>
+        <translation type="vanished">3つのバッファサイズがサポートされています</translation>
+    </message>
+    <message>
+        <source>Some sound card drivers do not allow the buffer delay to be changed from within the application. In this case the buffer delay setting is disabled and has to be changed using the sound card driver. On Windows, press the ASIO Device Settings button to open the driver settings panel. On Linux, use the Jack configuration tool to change the buffer size.</source>
+        <translation type="vanished">一部のサウンドカードドライバーでは、アプリケーション内からバッファ遅延を変更できません。この場合、バッファ遅延設定は無効になり、サウンドカードドライバーを使用して変更する必要があります。Windowsでは、ASIOデバイス設定ボタンを押してドライバー設定パネルを開きます。Linuxでは、Jack設定ツールを使用してバッファサイズを変更します。</translation>
+    </message>
+    <message>
+        <source>The actual buffer delay has influence on the connection status, the current upload rate and the overall delay. The lower the buffer size, the higher the probability of a red light in the status indicator (drop outs) and the higher the upload rate and the lower the overall delay.</source>
+        <translation type="vanished">実際のバッファ遅延は、接続状態、現在のアップロードレート、全体的な遅延に影響します。バッファサイズが小さいほど、ステータスインジケーターで赤いライト（ドロップアウト）が発生する確率が高くなり、アップロードレートが高くなり、全体的な遅延が低くなります。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="220"/>
+        <source>The buffer setting is therefore a trade-off between audio quality and overall delay.</source>
+        <translation>したがって、バッファ設定はオーディオ品質と全体的な遅延のトレードオフです。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="261"/>
+        <source>ASIO Device Settings push button</source>
+        <translation>ASIOデバイス設定プッシュボタン</translation>
+    </message>
+    <message>
+        <source> input/output channel (Left and Right channel) a different actual sound card channel can be selected.</source>
+        <translation type="vanished">入力/出力チャンネル（左右チャンネル）ごとに異なる実際のサウンドカードチャンネルを選択できます。</translation>
+    </message>
+    <message>
+        <source>If the buffer delay settings are disabled, it is prohibited by the audio driver to modify this setting from within the software. On Windows, press the ASIO Device Settings button to open the driver settings panel. On Linux, use the Jack configuration tool to change the buffer size.</source>
+        <translation type="vanished">バッファ遅延設定が無効になっている場合、オーディオドライバーによってソフトウェア内からこの設定を変更することが禁止されています。Windowsでは、ASIOデバイス設定ボタンを押してドライバー設定パネルを開きます。Linuxでは、Jack設定ツールを使用してバッファサイズを変更します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="234"/>
+        <source>Sound card driver settings</source>
+        <translation>サウンドカードドライバー設定</translation>
+    </message>
+    <message>
+        <source>This opens the driver settings of your sound card. Some drivers allow you to change buffer settings, others like ASIO4ALL let you choose input or outputs of your device(s). More information can be found on jamulus.io.</source>
+        <translation type="vanished">サウンドカードのドライバー設定を開きます。一部のドライバーではバッファ設定を変更でき、ASIO4ALLなどのドライバーではデバイスの入力または出力を選択できます。詳細はjamulus.ioで確認できます。</translation>
+    </message>
+    <message>
+        <source>Opens the driver settings. Note: </source>
+        <translation type="vanished">ドライバー設定を開きます。注意: </translation>
+    </message>
+    <message>
+        <source> currently only supports devices supporting a sample rate of </source>
+        <translation type="vanished">は現在、サンプルレートをサポートするデバイスのみサポートしています</translation>
+    </message>
+    <message>
+        <source>Hz. You will not be able to select a driver/device which doesn&apos;t. For more help see jamulus.io.</source>
+        <translation type="vanished">Hz。これをサポートしていないドライバー/デバイスは選択できません。詳細はjamulus.ioをご覧ください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="250"/>
+        <source>64 samples setting radio button</source>
+        <translation>64サンプル設定ラジオボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="253"/>
+        <source>128 samples setting radio button</source>
+        <translation>128サンプル設定ラジオボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="256"/>
+        <source>256 samples setting radio button</source>
+        <translation>256サンプル設定ラジオボタン</translation>
+    </message>
+    <message>
+        <source>ASIO setup push button</source>
+        <translation type="vanished">ASIO設定プッシュボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="286"/>
+        <source>Audio Channels</source>
+        <translation>オーディオチャンネル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="319"/>
+        <source>Audio channels combo box</source>
+        <translation>オーディオチャンネルコンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="322"/>
+        <source>Audio Quality</source>
+        <translation>オーディオ品質</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="329"/>
+        <source>Audio quality combo box</source>
+        <translation>オーディオ品質コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="332"/>
+        <source>New Client Level</source>
+        <translation>新規クライアントレベル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="341"/>
+        <source>New client level edit box</source>
+        <translation>新規クライアントレベル編集ボックス</translation>
+    </message>
+    <message>
+        <source>Custom Directory Server Address</source>
+        <translation type="vanished">カスタムディレクトリサーバーアドレス</translation>
+    </message>
+    <message>
+        <source>Current Connection Status Parameter</source>
+        <translation type="vanished">現在の接続状態パラメータ</translation>
+    </message>
+    <message>
+        <source>If this LED indicator turns red, you will not have much fun using the </source>
+        <translation type="vanished">このLEDインジケーターが赤くなると、</translation>
+    </message>
+    <message>
+        <source> software.</source>
+        <translation type="vanished">ソフトウェアを快適に使用できなくなります。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="292"/>
+        <location filename="../clientsettingsdlg.cpp" line="429"/>
+        <source>Mono</source>
+        <translation>モノラル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="308"/>
+        <source> mode will increase your stream&apos;s data rate. Make sure your upload rate does not exceed the available upload speed of your internet connection.</source>
+        <translation>モードではストリームのデータレートが増加します。アップロードレートがインターネット接続の利用可能なアップロード速度を超えないようにしてください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="362"/>
+        <source>If you need to add additional directories to the Connect dialog Directory drop down, you can enter the addresses here.&lt;br&gt;</source>
+        <translation>接続ダイアログのディレクトリドロップダウンに追加のディレクトリを追加する必要がある場合は、ここにアドレスを入力できます。&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="430"/>
+        <source>Mono-in/Stereo-out</source>
+        <translation>モノラル入力/ステレオ出力</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="292"/>
+        <location filename="../clientsettingsdlg.cpp" line="307"/>
+        <location filename="../clientsettingsdlg.cpp" line="431"/>
+        <source>Stereo</source>
+        <translation>ステレオ</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="38"/>
+        <location filename="../clientsettingsdlg.cpp" line="48"/>
+        <location filename="../clientsettingsdlg.cpp" line="49"/>
+        <source>&amp;Close</source>
+        <translation>閉じる(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="58"/>
+        <source>Local Audio Input Fader</source>
+        <translation>ローカルオーディオ入力フェーダー</translation>
+    </message>
+    <message>
+        <source>Controls the relative levels of the left and right local audio channels. For a mono signal it acts as a pan between the two channels. For example, if a microphone is connected to the right input channel and an instrument is connected to the left input channel which is much louder than the microphone, move the audio fader in a direction where the label above the fader shows </source>
+        <translation type="vanished">左右のローカルオーディオチャンネルの相対レベルを制御します。モノラル信号の場合、2つのチャンネル間のパンとして機能します。例えば、マイクが右入力チャンネルに接続されていて、楽器がマイクよりもはるかに大きい左入力チャンネルに接続されている場合、フェーダー上のラベルが示す方向にオーディオフェーダーを動かしてください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="66"/>
+        <location filename="../clientsettingsdlg.cpp" line="1204"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <source>, where</source>
+        <translation type="vanished">、ここで</translation>
+    </message>
+    <message>
+        <source>is the current attenuation indicator.</source>
+        <translation type="vanished">は現在の減衰インジケーターです。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="72"/>
+        <source>Local audio input fader (left/right)</source>
+        <translation>ローカルオーディオ入力フェーダー（左/右）</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="76"/>
+        <source>The jitter buffer compensates for network and sound card timing jitters. The size of the buffer therefore influences the quality of the audio stream (how many dropouts occur) and the overall delay (the longer the buffer, the higher the delay).</source>
+        <translation>ジッターバッファはネットワークとサウンドカードのタイミングジッターを補正します。したがってバッファのサイズはオーディオストリームの品質（ドロップアウトの発生頻度）と全体的な遅延（バッファが長いほど遅延が大きくなる）に影響します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="81"/>
+        <source>You can set the jitter buffer size manually for the local client and the remote server. For the local jitter buffer, dropouts in the audio stream are indicated by the light below the jitter buffer size faders. If the light turns to red, a buffer overrun/underrun has taken place and the audio stream is interrupted.</source>
+        <translation>ローカルクライアントとリモートサーバーのジッターバッファサイズを手動で設定できます。ローカルジッターバッファの場合、オーディオストリームのドロップアウトはジッターバッファサイズフェーダーの下のライトで示されます。ライトが赤くなると、バッファオーバーラン/アンダーランが発生し、オーディオストリームが中断されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="90"/>
+        <source>If the Auto setting is enabled, the jitter buffers of the local client and the remote server are set automatically based on measurements of the network and sound card timing jitter. If Auto is enabled, the jitter buffer size faders are disabled (they cannot be moved with the mouse).</source>
+        <translation>自動設定が有効な場合、ローカルクライアントとリモートサーバーのジッターバッファはネットワークとサウンドカードのタイミングジッター測定に基づいて自動的に設定されます。自動が有効な場合、ジッターバッファサイズフェーダーは無効化されます（マウスで動かせません）。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="96"/>
+        <source>If the Auto setting is enabled, the network buffers of the local client and the remote server are set to a conservative value to minimize the audio dropout probability. To tweak the audio delay/latency it is recommended to disable the Auto setting and to lower the jitter buffer size manually by using the sliders until your personal acceptable amount of dropouts is reached. The LED indicator will display the audio dropouts of the local jitter buffer with a red light.</source>
+        <translation>自動設定が有効な場合、オーディオドロップアウトの可能性を最小限に抑えるため、ローカルクライアントとリモートサーバーのネットワークバッファは保守的な値に設定されます。オーディオ遅延/レイテンシを調整するには、自動設定を無効にして、スライダーを使用して個人的に許容できるドロップアウト量に達するまでジッターバッファサイズを手動で下げることをお勧めします。LEDインジケーターはローカルジッターバッファのオーディオドロップアウトを赤色で表示します。</translation>
+    </message>
+    <message>
+        <source>The buffer delay setting is a fundamental setting of this software. This setting has an influence on many connection properties.</source>
+        <translation type="vanished">バッファ遅延設定はこのソフトウェアの基本設定です。この設定は多くの接続プロパティに影響します。</translation>
+    </message>
+    <message>
+        <source>64 samples: The preferred setting. Provides the lowest latency but does not work with all sound cards.</source>
+        <translation type="vanished">64サンプル：推奨設定です。最も低いレイテンシを提供しますが、すべてのサウンドカードで動作するわけではありません。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="194"/>
+        <source>128 samples: Should work for most available sound cards.</source>
+        <translation>128サンプル：ほとんどの利用可能なサウンドカードで動作するはずです。</translation>
+    </message>
+    <message>
+        <source>256 samples: Should only be used on very slow computers or with a slow internet connection.</source>
+        <translation type="vanished">256サンプル：非常に遅いコンピュータまたは遅いインターネット接続でのみ使用してください。</translation>
+    </message>
+    <message>
+        <source>If no buffer size is selected and all settings are disabled, an unsupported buffer size is used by the driver. The application will still work with this setting but with restricted performance.</source>
+        <translation type="vanished">バッファサイズが選択されておらず、すべての設定が無効になっている場合、ドライバーはサポートされていないバッファサイズを使用します。アプリケーションはこの設定でも動作しますが、パフォーマンスが制限されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="266"/>
+        <source>Skin</source>
+        <translation>スキン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="266"/>
+        <source>Select the skin to be used for the main window.</source>
+        <translation>メインウィンドウに使用するスキンを選択します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="268"/>
+        <source>Skin combo box</source>
+        <translation>スキンコンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="272"/>
+        <source>Select the meter style to be used for the level meters. The Bar (narrow) and LEDs (round, small) options only apply to the mixerboard. When Bar (narrow) is selected, the input meters are set to Bar (wide). When LEDs (round, small) is selected, the input meters are set to LEDs (round, big). The remaining options apply to the mixerboard and input meters.</source>
+        <translation>レベルメーターに使用するメータースタイルを選択します。バー（細）およびLED（丸、小）オプションはミキサーボードにのみ適用されます。バー（細）を選択すると、入力メーターはバー（太）に設定されます。LED（丸、小）を選択すると、入力メーターはLED（丸、大）に設定されます。残りのオプションはミキサーボードと入力メーターに適用されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="281"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="281"/>
+        <source>Select the language to be used for the user interface.</source>
+        <translation>ユーザーインターフェースに使用する言語を選択します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="283"/>
+        <source>Language combo box</source>
+        <translation>言語コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="287"/>
+        <source>Selects the number of audio channels to be used for communication between client and server. There are three modes available:</source>
+        <translation>クライアントとサーバー間の通信に使用するオーディオチャンネル数を選択します。3つのモードが利用可能です：</translation>
+    </message>
+    <message>
+        <source>and </source>
+        <translation type="vanished">と</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="293"/>
+        <source>These modes use one and two audio channels respectively.</source>
+        <translation>これらのモードはそれぞれ1つと2つのオーディオチャンネルを使用します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="298"/>
+        <source>Mono in/Stereo-out</source>
+        <translation>モノラル入力/ステレオ出力</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="299"/>
+        <source>The audio signal sent to the server is mono but the return signal is stereo. This is useful if the sound card has the instrument on one input channel and the microphone on the other. In that case the two input signals can be mixed to one mono channel but the server mix is heard in stereo.</source>
+        <translation>サーバーに送信されるオーディオ信号はモノラルですが、リターン信号はステレオです。これはサウンドカードの一方の入力チャンネルに楽器があり、もう一方にマイクがある場合に便利です。この場合、2つの入力信号を1つのモノラルチャンネルにミックスできますが、サーバーミックスはステレオで聴こえます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="307"/>
+        <source>Enabling </source>
+        <translation>有効化</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="313"/>
+        <source>In stereo streaming mode, no audio channel selection for the reverb effect will be available on the main window since the effect is applied to both channels in this case.</source>
+        <translation>ステレオストリーミングモードでは、リバーブエフェクトがこの場合両方のチャンネルに適用されるため、メインウィンドウでのオーディオチャンネル選択は利用できません。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="323"/>
+        <source>The higher the audio quality, the higher your audio stream&apos;s data rate. Make sure your upload rate does not exceed the available bandwidth of your internet connection.</source>
+        <translation>オーディオ品質が高いほど、オーディオストリームのデータレートが高くなります。アップロードレートがインターネット接続の利用可能な帯域幅を超えないようにしてください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="333"/>
+        <source>This setting defines the fader level of a newly connected client in percent. If a new client connects to the current server, they will get the specified initial fader level if no other fader level from a previous connection of that client was already stored.</source>
+        <translation>この設定は、新しく接続されたクライアントのフェーダーレベルをパーセントで定義します。新しいクライアントが現在のサーバーに接続すると、そのクライアントの以前の接続から他のフェーダーレベルがまだ保存されていない場合、指定された初期フェーダーレベルが適用されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="344"/>
+        <source>Input Boost</source>
+        <translation>入力ブースト</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="345"/>
+        <source>This setting allows you to increase your input signal level by factors up to 10 (+20dB). If your sound is too quiet, first try to increase the level by getting closer to the microphone, adjusting your sound equipment or increasing levels in your operating system&apos;s input settings. Only if this fails, set a factor here. If your sound is too loud, sounds distorted and is clipping, this option will not help. Do not use it. The distortion will still be there. Instead, decrease your input level by getting farther away from your microphone, adjusting your sound equipment or by decreasing your operating system&apos;s input settings.</source>
+        <translation>この設定では、入力信号レベルを最大10倍（+20dB）まで上げることができます。音が小さすぎる場合は、まずマイクに近づく、音響機器を調整する、またはオペレーティングシステムの入力設定でレベルを上げることを試してください。それでも改善しない場合のみ、ここで係数を設定してください。音が大きすぎる、歪んでいる、クリッピングしている場合、このオプションは役に立ちません。使用しないでください。歪みは残ります。代わりに、マイクから離れる、音響機器を調整する、またはオペレーティングシステムの入力設定を下げることで入力レベルを下げてください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="358"/>
+        <source>Input Boost combo box</source>
+        <translation>入力ブーストコンボボックス</translation>
+    </message>
+    <message>
+        <source>Leave this blank unless you need to enter the address of a directory server other than the default.</source>
+        <translation type="vanished">デフォルト以外のディレクトリサーバーアドレスを入力する必要がない限り、空白のままにしてください。</translation>
+    </message>
+    <message>
+        <source>Directory server address combo box</source>
+        <translation type="vanished">ディレクトリサーバーアドレスコンボボックス</translation>
+    </message>
+    <message>
+        <source>The Ping Time is the time required for the audio stream to travel from the client to the server and back again. This delay is introduced by the network and should be about 20-30 ms. If this delay is higher than about 50 ms, your distance to the server is too large or your internet connection is not sufficient.</source>
+        <translation type="vanished">Ping時間は、オーディオストリームがクライアントからサーバーへ送られ、戻ってくるのに必要な時間です。この遅延はネットワークによって発生し、約20-30msであるべきです。この遅延が約50ms以上の場合、サーバーとの距離が遠すぎるか、インターネット接続が不十分です。</translation>
+    </message>
+    <message>
+        <source>Overall Delay is calculated from the current Ping Time and the delay introduced by the current buffer settings.</source>
+        <translation type="vanished">全体遅延は、現在のPing時間と現在のバッファ設定による遅延から計算されます。</translation>
+    </message>
+    <message>
+        <source>Audio Upstream Rate depends on the current audio packet size and compression setting. Make sure that the upstream rate is not higher than your available internet upload speed (check this with a service such as speedtest.net).</source>
+        <translation type="vanished">オーディオアップストリームレートは、現在のオーディオパケットサイズと圧縮設定に依存します。アップストリームレートが利用可能なインターネットアップロード速度より高くないことを確認してください（speedtest.netなどのサービスで確認してください）。</translation>
+    </message>
+    <message>
+        <source>The ASIO driver (sound card) can be selected using %1 under the Windows operating system. Under macOS/Linux, no sound card selection is possible. If the selected ASIO driver is not valid an error message is shown and the previous valid driver is selected.</source>
+        <translation type="vanished">Windowsオペレーティングシステムでは、%1を使用してASIOドライバー（サウンドカード）を選択できます。macOS/Linuxではサウンドカードの選択はできません。選択したASIOドライバーが有効でない場合、エラーメッセージが表示され、以前の有効なドライバーが選択されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="154"/>
+        <source>For each %1 input/output channel (left and right channel) a different actual sound card channel can be selected.</source>
+        <translation>各%1入力/出力チャンネル（左右チャンネル）に対して、異なる実際のサウンドカードチャンネルを選択できます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="174"/>
+        <source>Enables support for very small network audio packets. These network packets are only actually used if the sound card buffer delay is smaller than %1 samples. The smaller the network buffers, the lower the audio latency. But at the same time the network load and the probability of audio dropouts or sound artifacts increases.</source>
+        <translation>非常に小さいネットワークオーディオパケットのサポートを有効にします。これらのネットワークパケットは、サウンドカードバッファ遅延が%1サンプルより小さい場合にのみ実際に使用されます。ネットワークバッファが小さいほど、オーディオレイテンシが低くなります。しかし同時に、ネットワーク負荷とオーディオドロップアウトまたはサウンドアーティファクトの可能性が増加します。</translation>
+    </message>
+    <message>
+        <source>Some sound card drivers do not allow the buffer delay to be changed from within %1. In this case the buffer delay setting is disabled and has to be changed using the sound card driver. On Windows, use the ASIO Device Settings button to open the driver settings panel. On Linux, use the JACK configuration tool to change the buffer size.</source>
+        <translation type="vanished">一部のサウンドカードドライバーは、%1内からバッファ遅延を変更することを許可しません。この場合、バッファ遅延設定は無効になり、サウンドカードドライバーを使用して変更する必要があります。Windowsでは、ASIOデバイス設定ボタンを使用してドライバー設定パネルを開きます。Linuxでは、JACK設定ツールを使用してバッファサイズを変更します。</translation>
+    </message>
+    <message>
+        <source>If no buffer size is selected and all settings are disabled, this means an unsupported buffer size is in use by the driver. %1 will still work with this setting but may have restricted performance.</source>
+        <translation type="vanished">バッファサイズが選択されておらず、すべての設定が無効になっている場合、ドライバーでサポートされていないバッファサイズが使用されていることを意味します。%1はこの設定でも動作しますが、パフォーマンスが制限される可能性があります。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="59"/>
+        <source>Controls the relative levels of the left and right local audio channels. For a mono signal it acts as a pan between the two channels. For example, if a microphone is connected to the right input channel and an instrument is connected to the left input channel which is much louder than the microphone, move the audio fader in a direction where the label above the fader shows %1, where %2 is the current attenuation indicator.</source>
+        <translation>左右のローカルオーディオチャンネルの相対レベルを制御します。モノラル信号の場合、2つのチャンネル間のパンとして機能します。例えば、マイクが右入力チャンネルに接続されていて、楽器がマイクよりもはるかに大きい左入力チャンネルに接続されている場合、フェーダー上のラベルが%1を示す方向にオーディオフェーダーを動かしてください。%2は現在の減衰インジケーターです。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="122"/>
+        <source>Audio Device</source>
+        <translation>オーディオデバイス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="123"/>
+        <source>Under the Windows operating system the ASIO driver (sound card) can be selected using %1. If the selected ASIO driver is not valid an error message is shown and the previous valid driver is selected. Under macOS the input and output hardware can be selected.</source>
+        <translation>Windowsオペレーティングシステムでは、%1を使用してASIOドライバー（サウンドカード）を選択できます。選択したASIOドライバーが有効でない場合、エラーメッセージが表示され、以前の有効なドライバーが選択されます。macOSでは入力および出力ハードウェアを選択できます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="188"/>
+        <source>Three buffer sizes can be selected</source>
+        <translation>3つのバッファサイズを選択できます</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="191"/>
+        <source>64 samples: Provides the lowest latency but does not work with all sound cards.</source>
+        <translation>64サンプル：最も低いレイテンシを提供しますが、すべてのサウンドカードで動作するわけではありません。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="197"/>
+        <source>256 samples: Should only be used when 64 or 128 samples is causing issues.</source>
+        <translation>256サンプル：64または128サンプルで問題が発生する場合にのみ使用してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="201"/>
+        <location filename="../clientsettingsdlg.cpp" line="223"/>
+        <source>Some sound card drivers do not allow the buffer delay to be changed from within %1. In this case the buffer delay setting is disabled and has to be changed using the sound card driver. Use the appropriate tool for the interface in use to adjust this buffer size. For example, if using ASIO, use the &quot;ASIO Device Settings&quot; button to open the driver settings panel or if using JACK, use a tool such as QjackCtl to adjust the buffer size. Other interfaces, such as Pipewire, would require their appropriate tool being used. Please refer to the interface manual.</source>
+        <translation>一部のサウンドカードドライバーは、%1内からバッファ遅延を変更することを許可しません。この場合、バッファ遅延設定は無効になり、サウンドカードドライバーを使用して変更する必要があります。このバッファサイズを調整するには、使用中のインターフェースに適したツールを使用してください。例えば、ASIOを使用している場合は「ASIOデバイス設定」ボタンを使用してドライバー設定パネルを開き、JACKを使用している場合はQjackCtlなどのツールを使用してバッファサイズを調整します。Pipewireなどの他のインターフェースは、適切なツールを使用する必要があります。インターフェースのマニュアルを参照してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="209"/>
+        <source>If no buffer size is selected and all settings are disabled, this means a buffer size in use by the driver which does not match the values. %1 will still work with this setting but may have restricted performance.</source>
+        <translation>バッファサイズが選択されておらず、すべての設定が無効になっている場合、ドライバーで使用中のバッファサイズが値と一致しないことを意味します。%1はこの設定でも動作しますが、パフォーマンスが制限される可能性があります。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="215"/>
+        <source>The actual buffer delay has influence on the connection, the current upload rate and the overall delay. The lower the buffer size, the higher the probability of a red light in the status indicator (drop outs) and the higher the upload rate and the lower the overall delay.</source>
+        <translation>実際のバッファ遅延は、接続、現在のアップロードレート、および全体遅延に影響します。バッファサイズが小さいほど、ステータスインジケーターの赤いライト（ドロップアウト）の確率が高くなり、アップロードレートが高くなり、全体遅延が低くなります。</translation>
+    </message>
+    <message>
+        <source>If the buffer delay settings are disabled, it is prohibited by the audio driver to modify this setting from within %1. On Windows, press the ASIO Device Settings button to open the driver settings panel. On Linux, use the JACK configuration tool to change the buffer size.</source>
+        <translation type="vanished">バッファ遅延設定が無効な場合、%1内からこの設定を変更することはオーディオドライバーによって禁止されています。Windowsでは、ASIOデバイス設定ボタンを押してドライバー設定パネルを開きます。Linuxでは、JACK設定ツールを使用してバッファサイズを変更します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="235"/>
+        <source>This opens the driver settings of your sound card. Some drivers allow you to change buffer settings, others like ASIO4ALL lets you choose input or outputs of your device(s). More information can be found on jamulus.io.</source>
+        <translation>サウンドカードのドライバー設定を開きます。一部のドライバーではバッファ設定を変更でき、ASIO4ALLなどの他のドライバーではデバイスの入力または出力を選択できます。詳細はjamulus.ioで確認できます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="240"/>
+        <source>Opens the driver settings. Note: %1 currently only supports devices with a sample rate of %2 Hz. You will not be able to select a driver/device which doesn&apos;t. For more help see jamulus.io.</source>
+        <translation>ドライバー設定を開きます。注：%1は現在、サンプルレートが%2 Hzのデバイスのみをサポートしています。それ以外のドライバー/デバイスは選択できません。詳しいヘルプはjamulus.ioを参照してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="271"/>
+        <source>Meter Style</source>
+        <translation>メータースタイル</translation>
+    </message>
+    <message>
+        <source>Select the meter style to be used for the level meters. The Narrow Bar and Small LEDs options only apply to the mixerboard. When Narrow Bar is selected, the input meters are set to Bar. When Small LEDs is selected, the input meters are set to Round LEDs. The remaining options apply to the mixerboard and input meters.</source>
+        <translation type="vanished">レベルメーターに使用するメータースタイルを選択します。細いバーと小さなLEDオプションはミキサーボードにのみ適用されます。細いバーを選択すると、入力メーターはバーに設定されます。小さなLEDを選択すると、入力メーターは丸いLEDに設定されます。残りのオプションはミキサーボードと入力メーターに適用されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="278"/>
+        <source>Meter Style combo box</source>
+        <translation>メータースタイルコンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="292"/>
+        <source>and</source>
+        <translation>と</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="361"/>
+        <source>Custom Directories</source>
+        <translation>カスタムディレクトリ</translation>
+    </message>
+    <message>
+        <source>If you need to add additional directories to the Connect dialog Directory drop down, you can enter the addresses here.&lt;br&gt;To remove a value, select it, delete the text in the input box, then move focus out of the control.</source>
+        <translation type="vanished">接続ダイアログのディレクトリドロップダウンにディレクトリを追加する必要がある場合は、ここにアドレスを入力できます。&lt;br&gt;値を削除するには、値を選択し、入力ボックスのテキストを削除してから、コントロールの外にフォーカスを移動してください。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="367"/>
+        <source>Custom Directories combo box</source>
+        <translation>カスタムディレクトリコンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="369"/>
+        <source>Delete custom directory button</source>
+        <translation>カスタムディレクトリ削除ボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="370"/>
+        <source>Delete Custom Directory</source>
+        <translation>カスタムディレクトリを削除</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="371"/>
+        <source>Click the button to delete the currently selected custom directory.</source>
+        <translation>ボタンをクリックして、現在選択されているカスタムディレクトリを削除します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="375"/>
+        <source>Audio Upstream Rate</source>
+        <translation>オーディオアップストリームレート</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="376"/>
+        <source>Depends on the current audio packet size and compression setting. Make sure that the upstream rate is not higher than your available internet upload speed (check this with a service such as speedtest.net).</source>
+        <translation>現在のオーディオパケットサイズと圧縮設定に依存します。アップストリームレートが利用可能なインターネットアップロード速度より高くないことを確認してください（speedtest.netなどのサービスで確認）。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="385"/>
+        <source>Number of Mixer Panel Rows</source>
+        <translation>ミキサーパネルの行数</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="385"/>
+        <source>Adjust the number of rows used to arrange the mixer panel.</source>
+        <translation>ミキサーパネルの配置に使用する行数を調整します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="388"/>
+        <source>Number of Mixer Panel Rows spin box</source>
+        <translation>ミキサーパネル行数スピンボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="390"/>
+        <source>Feedback Protection</source>
+        <translation>フィードバック保護</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="391"/>
+        <source>Prevents acoustic feedback between microphone and speakers.</source>
+        <translation>マイクとスピーカー間の音響フィードバックを防止します。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="392"/>
+        <source>Feedback Protection check box</source>
+        <translation>フィードバック保護チェックボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="395"/>
+        <source>Audio Alerts</source>
+        <translation>オーディオアラート</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="396"/>
+        <source>Trigger an audio alert when receiving a chat message and when a new client joins the session. A second sound device may be required to hear the alerts.</source>
+        <translation>チャットメッセージを受信したときや、新しいクライアントがセッションに参加したときにオーディオアラートをトリガーします。アラートを聞くには、2番目のサウンドデバイスが必要な場合があります。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="398"/>
+        <source>Audio Alerts check box</source>
+        <translation>オーディオアラートチェックボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="402"/>
+        <source>ASIO Device Settings</source>
+        <translation>ASIOデバイス設定</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="436"/>
+        <source>Low</source>
+        <translation>低</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="437"/>
+        <location filename="../clientsettingsdlg.cpp" line="443"/>
+        <source>Normal</source>
+        <translation>通常</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="438"/>
+        <source>High</source>
+        <translation>高</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="444"/>
+        <source>Fancy</source>
+        <translation>ファンシー</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="445"/>
+        <source>Compact</source>
+        <translation>コンパクト</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="450"/>
+        <source>Bar (narrow)</source>
+        <translation>バー（細）</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="451"/>
+        <source>Bar (wide)</source>
+        <translation>バー（太）</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="452"/>
+        <source>LEDs (stripe)</source>
+        <translation>LED（ストライプ）</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="453"/>
+        <source>LEDs (round, small)</source>
+        <translation>LED（丸、小）</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="454"/>
+        <source>LEDs (round, big)</source>
+        <translation>LED（丸、大）</translation>
+    </message>
+    <message>
+        <source>LEDs</source>
+        <translation type="vanished">LED</translation>
+    </message>
+    <message>
+        <source>Bar</source>
+        <translation type="vanished">バー</translation>
+    </message>
+    <message>
+        <source>Narrow Bar</source>
+        <translation type="vanished">細いバー</translation>
+    </message>
+    <message>
+        <source>Round LEDs</source>
+        <translation type="vanished">丸いLED</translation>
+    </message>
+    <message>
+        <source>Small LEDs</source>
+        <translation type="vanished">小さいLED</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="469"/>
+        <location filename="../clientsettingsdlg.cpp" line="608"/>
+        <location filename="../clientsettingsdlg.cpp" line="616"/>
+        <location filename="../util.cpp" line="1099"/>
+        <source>None</source>
+        <translation>なし</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="506"/>
+        <source>Write your name or an alias here so the other musicians you want to play with know who you are. You may also add a picture of the instrument you play and a flag of the country or region you are located in. Your city and skill level playing your instrument may also be added.</source>
+        <translation>ここに名前やニックネームを入力して、一緒に演奏したい他のミュージシャンにあなたが誰かを知らせましょう。演奏する楽器の画像や、あなたがいる国や地域の旗を追加することもできます。都市名や楽器の演奏スキルレベルも追加できます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="511"/>
+        <source>What you set here will appear at your fader on the mixer board when you are connected to a %1 server. This tag will also be shown at each client which is connected to the same server as you.</source>
+        <translation>ここで設定した内容は、%1サーバーに接続すると、ミキサーボードのフェーダーに表示されます。このタグは、あなたと同じサーバーに接続している各クライアントにも表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="522"/>
+        <source>Country/region flag button</source>
+        <translation>国/地域フラグボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="1197"/>
+        <source>Center</source>
+        <translation>中央</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="1209"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="610"/>
+        <source>Custom</source>
+        <translation>カスタム</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="592"/>
+        <source>Any Genre 2</source>
+        <translation>全ジャンル 2</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="595"/>
+        <source>Any Genre 3</source>
+        <translation>全ジャンル 3</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="598"/>
+        <source>Genre Rock</source>
+        <translation>ジャンル ロック</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="601"/>
+        <source>Genre Jazz</source>
+        <translation>ジャンル ジャズ</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="604"/>
+        <source>Genre Classical/Folk</source>
+        <translation>ジャンル クラシック/フォーク</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="607"/>
+        <source>Genre Choral/Barbershop</source>
+        <translation>ジャンル コーラス/バーバーショップ</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="613"/>
+        <source>Any Genre 1</source>
+        <translation>全ジャンル 1</translation>
+    </message>
+    <message>
+        <source>preferred</source>
+        <translation type="vanished">推奨</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="505"/>
+        <source>Musician Profile</source>
+        <translation>ミュージシャンプロファイル</translation>
+    </message>
+    <message>
+        <source>Write your name or an alias here so the other musicians you want to play with know who you are. You may also add a picture of the instrument you play and a flag of the country you are located in. Your city and skill level playing your instrument may also be added.</source>
+        <translation type="vanished">ここに名前やニックネームを入力して、一緒に演奏したい他のミュージシャンにあなたが誰かを知らせましょう。演奏する楽器の画像や、あなたがいる国の旗を追加することもできます。都市名や楽器の演奏スキルレベルも追加できます。</translation>
+    </message>
+    <message>
+        <source>What you set here will appear at your fader on the mixer board when you are connected to a Jamulus server. This tag will also be shown at each client which is connected to the same server as you.</source>
+        <translation type="vanished">ここで設定した内容は、Jamulusサーバーに接続するとミキサーボードのフェーダーに表示されます。このタグは、あなたと同じサーバーに接続している各クライアントにも表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="518"/>
+        <source>Alias or name edit box</source>
+        <translation>ニックネームまたは名前編集ボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="520"/>
+        <source>Instrument picture button</source>
+        <translation>楽器画像ボタン</translation>
+    </message>
+    <message>
+        <source>Country flag button</source>
+        <translation type="vanished">国旗ボタン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="524"/>
+        <source>City edit box</source>
+        <translation>都市編集ボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="526"/>
+        <source>Skill level combo box</source>
+        <translation>スキルレベルコンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="620"/>
+        <source>Beginner</source>
+        <translation>初心者</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="624"/>
+        <source>Intermediate</source>
+        <translation>中級</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="628"/>
+        <source>Expert</source>
+        <translation>エキスパート</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="784"/>
+        <location filename="../clientsettingsdlg.cpp" line="788"/>
+        <source>Size: </source>
+        <translation>サイズ: </translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="843"/>
+        <source>Buffer Delay</source>
+        <translation>バッファ遅延</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlg.cpp" line="848"/>
+        <source>Buffer Delay: </source>
+        <translation>バッファ遅延: </translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1102"/>
+        <source>Drum Set</source>
+        <translation>ドラムセット</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1105"/>
+        <source>Djembe</source>
+        <translation>ジャンベ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1108"/>
+        <source>Electric Guitar</source>
+        <translation>エレキギター</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1111"/>
+        <source>Acoustic Guitar</source>
+        <translation>アコースティックギター</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1114"/>
+        <source>Bass Guitar</source>
+        <translation>ベースギター</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1117"/>
+        <source>Keyboard</source>
+        <translation>キーボード</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1120"/>
+        <source>Synthesizer</source>
+        <translation>シンセサイザー</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1123"/>
+        <source>Grand Piano</source>
+        <translation>グランドピアノ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1126"/>
+        <source>Accordion</source>
+        <translation>アコーディオン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1129"/>
+        <source>Vocal</source>
+        <translation>ボーカル</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1132"/>
+        <source>Microphone</source>
+        <translation>マイク</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1135"/>
+        <source>Harmonica</source>
+        <translation>ハーモニカ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1138"/>
+        <source>Trumpet</source>
+        <translation>トランペット</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1141"/>
+        <source>Trombone</source>
+        <translation>トロンボーン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1144"/>
+        <source>French Horn</source>
+        <translation>フレンチホルン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1147"/>
+        <source>Tuba</source>
+        <translation>チューバ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1150"/>
+        <source>Saxophone</source>
+        <translation>サクソフォン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1153"/>
+        <source>Clarinet</source>
+        <translation>クラリネット</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1156"/>
+        <source>Flute</source>
+        <translation>フルート</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1159"/>
+        <source>Violin</source>
+        <translation>バイオリン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1162"/>
+        <source>Cello</source>
+        <translation>チェロ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1165"/>
+        <source>Double Bass</source>
+        <translation>コントラバス</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1168"/>
+        <source>Recorder</source>
+        <translation>リコーダー</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1171"/>
+        <source>Streamer</source>
+        <translation>ストリーマー</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1174"/>
+        <source>Listener</source>
+        <translation>リスナー</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1177"/>
+        <source>Guitar+Vocal</source>
+        <translation>ギター+ボーカル</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1180"/>
+        <source>Keyboard+Vocal</source>
+        <translation>キーボード+ボーカル</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1183"/>
+        <source>Bodhran</source>
+        <translation>バウロン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1186"/>
+        <source>Bassoon</source>
+        <translation>ファゴット</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1189"/>
+        <source>Oboe</source>
+        <translation>オーボエ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1192"/>
+        <source>Harp</source>
+        <translation>ハープ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1195"/>
+        <source>Viola</source>
+        <translation>ビオラ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1198"/>
+        <source>Congas</source>
+        <translation>コンガ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1201"/>
+        <source>Bongo</source>
+        <translation>ボンゴ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1204"/>
+        <source>Vocal Bass</source>
+        <translation>ボーカル バス</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1207"/>
+        <source>Vocal Tenor</source>
+        <translation>ボーカル テノール</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1210"/>
+        <source>Vocal Alto</source>
+        <translation>ボーカル アルト</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1213"/>
+        <source>Vocal Soprano</source>
+        <translation>ボーカル ソプラノ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1216"/>
+        <source>Banjo</source>
+        <translation>バンジョー</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1219"/>
+        <source>Mandolin</source>
+        <translation>マンドリン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1222"/>
+        <source>Ukulele</source>
+        <translation>ウクレレ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1225"/>
+        <source>Bass Ukulele</source>
+        <translation>ベースウクレレ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1228"/>
+        <source>Vocal Baritone</source>
+        <translation>ボーカル バリトン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1231"/>
+        <source>Vocal Lead</source>
+        <translation>リードボーカル</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1234"/>
+        <source>Mountain Dulcimer</source>
+        <translation>マウンテンダルシマー</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1237"/>
+        <source>Scratching</source>
+        <translation>スクラッチ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1240"/>
+        <source>Rapping</source>
+        <translation>ラップ</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1243"/>
+        <source>Vibraphone</source>
+        <translation>ビブラフォン</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1246"/>
+        <source>Conductor</source>
+        <translation>指揮者</translation>
+    </message>
+</context>
+<context>
+    <name>CClientSettingsDlgBase</name>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="14"/>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>Soundcard</source>
+        <translation type="vanished">サウンドカード</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation type="vanished">デバイス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="474"/>
+        <source>Input Channel Mapping</source>
+        <translation>入力チャンネルマッピング</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="494"/>
+        <location filename="../clientsettingsdlgbase.ui" line="557"/>
+        <source>L</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="510"/>
+        <location filename="../clientsettingsdlgbase.ui" line="573"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="537"/>
+        <source>Output Channel Mapping</source>
+        <translation>出力チャンネルマッピング</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="900"/>
+        <source>Small Network Buffers</source>
+        <translation>小さなネットワークバッファ</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="670"/>
+        <source>Buffer Delay</source>
+        <translation>バッファ遅延</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="109"/>
+        <source>Country/Region</source>
+        <translation>国/地域</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="682"/>
+        <source>(preferred)</source>
+        <translation>(推奨)</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="695"/>
+        <source>(default)</source>
+        <translation>(デフォルト)</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="708"/>
+        <source>(safe)</source>
+        <translation>(安全)</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="424"/>
+        <source>Driver Setup</source>
+        <translation>ドライバー設定</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="40"/>
+        <source>My Profile</source>
+        <translation>マイプロフィール</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="79"/>
+        <source>Musician&apos;s Profile</source>
+        <translation>ミュージシャンプロフィール</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="89"/>
+        <source>Alias/Name</source>
+        <translation>別名/名前</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="99"/>
+        <source>Instrument</source>
+        <translation>楽器</translation>
+    </message>
+    <message>
+        <source>Country</source>
+        <translation type="vanished">国</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="119"/>
+        <source>City</source>
+        <translation>都市</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="129"/>
+        <source>Skill</source>
+        <translation>スキル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="225"/>
+        <source>User Interface</source>
+        <translation>ユーザーインターフェース</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="245"/>
+        <source>Meter Style</source>
+        <translation>メータースタイル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="265"/>
+        <source>Mixer Rows</source>
+        <translation>ミキサー行</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="321"/>
+        <source>Audio Alerts</source>
+        <translation>オーディオアラート</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="366"/>
+        <source>Audio/Network Setup</source>
+        <translation>オーディオ/ネットワーク設定</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="376"/>
+        <source>Audio Device</source>
+        <translation>オーディオデバイス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="738"/>
+        <source>Jitter Buffer</source>
+        <translation>ジッターバッファ</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="750"/>
+        <source>Auto</source>
+        <translation>自動</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="759"/>
+        <source>Local</source>
+        <translation>ローカル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="772"/>
+        <source>Server</source>
+        <translation>サーバー</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="789"/>
+        <location filename="../clientsettingsdlgbase.ui" line="802"/>
+        <source>Size</source>
+        <translation>サイズ</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="931"/>
+        <source>kbps</source>
+        <translation>kbps</translation>
+    </message>
+    <message>
+        <source>ms</source>
+        <translation type="vanished">ms</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1108"/>
+        <source>Input Boost</source>
+        <translation>入力ブースト</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1140"/>
+        <source>Feedback Protection</source>
+        <translation>フィードバック保護</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation type="vanished">有効化</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1195"/>
+        <source>Input Balance</source>
+        <translation>入力バランス</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1206"/>
+        <source>Pan</source>
+        <translation>パン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1289"/>
+        <source>Center</source>
+        <translation>中央</translation>
+    </message>
+    <message>
+        <source>Misc</source>
+        <translation type="vanished">その他</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="623"/>
+        <source>Audio Channels</source>
+        <translation>オーディオチャンネル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="633"/>
+        <source>Audio Quality</source>
+        <translation>オーディオ品質</translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="vanished">測定値</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="993"/>
+        <source>Advanced Setup</source>
+        <translation>詳細設定</translation>
+    </message>
+    <message>
+        <source>Custom Central Server Address:</source>
+        <translation type="vanished">カスタム中央サーバーアドレス:</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1071"/>
+        <source>New Client Level</source>
+        <translation>新規クライアントレベル</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="235"/>
+        <source>Skin</source>
+        <translation>スキン</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="255"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1034"/>
+        <source>Custom Directories:</source>
+        <translation>カスタムディレクトリ:</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="1086"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <source>Custom Directory Server Address:</source>
+        <translation type="vanished">カスタムディレクトリサーバーアドレス:</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="907"/>
+        <source>Audio Stream Rate</source>
+        <translation>オーディオストリームレート</translation>
+    </message>
+    <message>
+        <location filename="../clientsettingsdlgbase.ui" line="941"/>
+        <source>val</source>
+        <translation>val</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="vanished">Ping時間</translation>
+    </message>
+    <message>
+        <source>Overall Delay</source>
+        <translation type="vanished">全体遅延</translation>
+    </message>
+    <message>
+        <source>Local Jitter Buffer</source>
+        <translation type="vanished">ローカルジッターバッファ</translation>
+    </message>
+</context>
+<context>
+    <name>CConnectDlg</name>
+    <message>
+        <location filename="../connectdlg.cpp" line="45"/>
+        <source>Directory</source>
+        <translation>ディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="46"/>
+        <source>Shows the servers listed by the selected directory. You can add custom directories in Advanced Settings.</source>
+        <translation>選択したディレクトリに登録されているサーバーを表示します。詳細設定でカスタムディレクトリを追加できます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="48"/>
+        <source>Directory combo box</source>
+        <translation>ディレクトリコンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="57"/>
+        <source>Filters the server list by the given text. Note that the filter is case insensitive. A single # character will filter for those servers with at least one person connected.</source>
+        <translation>指定したテキストでサーバーリストをフィルタリングします。フィルターは大文字小文字を区別しません。単一の # 文字は、少なくとも1人が接続しているサーバーをフィルタリングします。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="68"/>
+        <source>Uncheck to collapse the server list to show just the server details. Check to show everyone on the servers.</source>
+        <translation>チェックを外すとサーバーリストを折りたたんでサーバー詳細のみを表示します。チェックするとサーバー上の全員を表示します。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="74"/>
+        <source>Server List</source>
+        <translation>サーバーリスト</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="75"/>
+        <source>The Connection Setup window lists the available servers registered with the selected directory. Use the Directory dropdown to change the directory, find the server you want to join in the server list, click on it, and then click the Connect button to connect. Alternatively, double click on the server name to connect.</source>
+        <translation>接続設定ウィンドウには、選択したディレクトリに登録された利用可能なサーバーが一覧表示されます。ディレクトリドロップダウンを使用してディレクトリを変更し、サーバーリストで参加したいサーバーを見つけてクリックし、接続ボタンをクリックして接続します。または、サーバー名をダブルクリックして接続します。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="80"/>
+        <source>Permanent servers (those that have been listed for longer than 48 hours) are shown in bold.</source>
+        <translation>永続サーバー（48時間以上リストに載っているサーバー）は太字で表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="81"/>
+        <source>You can add custom directories in Advanced Settings.</source>
+        <translation>詳細設定でカスタムディレクトリを追加できます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="83"/>
+        <source>Server list view</source>
+        <translation>サーバーリストビュー</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="86"/>
+        <source>Server Address</source>
+        <translation>サーバーアドレス</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="87"/>
+        <source>If you know the server address, you can connect to it using the Server name/Address field. An optional port number can be added after the server address using a colon as a separator, e.g. %1. The field will also show a list of the most recently used server addresses.</source>
+        <translation>サーバーアドレスを知っている場合は、サーバー名/アドレスフィールドを使用して接続できます。コロンを区切り文字として使用して、サーバーアドレスの後にオプションのポート番号を追加できます。例）%1。このフィールドには、最近使用したサーバーアドレスのリストも表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="97"/>
+        <source>Holds the current server address. It also stores old addresses in the combo box list.</source>
+        <translation>現在のサーバーアドレスを保持し、コンボボックスリストに以前のアドレスを保存します。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="99"/>
+        <source>Delete server address button</source>
+        <translation>サーバーアドレス削除ボタン</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="100"/>
+        <source>Delete Server Address</source>
+        <translation>サーバーアドレスを削除</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="101"/>
+        <source>Click the button to clear the currently selected server address and delete it from the list of stored servers.</source>
+        <translation>ボタンをクリックすると、現在選択されているサーバーアドレスがクリアされ、保存済みサーバーリストから削除されます。</translation>
+    </message>
+    <message>
+        <source>The Connection Setup window shows a list of available servers. Server operators can optionally list their servers by music genre. Use the List dropdown to select a genre, click on the server you want to join and press the Connect button to connect to it. Alternatively, double click on on the server name. Permanent servers (those that have been listed for longer than 48 hours) are shown in bold.</source>
+        <translation type="vanished">接続設定ウィンドウには利用可能なサーバーのリストが表示されます。サーバー運営者は音楽ジャンル別にサーバーを一覧表示することができます。リストドロップダウンを使用してジャンルを選択し、参加したいサーバーをクリックしてから接続ボタンを押して接続します。または、サーバー名をダブルクリックします。永続サーバー（48時間以上リストに載っているサーバー）は太字で表示されます。</translation>
+    </message>
+    <message>
+        <source>If you know the IP address or URL of a server, you can connect to it using the Server name/Address field. An optional port number can be added after the IP address or URL using a colon as a separator, e.g. example.org:</source>
+        <translation type="vanished">サーバーのIPアドレスまたはURLを知っている場合は、サーバー名/アドレスフィールドを使用して接続できます。コロンを区切り文字として使用して、IPアドレスまたはURLの後にオプションのポート番号を追加できます。例）example.org:</translation>
+    </message>
+    <message>
+        <source>. The field will also show a list of the most recently used server addresses.</source>
+        <translation type="vanished">。このフィールドには最近使用したサーバーアドレスのリストも表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="96"/>
+        <source>Server address edit box</source>
+        <translation>サーバーアドレス編集ボックス</translation>
+    </message>
+    <message>
+        <source>Holds the current server IP address or URL. It also stores old URLs in the combo box list.</source>
+        <translation type="vanished">現在のサーバーIPアドレスまたはURLを保持し、コンボボックスリストに以前のURLを保存します。</translation>
+    </message>
+    <message>
+        <source>Server List Selection</source>
+        <translation type="vanished">サーバーリスト選択</translation>
+    </message>
+    <message>
+        <source>Selects the server list to be shown.</source>
+        <translation type="vanished">表示するサーバーリストを選択します。</translation>
+    </message>
+    <message>
+        <source>Server list selection combo box</source>
+        <translation type="vanished">サーバーリスト選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="56"/>
+        <source>Filter</source>
+        <translation>フィルター</translation>
+    </message>
+    <message>
+        <source>The server list is filtered by the given text. Note that the filter is case insensitive.</source>
+        <translation type="vanished">サーバーリストは指定したテキストでフィルタリングされます。フィルターは大文字小文字を区別しません。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="59"/>
+        <source>Filter edit box</source>
+        <translation>フィルター編集ボックス</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="67"/>
+        <source>Show All Musicians</source>
+        <translation>すべてのミュージシャンを表示</translation>
+    </message>
+    <message>
+        <source>If you check this check box, the musicians of all servers are shown. If you uncheck the check box, all list view items are collapsed.</source>
+        <translation type="vanished">このチェックボックスをオンにすると、すべてのサーバーのミュージシャンが表示されます。チェックボックスをオフにすると、すべてのリストビュー項目が折りたたまれます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="71"/>
+        <source>Show all musicians check box</source>
+        <translation>すべてのミュージシャン表示チェックボックス</translation>
+    </message>
+    <message>
+        <source>If you know the IP address or URL of a server, you can connect to it using the Server name/Address field. An optional port number can be added after the IP address or URL using a colon as a separator, e.g. %1. The field will also show a list of the most recently used server addresses.</source>
+        <translation type="vanished">サーバーのIPアドレスまたはURLを知っている場合は、サーバー名/アドレスフィールドを使用して接続できます。コロンを区切り文字として使用して、IPアドレスまたはURLの後にオプションのポート番号を追加できます。例）%1。このフィールドには最近使用したサーバーアドレスのリストも表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../connectdlg.cpp" line="160"/>
+        <source>Filter text, or # for occupied servers</source>
+        <translation>フィルターテキスト、または使用中サーバーの場合は #</translation>
+    </message>
+    <message>
+        <source>Type # for occupied servers</source>
+        <translation type="vanished">使用中サーバーの場合は # を入力</translation>
+    </message>
+</context>
+<context>
+    <name>CConnectDlgBase</name>
+    <message>
+        <location filename="../connectdlgbase.ui" line="14"/>
+        <source>Connection Setup</source>
+        <translation>接続設定</translation>
+    </message>
+    <message>
+        <source>List</source>
+        <translation type="vanished">リスト</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="35"/>
+        <source>Directory</source>
+        <translation>ディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="45"/>
+        <source>Filter</source>
+        <translation>フィルター</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="55"/>
+        <source>Show All Musicians</source>
+        <translation>すべてのミュージシャンを表示</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="71"/>
+        <source>Server Name</source>
+        <translation>サーバー名</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="76"/>
+        <source>Ping Time</source>
+        <translation>Ping時間</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="81"/>
+        <source>Musicians</source>
+        <translation>ミュージシャン</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="86"/>
+        <source>Location</source>
+        <translation>場所</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="91"/>
+        <source>Version</source>
+        <translation>バージョン</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="101"/>
+        <source>Server Address</source>
+        <translation>サーバーアドレス</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="138"/>
+        <source>C&amp;ancel</source>
+        <translation>キャンセル(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../connectdlgbase.ui" line="145"/>
+        <source>&amp;Connect</source>
+        <translation>接続(&amp;C)</translation>
+    </message>
+</context>
+<context>
+    <name>CHelpMenu</name>
+    <message>
+        <location filename="../util.cpp" line="619"/>
+        <source>&amp;Help</source>
+        <translation>ヘルプ(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="626"/>
+        <location filename="../util.cpp" line="631"/>
+        <source>Getting &amp;Started...</source>
+        <translation>はじめに(&amp;S)...</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="627"/>
+        <source>Software &amp;Manual...</source>
+        <translation>ソフトウェアマニュアル(&amp;M)...</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="634"/>
+        <source>What&apos;s &amp;This</source>
+        <translation>これは何？(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="636"/>
+        <source>&amp;About Jamulus...</source>
+        <translation>Jamulusについて(&amp;A)...</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="638"/>
+        <source>About &amp;Qt...</source>
+        <translation>Qtについて(&amp;Q)...</translation>
+    </message>
+    <message>
+        <source>&amp;About...</source>
+        <translation type="vanished">情報(&amp;A)...</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="435"/>
+        <source>About Qt</source>
+        <translation>Qtについて</translation>
+    </message>
+</context>
+<context>
+    <name>CLanguageComboBox</name>
+    <message>
+        <location filename="../util.cpp" line="700"/>
+        <source>Restart Required</source>
+        <translation>再起動が必要</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="700"/>
+        <source>Please restart the application for the language change to take effect.</source>
+        <translation>言語の変更を適用するにはアプリケーションを再起動してください。</translation>
+    </message>
+</context>
+<context>
+    <name>CLicenceDlg</name>
+    <message>
+        <location filename="../util.cpp" line="595"/>
+        <source>This server requires you accept conditions before you can join. Please read these in the chat window.</source>
+        <translation>このサーバーでは参加する前に条件に同意する必要があります。チャットウィンドウで内容をお読みください。</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="596"/>
+        <source>I have read the conditions and &amp;agree.</source>
+        <translation>条件を読み、同意します(&amp;A)。</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="597"/>
+        <source>Accept</source>
+        <translation>承諾</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="598"/>
+        <source>Decline</source>
+        <translation>拒否</translation>
+    </message>
+</context>
+<context>
+    <name>CMultiColorLED</name>
+    <message>
+        <location filename="../multicolorled.cpp" line="91"/>
+        <source>Red</source>
+        <translation>赤</translation>
+    </message>
+    <message>
+        <location filename="../multicolorled.cpp" line="108"/>
+        <source>Yellow</source>
+        <translation>黄</translation>
+    </message>
+    <message>
+        <location filename="../multicolorled.cpp" line="125"/>
+        <source>Green</source>
+        <translation>緑</translation>
+    </message>
+</context>
+<context>
+    <name>CMusProfDlg</name>
+    <message>
+        <source>Alias or name edit box</source>
+        <translation type="vanished">別名または名前編集ボックス</translation>
+    </message>
+    <message>
+        <source>Instrument picture button</source>
+        <translation type="vanished">楽器画像ボタン</translation>
+    </message>
+    <message>
+        <source>Country flag button</source>
+        <translation type="vanished">国旗ボタン</translation>
+    </message>
+    <message>
+        <source>City edit box</source>
+        <translation type="vanished">都市編集ボックス</translation>
+    </message>
+    <message>
+        <source>Skill level combo box</source>
+        <translation type="vanished">スキルレベルコンボボックス</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="vanished">なし</translation>
+    </message>
+    <message>
+        <source>Musician Profile</source>
+        <translation type="vanished">ミュージシャンプロフィール</translation>
+    </message>
+    <message>
+        <source>Alias/Name</source>
+        <translation type="vanished">別名/名前</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="vanished">楽器</translation>
+    </message>
+    <message>
+        <source>Country</source>
+        <translation type="vanished">国</translation>
+    </message>
+    <message>
+        <source>City</source>
+        <translation type="vanished">都市</translation>
+    </message>
+    <message>
+        <source>Skill</source>
+        <translation type="vanished">スキル</translation>
+    </message>
+    <message>
+        <source>&amp;Close</source>
+        <translation type="vanished">閉じる(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Beginner</source>
+        <translation type="vanished">初心者</translation>
+    </message>
+    <message>
+        <source>Intermediate</source>
+        <translation type="vanished">中級</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="vanished">上級者</translation>
+    </message>
+    <message>
+        <source>Write your name or an alias here so the other musicians you want to play with know who you are. You may also add a picture of the instrument you play and a flag of the country you are located in. Your city and skill level playing your instrument may also be added.</source>
+        <translation type="vanished">ここに名前やニックネームを入力して、一緒に演奏したい他のミュージシャンにあなたが誰かを知らせましょう。演奏する楽器の画像や、あなたがいる国の旗を追加することもできます。都市名や楽器の演奏スキルレベルも追加できます。</translation>
+    </message>
+    <message>
+        <source>What you set here will appear at your fader on the mixer board when you are connected to a Jamulus server. This tag will also be shown at each client which is connected to the same server as you.</source>
+        <translation type="vanished">ここで設定した内容は、Jamulusサーバーに接続するとミキサーボードのフェーダーに表示されます。このタグは、あなたと同じサーバーに接続している各クライアントにも表示されます。</translation>
+    </message>
+    <message>
+        <source>Drum Set</source>
+        <translation type="vanished">ドラムセット</translation>
+    </message>
+    <message>
+        <source>Djembe</source>
+        <translation type="vanished">ジャンベ</translation>
+    </message>
+    <message>
+        <source>Electric Guitar</source>
+        <translation type="vanished">エレキギター</translation>
+    </message>
+    <message>
+        <source>Acoustic Guitar</source>
+        <translation type="vanished">アコースティックギター</translation>
+    </message>
+    <message>
+        <source>Bass Guitar</source>
+        <translation type="vanished">ベースギター</translation>
+    </message>
+    <message>
+        <source>Keyboard</source>
+        <translation type="vanished">キーボード</translation>
+    </message>
+    <message>
+        <source>Synthesizer</source>
+        <translation type="vanished">シンセサイザー</translation>
+    </message>
+    <message>
+        <source>Grand Piano</source>
+        <translation type="vanished">グランドピアノ</translation>
+    </message>
+    <message>
+        <source>Accordion</source>
+        <translation type="vanished">アコーディオン</translation>
+    </message>
+    <message>
+        <source>Vocal</source>
+        <translation type="vanished">ボーカル</translation>
+    </message>
+    <message>
+        <source>Microphone</source>
+        <translation type="vanished">マイク</translation>
+    </message>
+    <message>
+        <source>Harmonica</source>
+        <translation type="vanished">ハーモニカ</translation>
+    </message>
+    <message>
+        <source>Trumpet</source>
+        <translation type="vanished">トランペット</translation>
+    </message>
+    <message>
+        <source>Trombone</source>
+        <translation type="vanished">トロンボーン</translation>
+    </message>
+    <message>
+        <source>French Horn</source>
+        <translation type="vanished">フレンチホルン</translation>
+    </message>
+    <message>
+        <source>Tuba</source>
+        <translation type="vanished">チューバ</translation>
+    </message>
+    <message>
+        <source>Saxophone</source>
+        <translation type="vanished">サクソフォン</translation>
+    </message>
+    <message>
+        <source>Clarinet</source>
+        <translation type="vanished">クラリネット</translation>
+    </message>
+    <message>
+        <source>Flute</source>
+        <translation type="vanished">フルート</translation>
+    </message>
+    <message>
+        <source>Violin</source>
+        <translation type="vanished">バイオリン</translation>
+    </message>
+    <message>
+        <source>Cello</source>
+        <translation type="vanished">チェロ</translation>
+    </message>
+    <message>
+        <source>Double Bass</source>
+        <translation type="vanished">コントラバス</translation>
+    </message>
+    <message>
+        <source>Recorder</source>
+        <translation type="vanished">リコーダー</translation>
+    </message>
+    <message>
+        <source>Streamer</source>
+        <translation type="vanished">ストリーマー</translation>
+    </message>
+    <message>
+        <source>Listener</source>
+        <translation type="vanished">リスナー</translation>
+    </message>
+    <message>
+        <source>Guitar+Vocal</source>
+        <translation type="vanished">ギター+ボーカル</translation>
+    </message>
+    <message>
+        <source>Keyboard+Vocal</source>
+        <translation type="vanished">キーボード+ボーカル</translation>
+    </message>
+    <message>
+        <source>Bodhran</source>
+        <translation type="vanished">バウロン</translation>
+    </message>
+    <message>
+        <source>Bassoon</source>
+        <translation type="vanished">ファゴット</translation>
+    </message>
+    <message>
+        <source>Oboe</source>
+        <translation type="vanished">オーボエ</translation>
+    </message>
+    <message>
+        <source>Harp</source>
+        <translation type="vanished">ハープ</translation>
+    </message>
+    <message>
+        <source>Viola</source>
+        <translation type="vanished">ビオラ</translation>
+    </message>
+    <message>
+        <source>Congas</source>
+        <translation type="vanished">コンガ</translation>
+    </message>
+    <message>
+        <source>Bongo</source>
+        <translation type="vanished">ボンゴ</translation>
+    </message>
+    <message>
+        <source>Vocal Bass</source>
+        <translation type="vanished">ボーカル バス</translation>
+    </message>
+    <message>
+        <source>Vocal Tenor</source>
+        <translation type="vanished">ボーカル テノール</translation>
+    </message>
+    <message>
+        <source>Vocal Alto</source>
+        <translation type="vanished">ボーカル アルト</translation>
+    </message>
+    <message>
+        <source>Vocal Soprano</source>
+        <translation type="vanished">ボーカル ソプラノ</translation>
+    </message>
+    <message>
+        <source>Banjo</source>
+        <translation type="vanished">バンジョー</translation>
+    </message>
+    <message>
+        <source>Mandolin</source>
+        <translation type="vanished">マンドリン</translation>
+    </message>
+    <message>
+        <source>Ukulele</source>
+        <translation type="vanished">ウクレレ</translation>
+    </message>
+    <message>
+        <source>Bass Ukulele</source>
+        <translation type="vanished">ベースウクレレ</translation>
+    </message>
+    <message>
+        <source>Vocal Baritone</source>
+        <translation type="vanished">ボーカル バリトン</translation>
+    </message>
+    <message>
+        <source>Vocal Lead</source>
+        <translation type="vanished">リードボーカル</translation>
+    </message>
+    <message>
+        <source>Mountain Dulcimer</source>
+        <translation type="vanished">マウンテンダルシマー</translation>
+    </message>
+    <message>
+        <source>Scratching</source>
+        <translation type="vanished">スクラッチ</translation>
+    </message>
+    <message>
+        <source>Rapping</source>
+        <translation type="vanished">ラップ</translation>
+    </message>
+    <message>
+        <location filename="../settings.cpp" line="294"/>
+        <source>No Name</source>
+        <translation>名前なし</translation>
+    </message>
+</context>
+<context>
+    <name>CServerDlg</name>
+    <message>
+        <location filename="../serverdlg.cpp" line="51"/>
+        <source>Client List</source>
+        <translation>クライアントリスト</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="52"/>
+        <source>The client list shows all clients which are currently connected to this server. Some information about the clients like the IP address and name are given for each connected client.</source>
+        <translation>クライアントリストには、現在このサーバーに接続されているすべてのクライアントが表示されます。IPアドレスや名前などのクライアント情報が、接続されている各クライアントについて表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="56"/>
+        <source>Connected clients list view</source>
+        <translation>接続中のクライアントリストビュー</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="63"/>
+        <source>&lt;b&gt;Directory:&lt;/b&gt; Select &apos;%1&apos; not to register your server with a directory.&lt;br&gt;Or select one of the genres to register with that directory.&lt;br&gt;Or select &apos;%2&apos; and specify a Custom Directory address on the Options tab to register with a custom directory.&lt;br&gt;&lt;br&gt;For any value except &apos;%1&apos;, this server registers with a directory so that a %3 user can select this server in the client connect dialog server list when they choose that directory.&lt;br&gt;&lt;br&gt;The registration of the server is renewed periodically to make sure that all servers in the connect dialog server list are actually available.</source>
+        <comment>%1: directory type NONE; %2: directory type CUSTOM; %3 app name, Jamulus</comment>
+        <translation>&lt;b&gt;ディレクトリ:&lt;/b&gt; サーバーをディレクトリに登録しない場合は「%1」を選択してください。&lt;br&gt;または、登録したいジャンルのディレクトリを選択してください。&lt;br&gt;または「%2」を選択し、オプションタブでカスタムディレクトリアドレスを指定してカスタムディレクトリに登録してください。&lt;br&gt;&lt;br&gt;「%1」以外の値の場合、このサーバーはディレクトリに登録され、%3ユーザーがそのディレクトリを選択した際にクライアント接続ダイアログのサーバーリストからこのサーバーを選択できるようになります。&lt;br&gt;&lt;br&gt;サーバーの登録は定期的に更新され、接続ダイアログのサーバーリストにあるすべてのサーバーが実際に利用可能であることを確認します。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="123"/>
+        <source>When checked, the recorder will run while a session is in progress (if set up correctly).</source>
+        <translation>このオプションを選択すると、セッション中にレコーダーが実行されます（正しく設定されている場合）。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="139"/>
+        <source>Recording has been switched off by the UI checkbox or JSON-RPC.</source>
+        <translation>録音がUIチェックボックスまたはJSON-RPCによってオフになりました。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="141"/>
+        <source>Recording has been switched off, by the UI checkbox, SIGUSR2 or JSON-RPC.</source>
+        <translation>録音がUIチェックボックス、SIGUSR2、またはJSON-RPCによってオフになりました。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="177"/>
+        <source>Click the button to open the dialog that allows the main recording directory to be selected.  The chosen value must exist and be writeable (allow creation of sub-directories by the user %1 is running as).</source>
+        <translation>ボタンをクリックして、メイン録音ディレクトリを選択するダイアログを開きます。選択した値は存在し、書き込み可能である必要があります（ユーザー%1として実行している場合、サブディレクトリの作成を許可）。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="184"/>
+        <source>The current value of the main recording directory. The chosen value must exist and be writeable (allow creation of sub-directories by the user %1 is running as). Click the button to open the dialog that allows the main recording directory to be selected.</source>
+        <translation>メイン録音ディレクトリの現在の値です。選択した値は存在し、書き込み可能である必要があります（ユーザー%1として実行している場合、サブディレクトリの作成を許可）。ボタンをクリックして、メイン録音ディレクトリを選択するダイアログを開きます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="196"/>
+        <source>Custom Directory address</source>
+        <translation>カスタムディレクトリアドレス</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="197"/>
+        <source>The Custom Directory address is the address of the directory holding the server list to which this server should be added.</source>
+        <translation>カスタムディレクトリアドレスは、このサーバーを追加するサーバーリストを保持するディレクトリのアドレスです。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="205"/>
+        <source>Server List Filename dialog push button</source>
+        <translation>サーバーリストファイル名ダイアログプッシュボタン</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="206"/>
+        <location filename="../serverdlg.cpp" line="214"/>
+        <source>Server List Filename</source>
+        <translation>サーバーリストファイル名</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="207"/>
+        <source>Click the button to open the dialog that allows the server list persistence file name to be set. The user %1 is running as needs to be able to create the file name specified although it may already exist (it will get overwritten on save).</source>
+        <translation>ボタンをクリックして、サーバーリスト永続化ファイル名を設定するダイアログを開きます。ユーザー%1として実行している必要があり、指定されたファイル名を作成できる必要があります（既に存在する場合があり、保存時に上書きされます）。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="213"/>
+        <source>Server List Filename text box (read-only)</source>
+        <translation>サーバーリストファイル名テキストボックス（読み取り専用）</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="215"/>
+        <source>The current value of server list persistence file name. The user %1 is running as needs to be able to create the file name specified although it may already exist (it will get overwritten on save). Click the button to open the dialog that allows the server list persistence file name to be set.</source>
+        <translation>サーバーリスト永続化ファイル名の現在の値です。ユーザー%1として実行している必要があり、指定されたファイル名を作成できる必要があります（既に存在する場合があり、保存時に上書きされます）。ボタンをクリックして、サーバーリスト永続化ファイル名を設定するダイアログを開きます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="222"/>
+        <source>Clear the server list file name button</source>
+        <translation>サーバーリストファイル名クリアボタン</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="223"/>
+        <source>Clear Server List Filename</source>
+        <translation>サーバーリストファイル名をクリア</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="224"/>
+        <source>Click the button to clear the currently selected server list persistence file name. This will prevent persisting the server list until a new value is selected.</source>
+        <translation>ボタンをクリックして、現在選択されているサーバーリスト永続化ファイル名をクリアします。これにより、新しい値が選択されるまでサーバーリストは保存されなくなります。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="228"/>
+        <source>Start Minimized on Operating System Start</source>
+        <translation>OS起動時に最小化で起動</translation>
+    </message>
+    <message>
+        <source>Make My Server Public</source>
+        <translation type="vanished">サーバーを公開に設定</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="82"/>
+        <source>Register Server Status</source>
+        <translation>サーバー登録状態</translation>
+    </message>
+    <message>
+        <source>If the Make My Server Public check box is checked, this will show whether registration with the directory server is successful. If the registration failed, please choose another server list.</source>
+        <translation type="vanished">「サーバーを公開」チェックボックスをオンにすると、ディレクトリサーバーへの登録が成功したかどうかが表示されます。登録に失敗した場合は、別のサーバーリストを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="229"/>
+        <source>If the start minimized on operating system start check box is checked, the server will be started when the operating system starts up and is automatically minimized to a system task bar icon.</source>
+        <translation>OS起動時に最小化で起動チェックボックスをオンにすると、OSの起動時にサーバーが起動し、自動的にシステムタスクバーアイコンに最小化されます。</translation>
+    </message>
+    <message>
+        <source>If the Make My Server Public check box is checked, this server registers itself at the directory server so that all users of the application can see the server in the connect dialog server list and connect to it. The registration of the server is renewed periodically to make sure that all servers in the connect dialog server list are actually available.</source>
+        <translation type="vanished">「サーバーを公開」チェックボックスをオンにすると、このサーバーがディレクトリサーバーに登録され、アプリケーションのすべてのユーザーが接続ダイアログのサーバーリストからサーバーを表示して接続できるようになります。サーバーの登録は定期的に更新され、接続ダイアログのサーバーリストにあるすべてのサーバーが実際に利用可能であることを確認します。</translation>
+    </message>
+    <message>
+        <source>Custom Directory Server Address</source>
+        <translation type="vanished">カスタムディレクトリサーバーアドレス</translation>
+    </message>
+    <message>
+        <source>The custom directory server address is the IP address or URL of the directory server at which the server list of the connection dialog is managed.</source>
+        <translation type="vanished">カスタムディレクトリサーバーアドレスは、接続ダイアログのサーバーリストが管理されているディレクトリサーバーのIPアドレスまたはURLです。</translation>
+    </message>
+    <message>
+        <source>Directory server address line edit</source>
+        <translation type="vanished">ディレクトリサーバーアドレス行編集</translation>
+    </message>
+    <message>
+        <source>Server List Selection</source>
+        <translation type="vanished">サーバーリスト選択</translation>
+    </message>
+    <message>
+        <source>Selects the server list (i.e. directory server address) in which your server will be added.</source>
+        <translation type="vanished">サーバーを追加するサーバーリスト（ディレクトリサーバーアドレス）を選択します。</translation>
+    </message>
+    <message>
+        <source>Server list selection combo box</source>
+        <translation type="vanished">サーバーリスト選択コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="89"/>
+        <source>Server Name</source>
+        <translation>サーバー名</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="90"/>
+        <source>The server name identifies your server in the connect dialog server list at the clients.</source>
+        <translation>サーバー名は、クライアントの接続ダイアログのサーバーリストでサーバーを識別します。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="96"/>
+        <source>Server name line edit</source>
+        <translation>サーバー名行編集</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="99"/>
+        <source>Location City</source>
+        <translation>所在地の都市</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="100"/>
+        <source>The city in which this server is located can be set here. If a city name is entered, it will be shown in the connect dialog server list at the clients.</source>
+        <translation>このサーバーが設置されている都市をここで設定できます。都市名を入力すると、クライアントの接続ダイアログのサーバーリストに表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="107"/>
+        <source>City where the server is located line edit</source>
+        <translation>サーバー所在都市行編集</translation>
+    </message>
+    <message>
+        <source>Location country</source>
+        <translation type="vanished">所在地の国</translation>
+    </message>
+    <message>
+        <source>The country in which this server is located can be set here. If a country is entered, it will be shown in the connect dialog server list at the clients.</source>
+        <translation type="vanished">このサーバーが設置されている国をここで設定できます。国を入力すると、クライアントの接続ダイアログのサーバーリストに表示されます。</translation>
+    </message>
+    <message>
+        <source>Country where the server is located combo box</source>
+        <translation type="vanished">サーバー所在国コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="175"/>
+        <source>Display dialog to select recording directory button</source>
+        <translation>録音ディレクトリ選択ダイアログ表示ボタン</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="176"/>
+        <location filename="../serverdlg.cpp" line="183"/>
+        <source>Main Recording Directory</source>
+        <translation>メイン録音ディレクトリ</translation>
+    </message>
+    <message>
+        <source>Click the button to open the dialog that allows the main recording directory to be selected. The chosen value must exist and be writeable (allow creation of sub-directories by the user Jamulus is running as). </source>
+        <translation type="vanished">ボタンをクリックして、メイン録音ディレクトリを選択するダイアログを開きます。選択した値は存在し、書き込み可能である必要があります（Jamulusを実行しているユーザーによるサブディレクトリの作成を許可）。 </translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="182"/>
+        <source>Main recording directory text box (read-only)</source>
+        <translation>メイン録音ディレクトリテキストボックス（読み取り専用）</translation>
+    </message>
+    <message>
+        <source>The current value of the main recording directory. The chosen value must exist and be writeable (allow creation of sub-directories by the user Jamulus is running as). Click the button to open the dialog that allows the main recording directory to be selected.</source>
+        <translation type="vanished">メイン録音ディレクトリの現在の値です。選択した値は存在し、書き込み可能である必要があります（Jamulusを実行しているユーザーによるサブディレクトリの作成を許可）。ボタンをクリックして、メイン録音ディレクトリを選択するダイアログを開きます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="190"/>
+        <source>Clear the recording directory button</source>
+        <translation>録音ディレクトリクリアボタン</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="191"/>
+        <source>Clear Recording Directory</source>
+        <translation>録音ディレクトリをクリア</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="192"/>
+        <source>Click the button to clear the currently selected recording directory. This will prevent recording until a new value is selected.</source>
+        <translation>ボタンをクリックすると、現在選択されている録音ディレクトリがクリアされます。これにより、新しい値が選択されるまで録音ができなくなります。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="121"/>
+        <source>Checkbox to turn on or off server recording</source>
+        <translation>サーバー録音のオン/オフを切り替えるチェックボックス</translation>
+    </message>
+    <message>
+        <source>If the Register Server check box is checked, this will show whether registration with the directory server is successful. If the registration failed, please choose another server list.</source>
+        <translation type="vanished">サーバー登録チェックボックスをオンにすると、ディレクトリサーバーへの登録が成功したかどうかが表示されます。登録に失敗した場合は、別のサーバーリストを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="122"/>
+        <source>Jam Recorder</source>
+        <translation>Jamレコーダー</translation>
+    </message>
+    <message>
+        <source>The recorder will run when a session is in progress, if (set up correctly and) checked.</source>
+        <translation type="obsolete">チェックした場合（正しく設定されていれば）、セッション中にレコーダーが動作します。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="146"/>
+        <source>If the recording directory is not useable, the problem will be displayed in place of the session directory.</source>
+        <translation>録音ディレクトリが使用できない場合、セッションディレクトリの代わりに問題が表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="149"/>
+        <source>Current session directory text box (read-only)</source>
+        <translation>現在のセッションディレクトリテキストボックス（読み取り専用）</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="153"/>
+        <source>Current Session Directory</source>
+        <translation>現在のセッションディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="154"/>
+        <source>Enabled during recording and holds the current recording session directory. Disabled after recording or when the recorder is not enabled.</source>
+        <translation>録音中に有効になり、現在の録音セッションディレクトリを保持します。録音後またはレコーダーが無効の場合は無効になります。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="131"/>
+        <source>Recorder status label</source>
+        <translation>レコーダー状態ラベル</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="133"/>
+        <source>Recorder Status</source>
+        <translation>レコーダー状態</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="133"/>
+        <source>Displays the current status of the recorder.  The following values are possible:</source>
+        <translation>レコーダーの現在の状態を表示します。以下の値が可能です:</translation>
+    </message>
+    <message>
+        <source>No recording directory has been set or the value is not useable.</source>
+        <translation type="vanished">録音ディレクトリが設定されていないか、値が使用できません。</translation>
+    </message>
+    <message>
+        <source>Recording has been switched off</source>
+        <translation type="vanished">録音がオフになっています</translation>
+    </message>
+    <message>
+        <source> by the UI checkbox</source>
+        <translation type="vanished"> UIチェックボックスによって</translation>
+    </message>
+    <message>
+        <source>, either by the UI checkbox or SIGUSR2 being received</source>
+        <translation type="vanished">、UIチェックボックスまたは受信したSIGUSR2によって</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="143"/>
+        <source>There is no one connected to the server to record.</source>
+        <translation>録音するサーバーに接続しているユーザーがいません。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="144"/>
+        <source>The performers are being recorded to the specified session directory.</source>
+        <translation>演奏は指定されたセッションディレクトリに録音されています。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="145"/>
+        <source>NOTE</source>
+        <translation>NOTE</translation>
+    </message>
+    <message>
+        <source>If the recording directory is not useable, the problem will be displayed in place of the directory.</source>
+        <translation type="vanished">録音ディレクトリが使用できない場合、ディレクトリの代わりに問題が表示されます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="160"/>
+        <source>Server welcome message edit box</source>
+        <translation>サーバーウェルカムメッセージ編集ボックス</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="161"/>
+        <source>Server Welcome Message</source>
+        <translation>サーバーウェルカムメッセージ</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="162"/>
+        <source>A server welcome message text is displayed in the chat window if a musician enters the server. If no message is set, the server welcome is disabled.</source>
+        <translation>ミュージシャンがサーバーに参加すると、チャットウィンドウにサーバーウェルカムテキストメッセージが表示されます。メッセージが設定されていない場合、サーバーウェルカムは無効になります。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="168"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="168"/>
+        <source>Select the language to be used for the user interface.</source>
+        <translation>ユーザーインターフェースに使用する言語を選択します。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="172"/>
+        <source>Language combo box</source>
+        <translation>言語コンボボックス</translation>
+    </message>
+    <message>
+        <source>Click the button to open the dialog that allows the main recording directory to be selected.  The chosen value must exist and be writeable (allow creation of sub-directories by the user Jamulus is running as).</source>
+        <translation type="vanished">ボタンをクリックして、メイン録音ディレクトリを選択するダイアログを開きます。選択した値は存在し、書き込み可能である必要があります（Jamulusを実行しているユーザーによるサブディレクトリの作成を許可）。</translation>
+    </message>
+    <message>
+        <source>Custom Directory</source>
+        <translation type="vanished">カスタムディレクトリ</translation>
+    </message>
+    <message>
+        <source>The custom directory is the IP address or URL of the directory server at which the server list of the connection dialog is managed.</source>
+        <translation type="vanished">カスタムディレクトリは、接続ダイアログのサーバーリストが管理されているディレクトリサーバーのIPアドレスまたはURLです。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="202"/>
+        <source>Custom Directory line edit</source>
+        <translation>カスタムディレクトリ行編集</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="246"/>
+        <source>&amp;Hide %1 server</source>
+        <translation>%1 サーバーを隠す(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="249"/>
+        <source>&amp;Show %1 server</source>
+        <translation>%1 サーバーを表示(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="254"/>
+        <source>%1 server</source>
+        <comment>%1 is the name of the main application</comment>
+        <translation>%1 サーバー</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="338"/>
+        <source>Type a message here. If no message is set, the server welcome is disabled.</source>
+        <translation>ここにメッセージを入力してください。メッセージが設定されていない場合、サーバーウェルカムは無効になります。</translation>
+    </message>
+    <message>
+        <source>software upgrade available</source>
+        <translation type="vanished">ソフトウェアアップグレードが利用可能</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="591"/>
+        <source>Recorder failed to start. Please check available disk space and permissions and try again. Error: </source>
+        <translation>録音の開始に失敗しました。使用可能なディスク容量と権限を確認して、再試行してください。エラー: </translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="737"/>
+        <source>Now a directory</source>
+        <translation>現在はディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="870"/>
+        <source>ERROR</source>
+        <translation>ERROR</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="126"/>
+        <source>Request new recording button</source>
+        <translation>新規録音要求ボタン</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="59"/>
+        <source>Directory Type combo box</source>
+        <translation>ディレクトリタイプコンボボックス</translation>
+    </message>
+    <message>
+        <source>Directory</source>
+        <translation type="vanished">ディレクトリ</translation>
+    </message>
+    <message>
+        <source>Select &apos;%1&apos; not to register your server with a directory.</source>
+        <translation type="vanished">サーバーをディレクトリに登録しない場合は「%1」を選択してください。</translation>
+    </message>
+    <message>
+        <source>Select one of the genres to register with that directory.</source>
+        <translation type="vanished">そのディレクトリに登録するジャンルの一つを選択します。</translation>
+    </message>
+    <message>
+        <source>Or select &apos;%1&apos; and specify a Custom Directory address on the Options tab to register with a custom directory.</source>
+        <translation type="vanished">または「%1」を選択し、オプションタブでカスタムディレクトリアドレスを指定して、カスタムディレクトリに登録することもできます。</translation>
+    </message>
+    <message>
+        <source>For any value except &apos;%1&apos;, this server registers with a directory so that a %2 user can select this server in the client connect dialog server list when they choose that directory.</source>
+        <translation type="vanished">「%1」以外の値の場合、このサーバーはディレクトリに登録され、%2 ユーザーがそのディレクトリを選択した際にクライアント接続ダイアログのサーバーリストでこのサーバーを選択できるようになります。</translation>
+    </message>
+    <message>
+        <source>The registration of the server is renewed periodically to make sure that all servers in the connect dialog server list are actually available.</source>
+        <translation type="vanished">接続ダイアログのサーバーリストにあるすべてのサーバーが実際に利用可能であることを確認するため、サーバーの登録は定期的に更新されます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="83"/>
+        <source>When a value other than &quot;%1&quot; is chosen for Directory, this will show whether registration is successful. If the registration failed, please choose a different directory.</source>
+        <translation>ディレクトリで「%1」以外の値を選択した場合、登録が成功したかどうかが表示されます。登録に失敗した場合は、別のディレクトリを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="110"/>
+        <source>Country/Region</source>
+        <translation>国/地域</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="111"/>
+        <source>Set the country or region where the server is running. Clients will show this location in their connect dialog&apos;s server list.</source>
+        <translation>サーバーが稼働している国または地域を設定します。クライアントは接続ダイアログのサーバーリストにこの場所を表示します。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="118"/>
+        <source>Combo box for location of this server</source>
+        <translation>このサーバーの場所コンボボックス</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="135"/>
+        <source>No recording directory has been set or the value is not useable. Check the value in the Options tab.</source>
+        <translation>録音ディレクトリが設定されていないか、値が使用できません。オプションタブで値を確認してください。</translation>
+    </message>
+    <message>
+        <source>Recording has been switched off by the UI checkbox.</source>
+        <translation type="vanished">UIチェックボックスにより録音がオフになりました。</translation>
+    </message>
+    <message>
+        <source>Recording has been switched off, either by the UI checkbox or SIGUSR2 being received.</source>
+        <translation type="vanished">UIチェックボックスまたはSIGUSR2の受信により、録音がオフになりました。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="127"/>
+        <source>New Recording</source>
+        <translation>新規録音</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="128"/>
+        <source>During a recording session, the button can be used to start a new recording.</source>
+        <translation>録音セッション中にボタンを使用して新しい録音を開始できます。</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="242"/>
+        <location filename="../serverdlg.cpp" line="394"/>
+        <source>E&amp;xit</source>
+        <translation>終了(&amp;X)</translation>
+    </message>
+    <message>
+        <source>&amp;Hide </source>
+        <translation type="vanished">非表示(&amp;H) </translation>
+    </message>
+    <message>
+        <source> server</source>
+        <translation type="vanished"> サーバー</translation>
+    </message>
+    <message>
+        <source>&amp;Open </source>
+        <translation type="vanished">開く(&amp;O) </translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="44"/>
+        <source>%1 Server</source>
+        <comment>%1 is the name of the main application</comment>
+        <translation>%1 サーバー</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="603"/>
+        <source>Select Main Recording Directory</source>
+        <translation>メイン録音ディレクトリを選択</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.h" line="56"/>
+        <source>Recording</source>
+        <translation>録音中</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.h" line="55"/>
+        <source>Not recording</source>
+        <translation>録音していません</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.h" line="53"/>
+        <source>Not initialised</source>
+        <translation>未初期化</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.h" line="54"/>
+        <source>Not enabled</source>
+        <translation>無効</translation>
+    </message>
+    <message>
+        <source> Server</source>
+        <translation type="vanished"> サーバー</translation>
+    </message>
+    <message>
+        <location filename="../serverdlg.cpp" line="392"/>
+        <source>&amp;Window</source>
+        <translation>ウィンドウ(&amp;W)</translation>
+    </message>
+    <message>
+        <source>Unregistered</source>
+        <translation type="vanished">未登録</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="589"/>
+        <source>None</source>
+        <translation>なし</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="636"/>
+        <source>Not registered</source>
+        <translation>未登録</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="639"/>
+        <source>Bad address</source>
+        <translation>無効なアドレス</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="642"/>
+        <source>Registration requested</source>
+        <translation>登録要求中</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="645"/>
+        <source>Registration failed</source>
+        <translation>登録失敗</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="648"/>
+        <source>Check server version</source>
+        <translation>サーバーバージョン確認</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="651"/>
+        <source>Registered</source>
+        <translation>登録済み</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="654"/>
+        <source>Server list full at directory</source>
+        <translation>ディレクトリのサーバーリストが満杯</translation>
+    </message>
+    <message>
+        <source>Directory server list full</source>
+        <translation type="vanished">ディレクトリサーバーリストが満杯</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="657"/>
+        <source>Your server version is too old</source>
+        <translation>サーバーバージョンが古すぎます</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="660"/>
+        <source>Requirements not fulfilled</source>
+        <translation>要件を満たしていません</translation>
+    </message>
+    <message>
+        <location filename="../util.h" line="663"/>
+        <source>Unknown value %1</source>
+        <translation>不明な値 %1</translation>
+    </message>
+    <message>
+        <source>Unknown value </source>
+        <translation type="vanished">不明な値 </translation>
+    </message>
+</context>
+<context>
+    <name>CServerDlgBase</name>
+    <message>
+        <location filename="../serverdlgbase.ui" line="34"/>
+        <source>Client IP:Port</source>
+        <translation>クライアント IP:ポート</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="39"/>
+        <location filename="../serverdlgbase.ui" line="118"/>
+        <source>Name</source>
+        <translation>名前</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="44"/>
+        <source>Jitter Buffer Size</source>
+        <translation>ジッターバッファサイズ</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="49"/>
+        <source>Channels</source>
+        <translation>チャンネル</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="67"/>
+        <source>Server Setup</source>
+        <translation>サーバー設定</translation>
+    </message>
+    <message>
+        <source>List</source>
+        <translation type="vanished">リスト</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="132"/>
+        <source>Location: Region</source>
+        <translation>場所: 地域</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="190"/>
+        <source>Session</source>
+        <translation>セッション</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="206"/>
+        <source>Chat Window Welcome (HTML/CSS Supported)</source>
+        <translation>チャットウィンドウ ウェルカムメッセージ (HTML/CSS対応)</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="224"/>
+        <source>Options</source>
+        <translation>オプション</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="274"/>
+        <source>Custom Directory address</source>
+        <translation>カスタムディレクトリアドレス</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="288"/>
+        <source>Server List Filename</source>
+        <translation>サーバーリストファイル名</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="307"/>
+        <source>Start Minimized on Windows Start</source>
+        <translation>Windows起動時に最小化で開始</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="314"/>
+        <source>Delay panning</source>
+        <translation>遅延パンニング</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="338"/>
+        <source>Update check</source>
+        <translation>アップデートを確認</translation>
+    </message>
+    <message>
+        <source>Make My Server Public (Register My Server in the Server List)</source>
+        <translation type="vanished">サーバーを公開（サーバーリストに登録）</translation>
+    </message>
+    <message>
+        <source>Genre</source>
+        <translation type="vanished">ジャンル</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="85"/>
+        <location filename="../serverdlgbase.ui" line="179"/>
+        <source>STATUS</source>
+        <translation>ステータス</translation>
+    </message>
+    <message>
+        <source>Custom Directory Server Address:</source>
+        <translation type="vanished">カスタムディレクトリサーバーアドレス:</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="253"/>
+        <source>Recording Directory</source>
+        <translation>録音ディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="159"/>
+        <source>Jam Recorder</source>
+        <translation>Jamレコーダー</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="75"/>
+        <source>Directory</source>
+        <translation>ディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="166"/>
+        <source>New Recording</source>
+        <translation>新規録音</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="232"/>
+        <source>Language</source>
+        <extracomment>Consider add &quot;(Lang)&quot; as a suffix to ensure that users who selected the wrong language find the correct button</extracomment>
+        <translation>言語 (Language)</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="110"/>
+        <source>My Server Info</source>
+        <translation>サーバー情報</translation>
+    </message>
+    <message>
+        <location filename="../serverdlgbase.ui" line="125"/>
+        <source>Location: City</source>
+        <translation>場所: 都市</translation>
+    </message>
+    <message>
+        <source>Location: Country</source>
+        <translation type="vanished">場所: 国</translation>
+    </message>
+</context>
+<context>
+    <name>CServerListManager</name>
+    <message>
+        <location filename="../serverlist.cpp" line="415"/>
+        <source>Now a directory</source>
+        <translation>現在はディレクトリ</translation>
+    </message>
+    <message>
+        <location filename="../serverlist.cpp" line="421"/>
+        <source>No longer a directory</source>
+        <translation>ディレクトリではなくなりました</translation>
+    </message>
+    <message>
+        <location filename="../serverlist.cpp" line="780"/>
+        <source>Could not open &apos;%1&apos; for read/write. Please check that %2 has permission (and that there is free space).</source>
+        <translation>「%1」を読み取り/書き込み用に開けませんでした。%2 に権限があるか（空き容量があるか）確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../serverlist.cpp" line="787"/>
+        <source>Loading persistent server list file: %1</source>
+        <translation>永続サーバーリストファイルを読み込み中: %1</translation>
+    </message>
+    <message>
+        <location filename="../serverlist.cpp" line="850"/>
+        <source>Could not write to &apos;%1&apos;</source>
+        <translation>「%1」に書き込めませんでした</translation>
+    </message>
+    <message>
+        <location filename="../serverlist.cpp" line="861"/>
+        <source>Saving registration for %1 (%2): %3</source>
+        <translation>%1 (%2) の登録を保存中: %3</translation>
+    </message>
+</context>
+<context>
+    <name>CSound</name>
+    <message>
+        <source>The Jack server is not running. This software requires a Jack server to run. Normally if the Jack server is not running this software will automatically start the Jack server. It seems that this auto start has not worked. Try to start the Jack server manually.</source>
+        <translation type="vanished">Jackサーバーが動作していません。このソフトウェアを実行するにはJackサーバーが必要です。通常、Jackサーバーが動作していない場合、このソフトウェアは自動的にJackサーバーを起動します。自動起動がうまくいかなかったようです。Jackサーバーを手動で起動してみてください。</translation>
+    </message>
+    <message>
+        <source>The Jack server sample rate is different from the required one. The required sample rate is:</source>
+        <translation type="vanished">Jackサーバーのサンプルレートが必要なサンプルレートと異なります。必要なサンプルレートは:</translation>
+    </message>
+    <message>
+        <source>You can use a tool like &lt;i&gt;&lt;a href=&quot;https://qjackctl.sourceforge.io&quot;&gt;QJackCtl&lt;/a&gt;&lt;/i&gt; to adjust the Jack server sample rate.</source>
+        <translation type="vanished">&lt;i&gt;&lt;a href=&quot;https://qjackctl.sourceforge.io&quot;&gt;QJackCtl&lt;/a&gt;&lt;/i&gt; のようなツールを使用して、Jackサーバーのサンプルレートを調整できます。</translation>
+    </message>
+    <message>
+        <source>Make sure to set the Frames/Period to a low value like </source>
+        <translation type="vanished">低遅延を実現するには、Frames/Periodを次のような低い値に設定してください: </translation>
+    </message>
+    <message>
+        <source> to achieve a low delay.</source>
+        <translation type="vanished"> 。</translation>
+    </message>
+    <message>
+        <source>The Jack port registering failed.</source>
+        <translation type="vanished">Jackポートの登録に失敗しました。</translation>
+    </message>
+    <message>
+        <source>Cannot activate the Jack client.</source>
+        <translation type="vanished">Jackクライアントを有効化できません。</translation>
+    </message>
+    <message>
+        <source>The Jack server was shut down. This software requires a Jack server to run. Try to restart the software to solve the issue.</source>
+        <translation type="vanished">Jackサーバーがシャットダウンしました。このソフトウェアの実行にはJackサーバーが必要です。問題を解決するにはソフトウェアを再起動してみてください。</translation>
+    </message>
+    <message>
+        <source>CoreAudio input AudioHardwareGetProperty call failed. It seems that no sound card is available in the system.</source>
+        <translation type="vanished">L&apos;appel d&apos;entrée AudioHardwareGetProperty CoreAudio a échoué failed. Il semble qu&apos;aucune carte son ne soit disponible dans le système.</translation>
+    </message>
+    <message>
+        <source>CoreAudio output AudioHardwareGetProperty call failed. It seems that no sound card is available in the system.</source>
+        <translation type="vanished">CoreAudio出力のAudioHardwareGetProperty呼び出しに失敗しました。システムで使用可能なサウンドカードがないようです。</translation>
+    </message>
+    <message>
+        <source>Current system audio input device sample rate of %1 Hz is not supported. Please open the Audio-MIDI-Setup in Applications-&gt;Utilities and try to set a sample rate of %2 Hz.</source>
+        <translation type="vanished">現在のシステムオーディオ入力デバイスのサンプルレート %1 Hz はサポートされていません。アプリケーション→ユーティリティでAudio-MIDI設定を開き、サンプルレートを %2 Hz に設定してみてください。</translation>
+    </message>
+    <message>
+        <source>The current selected audio device is no longer present in the system.</source>
+        <translation type="vanished">現在選択されているオーディオデバイスはシステムに存在しません。</translation>
+    </message>
+    <message>
+        <source>The audio input device is no longer available.</source>
+        <translation type="vanished">オーディオ入力デバイスが使用できなくなりました。</translation>
+    </message>
+    <message>
+        <source>The audio output device is no longer available.</source>
+        <translation type="vanished">オーディオ出力デバイスが使用できなくなりました。</translation>
+    </message>
+    <message>
+        <source>Current system audio output device sample rate of %1 Hz is not supported. Please open the Audio-MIDI-Setup in Applications-&gt;Utilities and try to set a sample rate of %2 Hz.</source>
+        <translation type="vanished">現在のシステムオーディオ出力デバイスのサンプルレート %1 Hz はサポートされていません。アプリケーション→ユーティリティでAudio-MIDI設定を開き、サンプルレートを %2 Hz に設定してみてください。</translation>
+    </message>
+    <message>
+        <source>The audio input stream format for this audio device is not compatible with this software.</source>
+        <translation type="vanished">このオーディオデバイスのオーディオ入力ストリーム形式は、このソフトウェアと互換性がありません。</translation>
+    </message>
+    <message>
+        <source>The audio output stream format for this audio device is not compatible with this software.</source>
+        <translation type="vanished">このオーディオデバイスのオーディオ出力ストリーム形式は、このソフトウェアと互換性がありません。</translation>
+    </message>
+    <message>
+        <source>The buffer sizes of the current input and output audio device cannot be set to a common value. Please choose other input/output audio devices in your system settings.</source>
+        <translation type="vanished">現在の入力・出力オーディオデバイスのバッファサイズを共通の値に設定できません。システム設定で別の入力/出力オーディオデバイスを選択してください。</translation>
+    </message>
+    <message>
+        <source>The audio driver could not be initialized.</source>
+        <translation type="vanished">オーディオドライバを初期化できませんでした。</translation>
+    </message>
+    <message>
+        <source>The audio device does not support the required sample rate. The required sample rate is: </source>
+        <translation type="vanished">オーディオデバイスは必要なサンプルレートをサポートしていません。必要なサンプルレートは: </translation>
+    </message>
+    <message>
+        <source>The audio device does not support setting the required sampling rate. This error can happen if you have an audio interface like the Roland UA-25EX where you set the sample rate with a hardware switch on the audio device. If this is the case, please change the sample rate to </source>
+        <translation type="vanished">オーディオデバイスは必要なサンプリングレートの設定をサポートしていません。このエラーは、Roland UA-25EXのようにオーディオデバイスのハードウェアスイッチでサンプルレートを設定するオーディオインターフェースを使用している場合に発生することがあります。その場合は、サンプルレートを </translation>
+    </message>
+    <message>
+        <source> Hz on the device and restart the </source>
+        <translation type="vanished"> Hz に変更し、</translation>
+    </message>
+    <message>
+        <source> software.</source>
+        <translation type="vanished"> ソフトウェアを再起動してください。</translation>
+    </message>
+    <message>
+        <source>The audio device does not support the required number of channels. The required number of channels for input and output is: </source>
+        <translation type="vanished">オーディオデバイスは必要なチャンネル数をサポートしていません。入力と出力に必要なチャンネル数は: </translation>
+    </message>
+    <message>
+        <source>Required audio sample format not available.</source>
+        <translation type="vanished">必要なオーディオサンプル形式が使用できません。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="57"/>
+        <source>The selected audio device is no longer present in the system. Please check your audio device.</source>
+        <translation>選択したオーディオデバイスはシステムに存在しません。オーディオデバイスを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="76"/>
+        <source>Couldn&apos;t initialise the audio driver. Check if your audio hardware is plugged in and verify your driver settings.</source>
+        <translation>オーディオドライバを初期化できませんでした。オーディオハードウェアが接続されているか確認し、ドライバ設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="146"/>
+        <source>The selected audio device is incompatible since it doesn&apos;t support a sample rate of %1 Hz. Please select another device.</source>
+        <translation>選択したオーディオデバイスは %1 Hz のサンプルレートをサポートしていないため互換性がありません。別のデバイスを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="158"/>
+        <source>The current audio device configuration is incompatible because the sample rate couldn&apos;t be set to %2 Hz. Please check for a hardware switch or driver setting to set the sample rate manually and restart %1.</source>
+        <translation>サンプルレートを %2 Hz に設定できなかったため、現在のオーディオデバイス設定は互換性がありません。ハードウェアスイッチまたはドライバ設定を確認してサンプルレートを手動で設定し、%1 を再起動してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="171"/>
+        <source>The selected audio device is incompatible since it doesn&apos;t support %1 in/out channels. Please select another device or configuration.</source>
+        <translation>選択したオーディオデバイスは %1 入力/出力チャンネルをサポートしていないため互換性がありません。別のデバイスまたは設定を選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="206"/>
+        <location filename="../sound/asio/sound.cpp" line="237"/>
+        <source>The selected audio device is incompatible since the required audio sample format isn&apos;t available. Please use another device.</source>
+        <translation>必要なオーディオサンプル形式が使用できないため、選択したオーディオデバイスは互換性がありません。別のデバイスを使用してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="554"/>
+        <source>No ASIO audio device driver found.</source>
+        <translation>ASIOオーディオデバイスドライバが見つかりません。</translation>
+    </message>
+    <message>
+        <location filename="../sound/asio/sound.cpp" line="555"/>
+        <source>Please install an ASIO driver before running %1. If you own a device with ASIO support, install its official ASIO driver. If not, you&apos;ll need to install a universal driver like ASIO4ALL.</source>
+        <translation>%1 を実行する前にASIOドライバをインストールしてください。ASIO対応のデバイスをお持ちの場合は、公式のASIOドライバをインストールしてください。そうでない場合は、ASIO4ALLのような汎用ドライバをインストールする必要があります。</translation>
+    </message>
+    <message>
+        <source>Please install an ASIO driver before running %1. If you own a device with ASIO support, install its official ASIO driver. If not, you&apos;ll need to download and install a universal driver like ASIO4ALL.</source>
+        <translation type="vanished">%1 を実行する前にASIOドライバをインストールしてください。ASIO対応のデバイスをお持ちの場合は、公式のASIOドライバをインストールしてください。そうでない場合は、ASIO4ALLのような汎用ドライバをダウンロードしてインストールする必要があります。</translation>
+    </message>
+    <message>
+        <source>No ASIO audio device (driver) found.</source>
+        <translation type="vanished">ASIOオーディオデバイス（ドライバ）が見つかりません。</translation>
+    </message>
+    <message>
+        <source>The </source>
+        <translation type="vanished">The </translation>
+    </message>
+    <message>
+        <source> software requires the low latency audio interface ASIO to work properly. This is not a standard Windows audio interface and therefore a special audio driver is required. Either your sound card has a native ASIO driver (which is recommended) or you might want to use alternative drivers like the ASIO4All driver.</source>
+        <translation type="vanished"> ソフトウェアが正常に動作するには、低遅延オーディオインターフェースASIOが必要です。これは標準のWindowsオーディオインターフェースではないため、特別なオーディオドライバが必要です。サウンドカードにネイティブASIOドライバがある（推奨）か、ASIO4Allドライバのような代替ドライバを使用できます。</translation>
+    </message>
+    <message>
+        <location filename="../sound/oboe/sound.cpp" line="69"/>
+        <source>Error requesting stream stop: $s</source>
+        <translation>ストリーム停止要求エラー: $s</translation>
+    </message>
+    <message>
+        <location filename="../sound/oboe/sound.cpp" line="75"/>
+        <source>Error closing stream: $s</source>
+        <translation>ストリーム終了エラー: $s</translation>
+    </message>
+    <message>
+        <location filename="../sound/jack/sound.cpp" line="47"/>
+        <source>JACK couldn&apos;t be started automatically. Please start JACK manually and check for error messages.</source>
+        <translation>JACKを自動的に起動できませんでした。JACKを手動で起動し、エラーメッセージを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/jack/sound.cpp" line="64"/>
+        <source>JACK isn&apos;t running at a sample rate of &lt;b&gt;%1 Hz&lt;/b&gt;. Please use a tool like &lt;i&gt;&lt;a href=&quot;https://qjackctl.sourceforge.io&quot;&gt;QjackCtl&lt;/a&gt;&lt;/i&gt; to set the the JACK sample rate to %1 Hz.</source>
+        <translation>JACKは &lt;b&gt;%1 Hz&lt;/b&gt; のサンプルレートで動作していません。&lt;i&gt;&lt;a href=&quot;https://qjackctl.sourceforge.io&quot;&gt;QjackCtl&lt;/a&gt;&lt;/i&gt; などのツールを使用して、JACKのサンプルレートを %1 Hz に設定してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/jack/sound.cpp" line="81"/>
+        <source>The JACK port registration failed. This is probably an error with JACK. Please stop %1 and JACK. Afterwards check if another program at a sample rate of %2 Hz can connect to JACK.</source>
+        <translation>JACKポートの登録に失敗しました。これはおそらくJACKのエラーです。%1 と JACK を停止してください。その後、サンプルレート %2 Hz の別のプログラムがJACKに接続できるか確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/jack/sound.cpp" line="94"/>
+        <source>The JACK port registration failed. This is probably an error with JACK. Please stop %1 and JACK. Afterwards, check if another MIDI program can connect to JACK.</source>
+        <translation>JACKポートの登録に失敗しました。これはおそらくJACKのエラーです。%1 と JACK を停止してください。その後、別のMIDIプログラムがJACKに接続できるか確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/jack/sound.cpp" line="107"/>
+        <source>Can&apos;t activate the JACK client. This is probably an error with JACK. Please check the JACK output.</source>
+        <translation>JACKクライアントを有効化できません。これはおそらくJACKのエラーです。JACKの出力を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/jack/sound.cpp" line="209"/>
+        <source>JACK was shut down. %1 requires JACK to run. Please restart %1 to start JACK again. </source>
+        <translation>JACKがシャットダウンしました。%1 を実行するにはJACKが必要です。JACKを再度起動するには %1 を再起動してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="113"/>
+        <source>No sound card is available in your system. CoreAudio input AudioHardwareGetProperty call failed.</source>
+        <translation>システムで使用可能なサウンドカードがありません。CoreAudio入力のAudioHardwareGetProperty呼び出しが失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="122"/>
+        <source>No sound card is available in the system. CoreAudio output AudioHardwareGetProperty call failed.</source>
+        <translation>システムで使用可能なサウンドカードがありません。CoreAudio出力のAudioHardwareGetProperty呼び出しが失敗しました。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="284"/>
+        <source>The currently selected audio device is no longer present. Please check your audio device.</source>
+        <translation>現在選択されているオーディオデバイスは存在しません。オーディオデバイスを確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="385"/>
+        <source>The audio input device is no longer available. Please check if your input device is connected correctly.</source>
+        <translation>オーディオ入力デバイスが使用できなくなりました。入力デバイスが正しく接続されているか確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="394"/>
+        <source>The sample rate on the current input device isn&apos;t %1 Hz and is therefore incompatible. Please select another device or try setting the sample rate to %1 Hz manually via Audio-MIDI-Setup (in Applications-&gt;Utilities).</source>
+        <translation>現在の入力デバイスのサンプルレートが %1 Hz ではないため互換性がありません。別のデバイスを選択するか、Audio-MIDI設定（アプリケーション→ユーティリティ）で手動でサンプルレートを %1 Hz に設定してみてください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="406"/>
+        <source>The audio output device is no longer available. Please check if your output device is connected correctly.</source>
+        <translation>オーディオ出力デバイスが使用できなくなりました。出力デバイスが正しく接続されているか確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="415"/>
+        <source>The sample rate on the current output device isn&apos;t %1 Hz and is therefore incompatible. Please select another device or try setting the sample rate to %1 Hz manually via Audio-MIDI-Setup (in Applications-&gt;Utilities).</source>
+        <translation>現在の出力デバイスのサンプルレートが %1 Hz ではないため互換性がありません。別のデバイスを選択するか、Audio-MIDI設定（アプリケーション→ユーティリティ）で手動でサンプルレートを %1 Hz に設定してみてください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="463"/>
+        <source>The stream format on the current input device isn&apos;t compatible with this software. Please select another device.</source>
+        <translation>現在の入力デバイスのストリーム形式はこのソフトウェアと互換性がありません。別のデバイスを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="474"/>
+        <source>The stream format on the current output device isn&apos;t compatible with %1. Please select another device.</source>
+        <translation>現在の出力デバイスのストリーム形式は %1 と互換性がありません。別のデバイスを選択してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/coreaudio-mac/sound.cpp" line="727"/>
+        <source>The buffer sizes of the current input and output audio device can&apos;t be set to a common value. Please select different input/output devices in your system settings.</source>
+        <translation>現在の入力および出力オーディオデバイスのバッファサイズを共通の値に設定できません。システム設定で別の入力/出力デバイスを選択してください。</translation>
+    </message>
+</context>
+<context>
+    <name>CSoundBase</name>
+    <message>
+        <source>The selected audio device could not be used because of the following error: </source>
+        <translation type="vanished">次のエラーにより、選択したオーディオデバイスを使用できませんでした: </translation>
+    </message>
+    <message>
+        <source> The previous driver will be selected.</source>
+        <translation type="vanished"> 以前のドライバーが選択されます。</translation>
+    </message>
+    <message>
+        <source>The previously selected audio device is no longer available or the audio driver properties have changed to a state which is incompatible with this software. We now try to find a valid audio device. This new audio device might cause audio feedback. So, before connecting to a server, please check the audio device setting.</source>
+        <translation type="vanished">以前選択したオーディオデバイスは使用できなくなったか、オーディオドライバーのプロパティがこのソフトウェアと互換性のない状態に変更されました。有効なオーディオデバイスを検索します。この新しいオーディオデバイスはオーディオフィードバックを引き起こす可能性があります。サーバーに接続する前に、オーディオデバイスの設定を確認してください。</translation>
+    </message>
+    <message>
+        <source>No usable </source>
+        <translation type="vanished">使用可能な</translation>
+    </message>
+    <message>
+        <source> audio device (driver) found.</source>
+        <translation type="vanished">オーディオデバイス（ドライバー）が見つかりません。</translation>
+    </message>
+    <message>
+        <source>In the following there is a list of all available drivers with the associated error message:</source>
+        <translation type="vanished">以下は関連するエラーメッセージとともに使用可能なすべてのドライバーの一覧です:</translation>
+    </message>
+    <message>
+        <source>Do you want to open the ASIO driver setups?</source>
+        <translation type="vanished">ASIOドライバーの設定を開きますか？</translation>
+    </message>
+    <message>
+        <source> could not be started because of audio interface issues.</source>
+        <translation type="vanished">オーディオインターフェースの問題により起動できませんでした。</translation>
+    </message>
+    <message>
+        <location filename="../sound/soundbase.cpp" line="118"/>
+        <source>Can&apos;t use the selected audio device because of the following error: %1 The previous driver will be selected.</source>
+        <translation>次のエラーにより選択したオーディオデバイスを使用できません: %1 以前のドライバーが選択されます。</translation>
+    </message>
+    <message>
+        <location filename="../sound/soundbase.cpp" line="159"/>
+        <source>The previously selected audio device is no longer available or the driver has changed to an incompatible state. We&apos;ll attempt to find a valid audio device, but this new audio device may cause feedback. Before connecting to a server, please check your audio device settings.</source>
+        <translation>以前選択したオーディオデバイスは使用できなくなったか、ドライバーが互換性のない状態に変更されました。有効なオーディオデバイスを検索します。ただし、この新しいオーディオデバイスはフィードバックを引き起こす可能性があります。サーバーに接続する前に、オーディオデバイスの設定を確認してください。</translation>
+    </message>
+    <message>
+        <location filename="../sound/soundbase.cpp" line="172"/>
+        <source>&lt;b&gt;%1 couldn&apos;t find a usable %2 audio device.&lt;/b&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>&lt;b&gt;%1 で使用可能な %2 オーディオデバイスが見つかりませんでした。&lt;/b&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../sound/soundbase.cpp" line="183"/>
+        <source>You may be able to fix errors in the driver settings. Do you want to open these settings now?</source>
+        <translation>ドライバー設定でエラーを修正できる場合があります。今すぐこの設定を開きますか？</translation>
+    </message>
+    <message>
+        <source>No usable %1 audio device found.</source>
+        <translation type="vanished">使用可能な %1 オーディオデバイスが見つかりませんでした。</translation>
+    </message>
+    <message>
+        <source>These are all the available drivers with error messages:</source>
+        <translation type="vanished">以下はエラーメッセージとともに使用可能なすべてのドライバーです:</translation>
+    </message>
+    <message>
+        <source>Do you want to open the ASIO driver setup to try changing your configuration to a working state?</source>
+        <translation type="vanished">ASIOドライバーの設定を開いて、構成を動作する状態に変更しますか？</translation>
+    </message>
+    <message>
+        <location filename="../sound/soundbase.cpp" line="190"/>
+        <source>Can&apos;t start %1. Please restart %1 and check/reconfigure your audio settings.</source>
+        <translation>%1 を起動できません。%1 を再起動して、オーディオ設定を確認/再構成してください。</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <source>%1, Version %2</source>
+        <translation type="vanished">%1、バージョン %2</translation>
+    </message>
+    <message>
+        <source>Internet Jam Session Software</source>
+        <translation type="vanished">インターネットジャムセッションソフトウェア</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1512"/>
+        <source>%1, Version %2</source>
+        <comment>%1 is app name, %2 is version number</comment>
+        <translation>%1、バージョン %2</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1529"/>
+        <source>Released under the GNU General Public License version 2 or later (GPLv2)</source>
+        <translation>GNU General Public License バージョン2以降 (GPLv2) に基づいてリリース</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1542"/>
+        <source>This app uses the following libraries, resources or code snippets:</source>
+        <translation>このアプリは以下のライブラリ、リソース、またはコードスニペットを使用しています:</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1544"/>
+        <source>Qt cross-platform application framework</source>
+        <translation>Qt クロスプラットフォームアプリケーションフレームワーク</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1545"/>
+        <source>(build)</source>
+        <translation>（ビルド）</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1545"/>
+        <source>(runtime)</source>
+        <translation>（ランタイム）</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1563"/>
+        <source>Some pixmaps are from the %1</source>
+        <translation>一部のピクスマップは %1 から取得しています</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1569"/>
+        <source>Some sound samples are from %1</source>
+        <translation>一部のサウンドサンプルは %1 から取得しています</translation>
+    </message>
+    <message>
+        <source>This program is free software; you can redistribute it and/or modify it under</source>
+        <translation type="vanished">このプログラムはフリーソフトウェアです。以下の条件に従って</translation>
+    </message>
+    <message>
+        <source>the terms of the GNU General Public License as published by the Free Software</source>
+        <translation type="vanished">再配布および/または改変することができます。Free Software Foundationが発行した</translation>
+    </message>
+    <message>
+        <source>Foundation; either version 2 of the License, or (at your option) any later version.</source>
+        <translation type="vanished">GNU General Public License バージョン2、または（あなたの選択により）それ以降のバージョンに基づきます。</translation>
+    </message>
+    <message>
+        <source>There is NO WARRANTY, to the extent permitted by law.</source>
+        <translation type="vanished">法律で許可される範囲内で、いかなる保証もありません。</translation>
+    </message>
+    <message>
+        <source>Using the following libraries, resources or code snippets:</source>
+        <translation type="vanished">以下のライブラリ、リソース、またはコードスニペットを使用しています:</translation>
+    </message>
+    <message>
+        <source>Qt framework </source>
+        <translation type="vanished">Qt framework </translation>
+    </message>
+    <message>
+        <source>Opus Interactive Audio Codec</source>
+        <translation type="vanished">Opus Interactive Audio Codec</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1559"/>
+        <source>Audio reverberation code by Perry R. Cook and Gary P. Scavone</source>
+        <translation>Perry R. Cook と Gary P. Scavone によるオーディオリバーブコード</translation>
+    </message>
+    <message>
+        <source>Some pixmaps are from the Open Clip Art Library (OCAL)</source>
+        <translation type="vanished">一部のピクスマップは Open Clip Art Library (OCAL) から取得しています</translation>
+    </message>
+    <message>
+        <location filename="../util.cpp" line="1566"/>
+        <source>Flag icons by Mark James</source>
+        <translation>Mark James による国旗アイコン</translation>
+    </message>
+    <message>
+        <source>Copyright (C) 2005-2025 The Jamulus Development Team</source>
+        <translation type="vanished">Copyright (C) 2005-2025 The Jamulus Development Team</translation>
+    </message>
+    <message>
+        <source>Released under the GNU General Public License (GPL)</source>
+        <translation type="vanished">GNU General Public License (GPL) に基づいてリリース</translation>
+    </message>
+</context>
+<context>
+    <name>global</name>
+    <message>
+        <location filename="../global.h" line="123"/>
+        <source>A %1 upgrade is available: &lt;a style=&apos;color:red;&apos; href=&apos;https://jamulus.io/upgrade?progversion=%2&apos;&gt;go to details and downloads&lt;/a&gt;</source>
+        <translation>%1 のアップグレードが利用可能です: &lt;a style=&apos;color:red;&apos; href=&apos;https://jamulus.io/upgrade?progversion=%2&apos;&gt;詳細とダウンロードへ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../global.h" line="273"/>
+        <source>For more information use the &quot;What&apos;s This&quot; help (help menu, right mouse button or Shift+F1)</source>
+        <translation>詳細については「これは何？」ヘルプをご利用ください（ヘルプメニュー、右クリック、または Shift+F1）</translation>
+    </message>
+</context>
+</TS>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -559,7 +559,10 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
                               "<p>Gary Wang (<a href=\"https://github.com/BLumia\">BLumia</a>)</p>" +
                               "<p><b>" + tr ( "Norwegian Bokmål" ) +
                               "</b></p>"
-                              "<p>Allan Nordhøy (<a href=\"https://hosted.weblate.org/user/kingu/\">kingu</a>)</p>" );
+                              "<p>Allan Nordhøy (<a href=\"https://hosted.weblate.org/user/kingu/\">kingu</a>)</p>" +
+                              "<p><b>" + tr ( "Japanese" ) +
+                              "</b></p>"
+                              "<p>tsukurun (<a href=\"https://github.com/tsukurun\">tsukurun</a>)</p>" );
 
     // set version number in about dialog
     lblVersion->setText ( GetVersionAndNameStr() );


### PR DESCRIPTION
  ## Summary
  - Add complete Japanese (ja_JP) translation for Jamulus client
  - Based on Korean (ko_KR) translation template
  - All 627 active strings translated

  ## Related Issue
  Closes #3567

  ## Test
  - Generated .qm file successfully with `lrelease`
  - No untranslated strings remaining