### PR TITLE
Add fader level set method to RPC remote interface

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -224,7 +224,7 @@ Results:
 
 ### jamulusclient/setFaderLevel
 
-Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level": 50}}.
+Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level":  50}}.
 
 Parameters:
 

--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -222,6 +222,24 @@ Results:
 | result | string | Always "ok". |
 
 
+### jamulusclient/setFaderLevel
+
+Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level": 50}}.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.channelIndex | number | The channel index of the fader to be set. |
+| params.level | number | The fader level in range 0..100. |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | Always "ok". |
+
+
 ### jamulusclient/setName
 
 Sets your name.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -881,7 +881,7 @@ void CClient::OnHandledSignal ( int sigNum )
 #endif
 }
 
-void CClient::OnControllerInFaderLevel ( int iChannelIdx, int iValue )
+void CClient::SetControllerInFaderLevel ( int iChannelIdx, int iValue )
 {
     // in case of a headless client the faders cannot be moved so we need
     // to send the controller information directly to the server

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -881,7 +881,7 @@ void CClient::OnHandledSignal ( int sigNum )
 #endif
 }
 
-void CClient::SetControllerInFaderLevel ( int iChannelIdx, int iValue )
+void CClient::OnControllerInFaderLevel ( int iChannelIdx, int iValue )
 {
     // in case of a headless client the faders cannot be moved so we need
     // to send the controller information directly to the server

--- a/src/client.h
+++ b/src/client.h
@@ -260,7 +260,7 @@ public:
     void OnTimerRemoteChanGainOrPan();
     void StartTimerGainOrPan();
 
-    void SetControllerInFaderLevel ( int iChannelIdx, int iValue );
+    void SetControllerInFaderLevel ( int iChannelIdx, int iValue )  { OnControllerInFaderLevel ( iChannelIdx, iValue ); }
 
     void SetInputBoost ( const int iNewBoost ) { iInputBoost = iNewBoost; }
 
@@ -434,7 +434,7 @@ protected slots:
     void OnCLPingWithNumClientsReceived ( CHostAddress InetAddr, int iMs, int iNumClients );
 
     void OnSndCrdReinitRequest ( int iSndCrdResetType );
-    void OnControllerInFaderLevel ( int iChannelIdx, int iValue ) { SetControllerInFaderLevel ( iChannelIdx, iValue ); }
+    void OnControllerInFaderLevel ( int iChannelIdx, int iValue );
     void OnControllerInPanValue ( int iChannelIdx, int iValue );
     void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );

--- a/src/client.h
+++ b/src/client.h
@@ -260,6 +260,8 @@ public:
     void OnTimerRemoteChanGainOrPan();
     void StartTimerGainOrPan();
 
+    void SetControllerInFaderLevel ( int iChannelIdx, int iValue );
+
     void SetInputBoost ( const int iNewBoost ) { iInputBoost = iNewBoost; }
 
     void SetRemoteInfo() { Channel.SetRemoteInfo ( ChannelInfo ); }
@@ -432,7 +434,7 @@ protected slots:
     void OnCLPingWithNumClientsReceived ( CHostAddress InetAddr, int iMs, int iNumClients );
 
     void OnSndCrdReinitRequest ( int iSndCrdResetType );
-    void OnControllerInFaderLevel ( int iChannelIdx, int iValue );
+    void OnControllerInFaderLevel ( int iChannelIdx, int iValue ) { SetControllerInFaderLevel ( iChannelIdx, iValue ); }
     void OnControllerInPanValue ( int iChannelIdx, int iValue );
     void OnControllerInFaderIsSolo ( int iChannelIdx, bool bIsSolo );
     void OnControllerInFaderIsMute ( int iChannelIdx, bool bIsMute );

--- a/src/client.h
+++ b/src/client.h
@@ -260,7 +260,7 @@ public:
     void OnTimerRemoteChanGainOrPan();
     void StartTimerGainOrPan();
 
-    void SetControllerInFaderLevel ( int iChannelIdx, int iValue )  { OnControllerInFaderLevel ( iChannelIdx, iValue ); }
+    void SetControllerInFaderLevel ( int iChannelIdx, int iValue ) { OnControllerInFaderLevel ( iChannelIdx, iValue ); }
 
     void SetInputBoost ( const int iNewBoost ) { iInputBoost = iNewBoost; }
 

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -328,7 +328,8 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
     } );
 
     /// @rpc_method jamulusclient/setFaderLevel
-    /// @brief Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level": 50}}.
+    /// @brief Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level":
+    /// 50}}.
     /// @param {number} params.channelIndex - The channel index of the fader to be set.
     /// @param {number} params.level - The fader level in range 0..100.
     /// @result {string} result - Always "ok".
