### PR TITLE
Fix deprecation of result_of in C++17

### DIFF
--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -35,13 +35,24 @@
 #include <functional>
 #include <stdexcept>
 
+// compatibility with C++17 deprecation of result_of
+#if __cplusplus >= 201703L
+// std::invoke_result_t should be used from C++17 onwards, but is not available in C++14 and earlier
+template<class F, class... Args>
+using threadpool_result_t = std::invoke_result_t<F, Args...>;
+#else
+// std::result_of should be used on C++14 and earlier, but is deprecated in C++17
+template<class F, class... Args>
+using threadpool_result_t = typename std::result_of<F ( Args... )>::type;
+#endif
+
 class CThreadPool
 {
 public:
     CThreadPool() = default;
     CThreadPool ( size_t );
     template<class F, class... Args>
-    auto enqueue ( F&& f, Args&&... args ) -> std::future<typename std::result_of<F ( Args... )>::type>;
+    auto enqueue ( F&& f, Args&&... args ) -> std::future<threadpool_result_t<F, Args...>>;
     ~CThreadPool();
 
 private:
@@ -87,9 +98,9 @@ inline CThreadPool::CThreadPool ( size_t threads ) : stop ( false )
 
 // add new work item to the pool
 template<class F, class... Args>
-auto CThreadPool::enqueue ( F&& f, Args&&... args ) -> std::future<typename std::result_of<F ( Args... )>::type>
+auto CThreadPool::enqueue ( F&& f, Args&&... args ) -> std::future<threadpool_result_t<F, Args...>>
 {
-    using return_type = typename std::result_of<F ( Args... )>::type;
+    using return_type = threadpool_result_t<F, Args...>;
 
     auto task = std::make_shared<std::packaged_task<return_type()>> ( std::bind ( std::forward<F> ( f ), std::forward<Args> ( args )... ) );
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Fixes a deprecation warning for result_of used in threadpool.h, when compiling in C++17 or later. In this case, invoke_result_t should be used instead, with slightly different syntax. In the CI with this change, invoke_result_t is used for Android and macOS, and result_of is used on Linux, macOS Legacy, iOS and Windows.

CHANGELOG: Internals: fix deprecation warnings in threadpool.h for C++17 onwards

**Context: Fixes an issue?**

I discovered this deprecation while compiling on FreeBSD 15, and subsequently noticed it also occurs in the CI build for macOS (non-legacy). Thanks to ChatGPT for the suggested fix.

**Does this change need documentation? What needs to be documented and how?**

No. Compilation enhancement only.

**Status of this Pull Request**

Tested locally and on all CI platforms.

**What is missing until this pull request can be merged?**

Nothing.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
