### PR TITLE
Add jamulusserver/getSilenceStatus RPC endpoint

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -660,6 +660,20 @@ void CServer::OnTimer()
         // calculate levels for all connected clients
         const bool bSendChannelLevels = CreateLevelsForAllConChannels ( iNumClients, vecNumAudioChannels, vecvecsData, vecChannelLevels );
 
+        {
+            bool bAnyActivity = false;
+            for ( int j = 0; j < iNumClients && !bAnyActivity; j++ )
+            {
+                const int iDataSize = vecvecsData[j].Size();
+                for ( int k = 0; k < iDataSize && !bAnyActivity; k++ )
+                {
+                    if ( vecvecsData[j][k] < -100 || vecvecsData[j][k] > 100 ) bAnyActivity = true;
+                }
+            }
+            if ( bAnyActivity ) m_iLastAudioActivityMs = QDateTime::currentMSecsSinceEpoch();
+            m_bIsSilent = ( QDateTime::currentMSecsSinceEpoch() - m_iLastAudioActivityMs ) > 2000;
+        }
+
         for ( int iChanCnt = 0; iChanCnt < iNumClients; iChanCnt++ )
         {
             // get actual ID of current channel
@@ -731,6 +745,8 @@ void CServer::OnTimer()
     {
         // Disable server if no clients are connected. In this case the server
         // does not consume any significant CPU when no client is connected.
+        m_iLastAudioActivityMs = QDateTime::currentMSecsSinceEpoch();
+        m_bIsSilent            = false;
         Stop();
     }
 }

--- a/src/server.h
+++ b/src/server.h
@@ -155,6 +155,8 @@ public:
     }
     QString GetRecordingDir() { return JamController.GetRecordingDir(); }
 
+    bool GetIsSilent() const { return m_bIsSilent; }
+
     void    SetWelcomeMessage ( const QString& strNWelcMess );
     QString GetWelcomeMessage() { return strWelcomeMessage; }
 
@@ -311,6 +313,9 @@ protected:
     CSignalHandler* pSignalHandler;
 
     std::unique_ptr<CThreadPool> pThreadPool;
+
+    bool   m_bIsSilent        = false;
+    qint64 m_iLastAudioActivityMs = 0;
 
 signals:
     void Started();

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -270,6 +270,15 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
         response["result"] = "acknowledged";
         Q_UNUSED ( params );
     } );
+
+    /// @rpc_method jamulusserver/getSilenceStatus
+    /// @brief Returns whether the server mix is currently silent.
+    /// @param {object} params - No parameters (empty object).
+    /// @result {boolean} result.silent - True if all connected clients have been below the audio threshold for ≥2 seconds. False if no clients are connected or audio is active.
+    pRpcServer->HandleMethod ( "jamulusserver/getSilenceStatus", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        response["result"] = QJsonObject{ { "silent", pServer->GetIsSilent() } };
+        Q_UNUSED ( params );
+    } );
 }
 
 #if defined( Q_OS_MACOS ) && QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )


### PR DESCRIPTION
## Summary

- Tracks whether the server audio mix has been silent for ≥2 seconds by scanning decoded PCM frames in `OnTimer()`.
- Adds `GetIsSilent()` to `CServer` and two private members (`m_bIsSilent`, `m_iLastAudioActivityMs`).
- Adds `jamulusserver/getSilenceStatus` RPC method returning `{"silent": bool}`.

When no clients are connected the flag resets to `false`.

## Test plan

- [ ] Connect clients playing audio → `getSilenceStatus` returns `{"silent": false}`
- [ ] All clients mute / go quiet for >2 s → returns `{"silent": true}`
- [ ] All clients disconnect → returns `{"silent": false}`
- [ ] Server with no RPC port configured is unaffected (no new required flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)