### PR TITLE
Update changelog-helper tool to report SKIPped PRs

### DIFF
--- a/tools/changelog-helper.sh
+++ b/tools/changelog-helper.sh
@@ -200,10 +200,11 @@ check_or_add_pr() {
     title_suggestion_in_pr=$(gh pr view "$id" --json body,comments,reviews --jq '(.body), (.comments[] .body), (.reviews[] .body)' |
         grep -oP '^\bCHANGELOG:\s*\K([^\\]{5,})' | tail -n1 | sanitize_title || true)
     if [[ "${title_suggestion_in_pr}" ]]; then
-        title="${title_suggestion_in_pr}"
         if [[ "${title_suggestion_in_pr}" == "SKIP" ]]; then
+            echo "-> Skipping PR #${id} ($title, @${author})"
             return
         fi
+        title="${title_suggestion_in_pr}"
     fi
     echo -n "-> Missing PR #${id} (${title}, @${author})"
     if [[ "${ACTION}" != add-missing-entries ]]; then


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

When changelog-helper.sh skips a PR that was marked "SKIP", output a message to reassure the user that it has still been seen.

CHANGELOG: Tools: Update changelog-helper to report skipped PRs

**Context: Fixes an issue?**

Fixes #3536

**Does this change need documentation? What needs to be documented and how?**

No, it doesn't change the behaviour, just makes the output more informative.

**Status of this Pull Request**

Tested and ready

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