@@ -336,14 +337,16 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
         auto jsonChannelIndex = params["channelIndex"];
         if ( !jsonChannelIndex.isDouble() || ( jsonChannelIndex.toInt() < 0 ) || ( jsonChannelIndex.toInt() > MAX_NUM_CHANNELS ) )
         {
-            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: channelIndex is not a number or out-of-range" );
+            response["error"] =
+                CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: channelIndex is not a number or out-of-range" );
             return;
         }
 
         auto jsonLevel = params["level"];
         if ( !jsonLevel.isDouble() || ( jsonLevel.toInt() < 0 ) || ( jsonLevel.toInt() > 100 ) )
         {
-            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: level is not a number or out-of-range" );
+            response["error"] =
+                CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: level is not a number or out-of-range" );
             return;
         }
 

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -334,16 +334,16 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
     /// @result {string} result - Always "ok".
     pRpcServer->HandleMethod ( "jamulusclient/setFaderLevel", [=] ( const QJsonObject& params, QJsonObject& response ) {
         auto jsonChannelIndex = params["channelIndex"];
-        if ( !jsonChannelIndex.isDouble() )
+        if ( !jsonChannelIndex.isDouble() || ( jsonChannelIndex.toInt() < 0 ) || ( jsonChannelIndex.toInt() > MAX_NUM_CHANNELS ) )
         {
-            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: channelIndex is not a number" );
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: channelIndex is not a number or out-of-range" );
             return;
         }
 
         auto jsonLevel = params["level"];
-        if ( !jsonLevel.isDouble() )
+        if ( !jsonLevel.isDouble() || ( jsonLevel.toInt() < 0 ) || ( jsonLevel.toInt() > 100 ) )
         {
-            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: level is not a number" );
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: level is not a number or out-of-range" );
             return;
         }
 

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -348,7 +348,7 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
         }
 
         // TODO How to set fader level in client correctly? OnControllerInFaderLevel is definitely the function we need to call...
-        //pClient->OnControllerInFaderLevel ( jsonChannelIndex.toInt(), jsonLevel.toInt() );
+        pClient->SetControllerInFaderLevel ( jsonChannelIndex.toInt(), jsonLevel.toInt() );
         response["result"] = "ok";
     } );
 }

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -347,7 +347,6 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
             return;
         }
 
-        // TODO How to set fader level in client correctly? OnControllerInFaderLevel is definitely the function we need to call...
         pClient->SetControllerInFaderLevel ( jsonChannelIndex.toInt(), jsonLevel.toInt() );
         response["result"] = "ok";
     } );

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -328,7 +328,7 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
     } );
 
     /// @rpc_method jamulusclient/setFaderLevel
-    /// @brief Sets the fader level.
+    /// @brief Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level": 50}}.
     /// @param {number} params.channelIndex - The channel index of the fader to be set.
     /// @param {number} params.level - The fader level in range 0..100.
     /// @result {string} result - Always "ok".

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -326,6 +326,31 @@ CClientRpc::CClientRpc ( CClient* pClient, CRpcServer* pRpcServer, QObject* pare
 
         response["result"] = "ok";
     } );
+
+    /// @rpc_method jamulusclient/setFaderLevel
+    /// @brief Sets the fader level.
+    /// @param {number} params.channelIndex - The channel index of the fader to be set.
+    /// @param {number} params.level - The fader level in range 0..100.
+    /// @result {string} result - Always "ok".
+    pRpcServer->HandleMethod ( "jamulusclient/setFaderLevel", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        auto jsonChannelIndex = params["channelIndex"];
+        if ( !jsonChannelIndex.isDouble() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: channelIndex is not a number" );
+            return;
+        }
+
+        auto jsonLevel = params["level"];
+        if ( !jsonLevel.isDouble() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: level is not a number" );
+            return;
+        }
+
+        // TODO How to set fader level in client correctly? OnControllerInFaderLevel is definitely the function we need to call...
+        //pClient->OnControllerInFaderLevel ( jsonChannelIndex.toInt(), jsonLevel.toInt() );
+        response["result"] = "ok";
+    } );
 }
 
 QJsonValue CClientRpc::SerializeSkillLevel ( ESkillLevel eSkillLevel )


### PR DESCRIPTION
**Short description of changes**

Dear Jamulus development team :-). After a very long time, I worked on Jamulus again. I needed to add a fader level set method to the RPC remote inteface because I want to run Jamulus in headless mode together with my Edrumulus e-drum software on a Raspberry Pi. Edrumulus is remote controlled with a smart phone via a web interface and for Jamulus I want to write a small Android app which uses the RPC interface.

Note: For being able to make changes, I had to create a fork. I remember that this was problematic since I moved the jamulus project from my private space "corrados" to "jamulussoftware" and Github automatically forwarded git actions if a developer did use the old path. Since jamulus is now about 5 years in "jamulussoftware", I hope that in the meantime all developer have updated their Git repo and have cloned from the correct origin URL. If this is not the case, please let me know. Then I will delete my fork again.

CHANGELOG: Added a jamulusclient/setFaderLevel method to the RPC remote interface.

**Context: Fixes an issue?**

No.

**Does this change need documentation? What needs to be documented and how?**

Yes, the new method should be documented in the JSON-RPC file. I added Doxygen description to the new function similar to what was done with the other functions. It seems that the documentation file is generated from this. I would need your help how to update the documentation (is it automatically done somehow?).

**Status of this Pull Request**

I tested my implementation as follows:

Start Jamulus with: ./Jamulus --jsonrpcport 11223 --jsonrpcsecretfile secret.txt
In a Linux shell: nc localhost 11223
Then:
{"id":1,"jsonrpc":"2.0","method":"jamulus/apiAuth","params":{"secret": "my_secret_which_i_do_not_show_here"}}
{"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0, "level": 50}}

That worked for me. The fader of the first channel moved after the last command.

**What is missing until this pull request can be merged?**

As stated above: The documentation may be updated first.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
