### PR TITLE
Remove unused default constructor in threadpool.h to fix AI finding

### DIFF
--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -49,7 +49,6 @@ using threadpool_result_t = typename std::result_of<F ( Args... )>::type;
 class CThreadPool
 {
 public:
-    CThreadPool() = default;
     CThreadPool ( size_t );
     template<class F, class... Args>
     auto enqueue ( F&& f, Args&&... args ) -> std::future<threadpool_result_t<F, Args...>>;


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Removes the unneeded default constructor for CThreadPool

<!-- Explain what your PR does -->

CHANGELOG: SKIP

**Context: Fixes an issue?**

AI code review correctly deduced that the default constructor leaves class members uninitialised, specifically `stop`.
This default constructor is never used within Jamulus, and the proper constructor `CThreadPool(size_t)` correctly does initialise `stop`.

Supersedes and closes #3686

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Tested and ready

**What is missing until this pull request can be merged?**

Nothing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
