### PR TITLE
fix: GetConCliParam skips channels not yet identified

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -78,6 +78,7 @@ public:
 
     void ResetTimeOutCounter() { iConTimeOut = iConTimeOutStartVal; }
     bool IsConnected() const { return iConTimeOut > 0; }
+    bool IsIdentified() const { return bIsIdentified; }
     void Disconnect();
 
     void SetEnable ( const bool bNEnStat );

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1533,7 +1533,7 @@ void CServer::GetConCliParam ( CVector<CHostAddress>&     vecHostAddresses,
     // check all possible channels
     for ( int i = 0; i < iMaxNumChannels; i++ )
     {
-        if ( vecChannels[i].IsConnected() )
+        if ( vecChannels[i].IsConnected() && vecChannels[i].IsIdentified() )
         {
             // get requested data
             vecHostAddresses[i]      = vecChannels[i].GetAddress();


### PR DESCRIPTION
## Problem

`GetConCliParam` (the backend for the `jamulusserver/getClients` JSON-RPC method and the GUI connected-clients list) filters channels with `IsConnected()` only.

`IsConnected()` becomes `true` as soon as the first UDP audio packet arrives. But `bIsIdentified` is only set `true` inside `SetChanInfo()`, which is called after the server sends `ReqChanInfo` and the client responds with its `CHANNEL_INFO` protocol message — typically one round-trip (20–200 ms) later.

During that window, `GetConCliParam` returns a default-constructed `CChannelCoreInfo` for the joining channel: empty name, `QLocale::AnyCountry`, and instrument 0 (`GetNotUsedInstrument()`). Any consumer reading the connected-clients list in that window gets stale data.

## Fix

- Add `IsIdentified() const` public getter to `CChannel` (mirrors the existing `IsConnected()` getter)
- Gate `GetConCliParam` on `IsConnected() && IsIdentified()`

Channels in the pre-identification window become invisible to `GetConCliParam` until their full profile is committed. This is consistent with the existing gate in `PrepAndSendPacket`, which already withholds audio delivery from unidentified channels.

The `serverdlg.cpp` GUI path also calls `GetConCliParam` and receives the fix automatically.

## Testing

Verified that a newly connecting client does not appear in `getClients` output until name, country, and instrument are all populated.