### PR TITLE
fix: use display version in registration packet to avoid exceeding MAX_LEN_VERSION_TEXT

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -1864,7 +1864,7 @@ void CProtocol::CreateCLRegisterServerExMes ( const CHostAddress& InetAddr, cons
     const QByteArray strUTF8LInetAddr = LInetAddr.InetAddr.toString().toUtf8();
     const QByteArray strUTF8Name      = ServerInfo.strName.toUtf8();
     const QByteArray strUTF8City      = ServerInfo.strCity.toUtf8();
-    const QByteArray strUTF8Version   = QString ( APP_VERSION ).toUtf8();
+    const QByteArray strUTF8Version   = QString ( VERSION ).toUtf8();
 
     // size of current message body
     const int iEntrLen = 2 +                           // server internal port number


### PR DESCRIPTION
## Bug

Dev builds from a dirty git tree silently fail to register with a directory server.

The build system produces `APP_VERSION` strings like `3.11.0dev-a91a593-dirty:1776526795` (34 chars) for dirty git builds. `CreateCLRegisterServerExMes` encodes this verbatim in the registration packet. The receiving directory calls `GetStringFromStream(vecData, iPos, MAX_LEN_VERSION_TEXT, strVersion)` where `MAX_LEN_VERSION_TEXT = 30`. When the string exceeds 30 chars, `GetStringFromStream` returns an error — the registration handler exits early and sends **no response**. The registering server sees only 500 ms timeouts, retries five times, and reports `Registration failed`.

## Why it wasn't caught

- Release builds: `3.11.0` — 6 chars ✓
- Dev builds without git: `3.11.0dev-nogit` — 15 chars ✓  
- Dev builds, clean git tree: `3.11.0dev-<7chars>:<10chars>` — 28 chars ✓ (just under the limit)
- Dev builds, **dirty** git tree: `3.11.0dev-<7chars>-dirty:<10chars>` — 34 chars ✗

The `-dirty` suffix (6 chars) is what pushes it over. CI always builds clean, so this path was never exercised.

## Fix

`VERSION` (`GetDisplayVersion(APP_VERSION)`) already exists to strip the `:timestamp` build artifact for external/display use. `CreateCLRegisterServerExMes` should use `VERSION` rather than `APP_VERSION`, consistent with the intent of that split.

`3.11.0dev-a91a593-dirty` → 23 chars, safely under the limit.

## Testing

Confirmed on a dirty-tree dev build: before fix, five registration attempts with zero responses from directory; after fix, registers successfully on first attempt.