### PR TITLE
Fixes 3572: macOS 13 runner is closing down

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -226,37 +226,35 @@ jobs:
 
           - config_name:            MacOS (artifacts)
             target_os:              macos
-            building_on_os:         macos-14
+            building_on_os:         macos-15
             base_command:           QT_VERSION=6.9.1 SIGN_IF_POSSIBLE=1 TARGET_ARCHS="x86_64 arm64" ./.github/autobuild/mac.sh
             # Disable CodeQL on mac as it interferes with signing the binaries (signing hangs, see #2563 and #2564)
             run_codeql:             false
-            # Latest Xcode which runs on macos-14:
-            xcode_version:          15.4.0
+            xcode_version:          16.3.0
             is_main_build_target:   true
 
           # Reminder: If Legacy is removed, be sure to add a dedicated job for CodeQL again.
           - config_name:            MacOS Legacy (artifacts+CodeQL)
             target_os:              macos
-            building_on_os:         macos-13
+            building_on_os:         macos-15-intel
             base_command:           QT_VERSION=5.15.2 SIGN_IF_POSSIBLE=0 ARTIFACT_SUFFIX=_legacy ./.github/autobuild/mac.sh
             # Enable CodeQL on mac legacy as this version does not get signed
             run_codeql:             true
-            # For Qt5 on Mac, we need to use an unsupported SDK version as macOS 13 doesn't
-            # support Xcode 12.1 which still ships SDK 10.15.
+            # macos-15-intel ships with Xcode 16.x; while Qt5 is older, Xcode 16 still supports building it
             # https://developer.apple.com/support/xcode/
             # https://xcodereleases.com/
-            xcode_version:          14.2.0
+            xcode_version:          16.3.0
             is_main_build_target:   true
 
           - config_name:            iOS (artifacts)
             target_os:              ios
-            building_on_os:         macos-14
+            building_on_os:         macos-15
             base_command:           QT_VERSION=6.7.3 ./.github/autobuild/ios.sh
             # Build failed with CodeQL enabled when last tested 03/2022 (#2490).
             # There are no hints that iOS is supposed to be supported by CodeQL.
             # Therefore, disable it:
             run_codeql:             false
-            xcode_version:          15.4.0
+            xcode_version:          16.3.0
 
           - config_name:            Windows (artifact+codeQL)
             target_os:              windows


### PR DESCRIPTION
**Short description of changes**

Claude Haiku 4.5 suggested fixes for continued support of macOS 10.13+ with Qt5.
- move to macos-15 builder for macOS on Apple Silicon and iOS and macos-15-intel for main and legacy macOS on Intel
- move to Xcode 16.3.0
- use QMAKE_MACOSX_DEPLOYMENT_TARGET to target 11.0 for "modern" and 10.13 for "legacy" macOS builds (rather than 10.12 previously)
- retain existing Qt versions

CHANGELOG: Provide continued legacy macOS support (but moving Sierra to High Sierra as minimum target)

**Context: Fixes an issue?**

Fixes 3572

**Does this change need documentation? What needs to be documented and how?**

No - change log should be enough.

> Note: You can find old (legacy) versions supporting outdated operating systems on the [GitHub release page](https://github.com/jamulussoftware/jamulus/releases).

The website doesn't document what "old (legacy) versions" means.

**Status of this Pull Request**

Needs reviewing by humans who know macOS (and potentially iOS).

**What is missing until this pull request can be merged?**

No testing has been done.  So someone with a legacy mac needs to try it.  Hopefully it'll actually build...

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
