### PR TITLE
make server version string searchable

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -736,6 +736,12 @@ void CConnectDlg::UpdateListFilter()
                     bFilterFound = true;
                 }
 
+                // search version
+                if ( pCurListViewItem->text ( LVC_VERSION ).indexOf ( sFilterText, 0, Qt::CaseInsensitive ) >= 0 )
+                {
+                    bFilterFound = true;
+                }
+
                 // search children
                 for ( int iCCnt = 0; iCCnt < pCurListViewItem->childCount(); iCCnt++ )
                 {


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

This makes the server version string searchable in the connect dialogue.  
Useful for searching for servers with a desired version.

<!-- Explain what your PR does -->

CHANGELOG: Make server version string searchable

**Context: Fixes an issue?**

This makes it possible to filter for the desired server version in the connect dialogue

**Does this change need documentation? What needs to be documented and how?**

No, as this is just a UX bug fix

**Status of this Pull Request**

Final

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
