### PR TITLE
Improve deploy_windows.ps1 fetching of dependencies

### DIFF
--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -79,8 +79,8 @@ jobs:
             changelog_name: ASIO SDK (Windows-only)
             get_upstream_version: |
               curl -s -o /dev/null --location --range 0-5 --write-out '%{url_effective}' https://www.steinberg.net/asiosdk |
-                grep -oP '.*asiosdk_\K.*(?=\.zip)'
-            local_version_regex: (.*["\/]asiosdk_)([^"]+?)(".*|\.zip.*)
+                grep -oP '.*\K(?:ASIO-SDK|asiosdk)_.*(?=\.zip)'
+            local_version_regex: (.*["\/])((?:ASIO-SDK|asiosdk)_[^"]+?)(".*|\.zip.*)
 
     steps:
       - uses: actions/checkout@v6

--- a/windows/deploy_windows.ps1
+++ b/windows/deploy_windows.ps1
@@ -11,9 +11,7 @@ param (
     #
     # The following version pinnings are semi-automatically checked for
     # updates. Verify .github/workflows/bump-dependencies.yaml when changing those manually:
-    [string] $AsioSDKName = "asiosdk_2.3.3_2019-06-14",
     [string] $AsioSDKUrl = "https://download.steinberg.net/sdk_downloads/asiosdk_2.3.3_2019-06-14.zip",
-    [string] $NsisName = "nsis-3.11",
     [string] $NsisUrl = "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.11/nsis-3.11.zip",
     [string] $BuildOption = ""
 )
@@ -128,8 +126,6 @@ Function Install-Dependency
         [Parameter(Mandatory=$true)]
         [string] $Uri,
         [Parameter(Mandatory=$true)]
-        [string] $Name,
-        [Parameter(Mandatory=$true)]
         [string] $Destination
     )
 
@@ -140,7 +136,11 @@ Function Install-Dependency
     }
 
     $TempFileName = [System.IO.Path]::GetTempFileName() + ".zip"
-    $TempDir = [System.IO.Path]::GetTempPath()
+    $TempPath = [System.IO.Path]::GetTempPath()
+    $TempGuid = [System.Guid]::NewGuid()
+    # Create a unique empty directory to unpack into
+    $TempDir = (Join-Path $TempPath $TempGuid)
+    New-Item -ItemType Directory -Path $TempDir
 
     if ($Uri -Match "downloads.sourceforge.net")
     {
@@ -151,7 +151,10 @@ Function Install-Dependency
     echo $TempFileName
     Expand-Archive -Path $TempFileName -DestinationPath $TempDir -Force
     echo $WindowsPath\$Destination
-    Move-Item -Path "$TempDir\$Name" -Destination "$WindowsPath\$Destination" -Force
+    # Because we unpacked into a new directory, we can use * for the directory in the archive,
+    # so that we do not need to know the directory name the archive was packed from.
+    Move-Item -Path "$TempDir\*" -Destination "$WindowsPath\$Destination" -Force
+    Remove-Item -Path $TempDir -Recurse -Force
     Remove-Item -Path $TempFileName -Force
 }
 
@@ -162,14 +165,12 @@ Function Install-Dependencies
       Install-PackageProvider -Name "Nuget" -Scope CurrentUser -Force
     }
     Initialize-Module-Here -m "VSSetup"
-    Install-Dependency -Uri $NsisUrl `
-        -Name $NsisName -Destination "..\libs\NSIS\NSIS-source"
+    Install-Dependency -Uri $NsisUrl -Destination "..\libs\NSIS\NSIS-source"
 
     if ($BuildOption -Notmatch "jack") {
         # Don't download ASIO SDK on Jamulus JACK builds to save
         # resources and to be extra-sure license-wise.
-        Install-Dependency -Uri $AsioSDKUrl `
-            -Name $AsioSDKName -Destination "..\libs\ASIOSDK2"
+        Install-Dependency -Uri $AsioSDKUrl -Destination "..\libs\ASIOSDK2"
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

In `deploy-windows.ps1`, updated `Install-Dependency` to create a unique empty directory for unpacking the fetched zip file into, for ASIO and NSIS.

Also updated the regex for matching the ASIO file version in `bump-dependencies.yml`.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes #3560
Replaces #3607

This avoids having to know the top-level directory name used within the archive, which for ASIO is not consistent between versions, and could not be updated by `bump-dependencies.yml`

**Does this change need documentation? What needs to be documented and how?**

I don't think so. It just makes the PRs generated for updating ASIO and NSIS build properly.

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

Ready for review

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Check CI works

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. (except iOS)<!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
