### PR TITLE
Add workaround from QTBUG-129651 for iOS FFMPEG linking

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -236,6 +236,7 @@ win32 {
     }
 
 } else:ios {
+    CONFIG+=add_ios_ffmpeg_libraries # QTBUG-129651
     QMAKE_ASSET_CATALOGS += src/res/iOSIcons.xcassets
     QMAKE_INFO_PLIST = ios/Info.plist
     OBJECTIVE_SOURCES += src/ios/ios_app_delegate.mm


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: SKIP
**Context: Fixes an issue?**

Allows building (but not running) Jamulus on iOS with Qt > 6.7.3 where the ffmpeg backend was introduced.
**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready for testing/review (I think it's worth just merging this as iOS Qt6 is not stable anyway). We shouldn't move up for iOS yet.

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want (as in: It compiles now but still produces a binary which starts with a black screen)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
