### PR TITLE
Add missing variable for IPv6

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -44,7 +44,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     eLastDesign ( GD_ORIGINAL ),         //          "
     ClientSettingsDlg ( pNCliP, pNSetP, parent ),
     ChatDlg ( parent ),
-    ConnectDlg ( pNSetP, bNewShowComplRegConnList, parent ),
+    ConnectDlg ( pNSetP, bNewShowComplRegConnList, bNEnableIPv6, parent ),
     AnalyzerConsole ( pNCliP, parent )
 {
     setupUi ( this );


### PR DESCRIPTION
Enhance the connection dialog by fixing a forgotten variable

CHANGELOG: Bug: Fix missing variables passed to connect dialog

**Context: Fixes an issue?**

Fixes: #3577
**Does this change need documentation? What needs to be documented and how?**

No
**Status of this Pull Request**

To be tested
**What is missing until this pull request can be merged?**

Testing
## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (ipv6 connection works on `::1`)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [ ] I've filled all the content above

<!-- AUTOBUILD: Please build all targets -->

