### PR TITLE
FreeBSD fix for dual-stack and IPv6 QoS

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -279,10 +279,16 @@ static ssize_t sendto_ipv4_with_tos ( int fd, const void* buf, size_t len, int f
     // For a description of 'struct cmsghdr' and the 'CMSG_xxx' macros, see 'man 3 cmsg' on a Linux machine.
     // The macOS man pages are less descriptive, but the API is the same, being based on the BSD socket interface.
 
+#    if defined( Q_OS_FREEBSD )
+    using tos_cmsg_type = unsigned char;
+#    else
+    using tos_cmsg_type = int;
+#    endif
+
     // The cmsg buffer is only set up once (tos doesn't change) so can be static
     static union
     {
-        unsigned char  cbuf[CMSG_SPACE ( sizeof ( int ) )];
+        unsigned char  cbuf[CMSG_SPACE ( sizeof ( tos_cmsg_type ) )];
         struct cmsghdr h;
     } u;
     static socklen_t clen = 0;
@@ -290,26 +296,30 @@ static ssize_t sendto_ipv4_with_tos ( int fd, const void* buf, size_t len, int f
     if ( clen == 0 )
     {
         // set up the cmsg buffer
-        memset ( u.cbuf, 0, sizeof ( u.cbuf ) );
+        memset ( &u, 0, sizeof ( u ) );
 
         u.h.cmsg_level = IPPROTO_IP;
         u.h.cmsg_type  = IP_TOS;
-        u.h.cmsg_len   = CMSG_LEN ( sizeof ( int ) );
-        memcpy ( CMSG_DATA ( &u.h ), &tos, sizeof ( int ) );
-        clen = (socklen_t) u.h.cmsg_len;
+        u.h.cmsg_len   = CMSG_LEN ( sizeof ( tos_cmsg_type ) );
+
+        tos_cmsg_type tosvalue = static_cast<tos_cmsg_type> ( tos & 0xFF );
+        memcpy ( CMSG_DATA ( &u.h ), &tosvalue, sizeof ( tosvalue ) );
+        clen = CMSG_SPACE ( sizeof ( tos_cmsg_type ) );
     }
 
     struct iovec iov;
+    memset ( &iov, 0, sizeof ( iov ) );
     iov.iov_base = const_cast<void*> ( buf );
     iov.iov_len  = len;
 
     struct msghdr msg;
+    memset ( &msg, 0, sizeof ( msg ) );
 
     msg.msg_name       = const_cast<sockaddr*> ( dest );
     msg.msg_namelen    = destlen;
     msg.msg_iov        = &iov;
     msg.msg_iovlen     = 1;
-    msg.msg_control    = (void*) u.cbuf;
+    msg.msg_control    = u.cbuf;
     msg.msg_controllen = clen;
 
     return sendmsg ( fd, &msg, flags );

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -129,7 +129,7 @@ void CSocket::Init ( const quint16 iNewPortNumber, const quint16 iNewQosNumber, 
         }
 #endif
 
-#if !defined( Q_OS_DARWIN ) && !defined( Q_OS_WIN )
+#if !defined( Q_OS_BSD4 ) && !defined( Q_OS_WIN )
         // set the QoS for IPv4 as well, as this is a dual-protocol socket
         if ( setsockopt ( UdpSocket, IPPROTO_IP, IP_TOS, (const char*) &tos, sizeof ( tos ) ) == -1 )
         {
@@ -272,8 +272,8 @@ CSocket::~CSocket()
 #endif
 }
 
-#if defined( Q_OS_DARWIN )
-// sendto_ipv4_with_tos - helper function for macOS to set TOS when sending IPv4 over IPv6 socket
+#if defined( Q_OS_BSD4 )
+// sendto_ipv4_with_tos - helper function for macOS and FreeBSD to set TOS when sending IPv4 over IPv6 socket
 static ssize_t sendto_ipv4_with_tos ( int fd, const void* buf, size_t len, int flags, const struct sockaddr* dest, socklen_t destlen, int tos )
 {
     // For a description of 'struct cmsghdr' and the 'CMSG_xxx' macros, see 'man 3 cmsg' on a Linux machine.
@@ -355,8 +355,8 @@ void CSocket::SendPacket ( const CVector<uint8_t>& vecbySendBuf, const CHostAddr
                     addr[2] = htonl ( 0xFFFF );
                     addr[3] = htonl ( HostAddr.InetAddr.toIPv4Address() );
 
-#if defined( Q_OS_DARWIN )
-                    // In macOS we need to set TOS explicitly when sending IPv4 over IPv6 socket
+#if defined( Q_OS_BSD4 )
+                    // In macOS and FreeBSD we need to set TOS explicitly when sending IPv4 over IPv6 socket
                     status = sendto_ipv4_with_tos ( UdpSocket,
                                                     (const char*) &( (CVector<uint8_t>) vecbySendBuf )[0],
                                                     iVecSizeOut,


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Enhances #3622 to fix an issue with running on FreeBSD, which is subtly different from macOS.

CHANGELOG: FreeBSD: make -6 option work properly with both IPv6 and IPv4 peers.

**Context: Fixes an issue?**

Fixes #3478 and also a crash with #3622 when running with -6 on FreeBSD

**Does this change need documentation? What needs to be documented and how?**

No, bug fix only

**Status of this Pull Request**

Tested on both macOS and FreeBSD. No changes to Linux or Windows.

**What is missing until this pull request can be merged?**

Nothing, but it is important to get this into 3.12.0

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
