### PR TITLE
Add missing override specifiers

### DIFF
--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -69,7 +69,7 @@ protected:
     void    UpdateAudioFaderSlider();
     QString GenSndCrdBufferDelayString ( const int iFrameSize, const QString strAddText = "" );
 
-    virtual void showEvent ( QShowEvent* );
+    virtual void showEvent ( QShowEvent* ) override;
     virtual bool eventFilter ( QObject* obj, QEvent* event ) override;
 
     CClient*         pClient;

--- a/src/sound/coreaudio-mac/sound.h
+++ b/src/sound/coreaudio-mac/sound.h
@@ -42,28 +42,28 @@ public:
 
     virtual ~CSound();
 
-    virtual int  Init ( const int iNewPrefMonoBufferSize );
-    virtual void Start();
-    virtual void Stop();
+    virtual int  Init ( const int iNewPrefMonoBufferSize ) override;
+    virtual void Start() override;
+    virtual void Stop() override;
 
     // channel selection
-    virtual int     GetNumInputChannels() { return iNumInChanPlusAddChan; }
-    virtual QString GetInputChannelName ( const int iDiD ) { return sChannelNamesInput[iDiD]; }
-    virtual void    SetLeftInputChannel ( const int iNewChan );
-    virtual void    SetRightInputChannel ( const int iNewChan );
-    virtual int     GetLeftInputChannel() { return iSelInputLeftChannel; }
-    virtual int     GetRightInputChannel() { return iSelInputRightChannel; }
+    virtual int     GetNumInputChannels() override { return iNumInChanPlusAddChan; }
+    virtual QString GetInputChannelName ( const int iDiD ) override { return sChannelNamesInput[iDiD]; }
+    virtual void    SetLeftInputChannel ( const int iNewChan ) override;
+    virtual void    SetRightInputChannel ( const int iNewChan ) override;
+    virtual int     GetLeftInputChannel() override { return iSelInputLeftChannel; }
+    virtual int     GetRightInputChannel() override { return iSelInputRightChannel; }
 
-    virtual int     GetNumOutputChannels() { return iNumOutChan; }
-    virtual QString GetOutputChannelName ( const int iDiD ) { return sChannelNamesOutput[iDiD]; }
-    virtual void    SetLeftOutputChannel ( const int iNewChan );
-    virtual void    SetRightOutputChannel ( const int iNewChan );
-    virtual int     GetLeftOutputChannel() { return iSelOutputLeftChannel; }
-    virtual int     GetRightOutputChannel() { return iSelOutputRightChannel; }
+    virtual int     GetNumOutputChannels() override { return iNumOutChan; }
+    virtual QString GetOutputChannelName ( const int iDiD ) override { return sChannelNamesOutput[iDiD]; }
+    virtual void    SetLeftOutputChannel ( const int iNewChan ) override;
+    virtual void    SetRightOutputChannel ( const int iNewChan ) override;
+    virtual int     GetLeftOutputChannel() override { return iSelOutputLeftChannel; }
+    virtual int     GetRightOutputChannel() override { return iSelOutputRightChannel; }
 
     // MIDI functions
-    virtual void        EnableMIDI ( const bool bEnable );
-    virtual bool        IsMIDIEnabled() const;
+    virtual void        EnableMIDI ( const bool bEnable ) override;
+    virtual bool        IsMIDIEnabled() const override;
     virtual QStringList GetMIDIDevNames() override;
 
     // these variables/functions should be protected but cannot since we want
@@ -97,7 +97,7 @@ public:
     CVector<int>   vecNumOutBufChan;
 
 protected:
-    virtual QString LoadAndInitializeDriver ( QString strDriverName, bool );
+    virtual QString LoadAndInitializeDriver ( QString strDriverName, bool ) override;
 
     QString CheckDeviceCapabilities ( const int iDriverIdx );
     void    UpdateChSelection();


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Add missing override specifiers to satisfy compiler warnings on macOS

CHANGELOG: Added missing override specifiers for virtual methods

**Context: Fixes an issue?**

While compiling on macOS, noticed a lot of virtual function overrides in the macOS sound implementation were not marked as override, generating a lot of compiler warnings. Also one in the client settings dialog.

This change adds the missing override specifiers, but does not change any functionality.

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready - no reason not to put it in 3.12.0

**What is missing until this pull request can be merged?**

Nothing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
