### PR TITLE
Fix spurious version update message display

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -825,25 +825,31 @@ void CClientDlg::OnVersionAndOSReceived ( COSUtil::EOpSystemType, QString strVer
 
 void CClientDlg::OnCLVersionAndOSReceived ( CHostAddress InetAddr, COSUtil::EOpSystemType, QString strVersion )
 {
-    // display version in connect dialog
-    ConnectDlg.SetServerVersionResult ( InetAddr, strVersion );
-
-    // update check
-#if ( QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 ) ) && !defined( DISABLE_VERSION_CHECK )
-    int            mySuffixIndex;
-    QVersionNumber myVersion = QVersionNumber::fromString ( VERSION, &mySuffixIndex );
-
-    int            serverSuffixIndex;
-    QVersionNumber serverVersion = QVersionNumber::fromString ( strVersion, &serverSuffixIndex );
-
-    // only compare if the server version has no suffix (such as dev or beta)
-    if ( strVersion.size() == serverSuffixIndex && QVersionNumber::compare ( serverVersion, myVersion ) > 0 )
+    // if connect dialog showing, pass version to it, and don't do update check
+    if ( bConnectDlgWasShown )
     {
-        // show the label and hide it after one minute again
-        lblUpdateCheck->show();
-        QTimer::singleShot ( 60000, [this]() { lblUpdateCheck->hide(); } );
+        // display version in connect dialog
+        ConnectDlg.SetServerVersionResult ( InetAddr, strVersion );
     }
+    else
+    {
+        // update check
+#if ( QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 ) ) && !defined( DISABLE_VERSION_CHECK )
+        int            mySuffixIndex;
+        QVersionNumber myVersion = QVersionNumber::fromString ( VERSION, &mySuffixIndex );
+
+        int            serverSuffixIndex;
+        QVersionNumber serverVersion = QVersionNumber::fromString ( strVersion, &serverSuffixIndex );
+
+        // only compare if the server version has no suffix (such as dev or beta)
+        if ( strVersion.size() == serverSuffixIndex && QVersionNumber::compare ( serverVersion, myVersion ) > 0 )
+        {
+            // show the label and hide it after one minute again
+            lblUpdateCheck->show();
+            QTimer::singleShot ( 60000, [this]() { lblUpdateCheck->hide(); } );
+        }
 #endif
+    }
 }
 
 void CClientDlg::OnChatTextReceived ( QString strChatText )


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This prevents the client from reporting an available update just because a random server in a directory has been given an unofficial higher version number. This was a regression between 3.11.0 and 3.12.0

CHANGELOG: Client: Fix occasional spurious version update message display

**Context: Fixes an issue?**

Fixes #3690
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

No, bugfix only

**Status of this Pull Request**

Ready for review

**What is missing until this pull request can be merged?**

Testing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
