### PR TITLE
IPv6 QoS fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -222,8 +222,12 @@ int main ( int argc, char** argv )
         // Quality of Service --------------------------------------------------
         if ( GetNumericArgument ( argc, argv, i, "-Q", "--qos", 0, 255, rDbleArgument ) )
         {
+#if defined( Q_OS_WIN )
+            qWarning() << "QoS is currently not available under Windows - ignoring";
+#else
             iQosNumber = static_cast<quint16> ( rDbleArgument );
             qInfo() << qUtf8Printable ( QString ( "- selected QoS value: %1" ).arg ( iQosNumber ) );
+#endif
             CommandLineOptions << "--qos";
             continue;
         }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -129,7 +129,7 @@ void CSocket::Init ( const quint16 iNewPortNumber, const quint16 iNewQosNumber, 
         }
 #endif
 
-#if !defined( Q_OS_DARWIN )
+#if !defined( Q_OS_DARWIN ) && !defined( Q_OS_WIN )
         // set the QoS for IPv4 as well, as this is a dual-protocol socket
         if ( setsockopt ( UdpSocket, IPPROTO_IP, IP_TOS, (const char*) &tos, sizeof ( tos ) ) == -1 )
         {
@@ -162,12 +162,14 @@ void CSocket::Init ( const quint16 iNewPortNumber, const quint16 iNewQosNumber, 
             throw CGenErr ( "IPv4 requested but not available on this system.", "Network Error" );
         }
 
+#if !defined( Q_OS_WIN )
         // set the QoS
         const int tos = (int) iQosNumber; // Quality of Service
         if ( setsockopt ( UdpSocket, IPPROTO_IP, IP_TOS, (const char*) &tos, sizeof ( tos ) ) == -1 )
         {
             throw CGenErr ( "request to set ToS for IPv4 failed", "Network Error" );
         }
+#endif
 
         // preinitialize socket in address (only the port number is missing)
         UdpSocketAddr.sa4.sin_family      = AF_INET;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

When IPv6 is enabled, this provides a fix to properly typecast `tos` so setsockopt can properly add DSCP field value.
Also adds error checking for `setsockopt()` calls and ensures correct QoS operation for dual-protocol sockets.

CHANGELOG: Client+Server: Correct QoS setting for IPv6
<!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->
Fixes: #3623 

**Does this change need documentation? What needs to be documented and how?**
No, just a bugfix

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

Needs testing on all but Linux OSes.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
