### PR TITLE
Remove unused sMidiCtlChar

### DIFF
--- a/src/sound/soundbase.cpp
+++ b/src/sound/soundbase.cpp
@@ -24,18 +24,6 @@
 
 #include "soundbase.h"
 
-// This is used as a lookup table for parsing option letters, mapping
-// a single character to an EMidiCtlType
-char const sMidiCtlChar[] = {
-    // Has to follow order of EMidiCtlType
-    /* [EMidiCtlType::Fader]       = */ 'f',
-    /* [EMidiCtlType::Pan]         = */ 'p',
-    /* [EMidiCtlType::Solo]        = */ 's',
-    /* [EMidiCtlType::Mute]        = */ 'm',
-    /* [EMidiCtlType::MuteMyself]  = */ 'o',
-    /* [EMidiCtlType::Device]      = */ 'd',
-    /* [EMidiCtlType::None]        = */ '\0' };
-
 /* Implementation *************************************************************/
 CSoundBase::CSoundBase ( const QString& strNewSystemDriverTechniqueName,
                          void ( *fpNewProcessCallback ) ( CVector<int16_t>& psData, void* pParg ),


### PR DESCRIPTION


<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Removes the unused array `sMidiCtlChar` from `src/sound/soundbase.cpp`

CHANGELOG: Internal: Removed unused array to silence compiler warning.

**Context: Fixes an issue?**

This became unused in PR #3502 MIDI update, but was not removed at the time. Some compilers, notably clang++ on Mac, emit a warning because it is unused.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Ready

**What is missing until this pull request can be merged?**

Nothing. Trivial change, and compiles correctly.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
