### PR TITLE
Remove invalid mention of "mach" on linux

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -36,7 +36,7 @@
 #    include <mach/mach_error.h>
 #    include <mach/mach_time.h>
 #else
-// using mach nanosleep for Linux
+// using nanosleep for Linux
 #    include <sys/time.h>
 #endif
 #include <QCoreApplication>


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/jamulussoftware/jamulus/security/quality/ai-findings)._