### PR TITLE
feat: add CLM request for channel level list (message ID 1025)

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -922,6 +922,10 @@ void CProtocol::ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMe
         EvaluateCLChannelLevelListMes ( InetAddr, vecbyMesBodyData );
         break;
 
+    case PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST:
+        EvaluateCLReqChannelLevelListMes ( InetAddr );
+        break;
+
     case PROTMESSID_CLM_REGISTER_SERVER_RESP:
         EvaluateCLRegisterServerResp ( InetAddr, vecbyMesBodyData );
         break;
@@ -2559,6 +2563,13 @@ bool CProtocol::EvaluateCLChannelLevelListMes ( const CHostAddress& InetAddr, co
 
     // invoke message action
     emit CLChannelLevelListReceived ( InetAddr, vecLevelList );
+
+    return false; // no error
+}
+
+bool CProtocol::EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr )
+{
+    emit CLReqChannelLevelList ( InetAddr );
 
     return false; // no error
 }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -977,10 +977,6 @@ void CProtocol::ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMe
         EvaluateCLChannelLevelListMes ( InetAddr, vecbyMesBodyData );
         break;
 
-    case PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST:
-        EvaluateCLReqChannelLevelListMes ( InetAddr );
-        break;
-
     case PROTMESSID_CLM_REGISTER_SERVER_RESP:
         EvaluateCLRegisterServerResp ( InetAddr, vecbyMesBodyData );
         break;
@@ -991,6 +987,10 @@ void CProtocol::ParseConnectionLessMessageBody ( const CVector<uint8_t>& vecbyMe
 
     case PROTMESSID_CLM_REQ_WELCOME_MESSAGE:
         EvaluateCLReqWelcomeMessageMes ( InetAddr );
+        break;
+
+    case PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST:
+        EvaluateCLReqChannelLevelListMes ( InetAddr );
         break;
     }
 }
@@ -2630,13 +2630,6 @@ bool CProtocol::EvaluateCLChannelLevelListMes ( const CHostAddress& InetAddr, co
     return false; // no error
 }
 
-bool CProtocol::EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr )
-{
-    emit CLReqChannelLevelList ( InetAddr );
-
-    return false; // no error
-}
-
 void CProtocol::CreateCLRegisterServerResp ( const CHostAddress& InetAddr, const ESvrRegResult eResult )
 {
     int              iPos = 0; // init position pointer
@@ -2717,6 +2710,14 @@ void CProtocol::CreateCLWelcomeMessageMes ( const CHostAddress& InetAddr, const 
     PutStringUTF8OnStream ( vecData, iPos, strUTF8WelcomeMessage );
 
     CreateAndImmSendConLessMessage ( PROTMESSID_CLM_WELCOME_MESSAGE, vecData, InetAddr );
+}
+
+bool CProtocol::EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr )
+{
+    // invoke message action
+    emit CLReqChannelLevelList ( InetAddr );
+
+    return false; // no error
 }
 
 /******************************************************************************\

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -484,6 +484,14 @@ CONNECTION LESS MESSAGES
 
     note: does not have any data -> n = 0
 
+
+- PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST: Request the channel level list
+
+    note: does not have any data -> n = 0
+
+    the server replies with one PROTMESSID_CLM_CHANNEL_LEVEL_LIST to the
+    requesting address
+
 */
 
 #include "protocol.h"

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -83,8 +83,8 @@
 #define PROTMESSID_CLM_CHANNEL_LEVEL_LIST     1015 // channel level list
 #define PROTMESSID_CLM_REGISTER_SERVER_RESP   1016 // status of server registration request
 #define PROTMESSID_CLM_REGISTER_SERVER_EX     1017 // register server with extended information
-#define PROTMESSID_CLM_RED_SERVER_LIST           1018 // reduced server list
-#define PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST   1028 // request channel level list (connectionless)
+#define PROTMESSID_CLM_RED_SERVER_LIST        1018 // reduced server list
+#define PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST 1028 // request channel level list (connectionless)
 
 // special IDs
 #define PROTMESSID_SPECIAL_SPLIT_MESSAGE 2001 // a container for split messages

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -83,7 +83,8 @@
 #define PROTMESSID_CLM_CHANNEL_LEVEL_LIST     1015 // channel level list
 #define PROTMESSID_CLM_REGISTER_SERVER_RESP   1016 // status of server registration request
 #define PROTMESSID_CLM_REGISTER_SERVER_EX     1017 // register server with extended information
-#define PROTMESSID_CLM_RED_SERVER_LIST        1018 // reduced server list
+#define PROTMESSID_CLM_RED_SERVER_LIST           1018 // reduced server list
+#define PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST   1028 // request channel level list (connectionless)
 
 // special IDs
 #define PROTMESSID_SPECIAL_SPLIT_MESSAGE 2001 // a container for split messages
@@ -281,6 +282,7 @@ protected:
     bool EvaluateCLConnClientsListMes ( const CHostAddress& InetAddr, const CVector<uint8_t>& vecData );
     bool EvaluateCLReqConnClientsListMes ( const CHostAddress& InetAddr );
     bool EvaluateCLChannelLevelListMes ( const CHostAddress& InetAddr, const CVector<uint8_t>& vecData );
+    bool EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr );
     bool EvaluateCLRegisterServerResp ( const CHostAddress& InetAddr, const CVector<uint8_t>& vecData );
 
     int iOldRecID;
@@ -348,5 +350,6 @@ signals:
     void CLConnClientsListMesReceived ( CHostAddress InetAddr, CVector<CChannelInfo> vecChanInfo );
     void CLReqConnClientsList ( CHostAddress InetAddr );
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
+    void CLReqChannelLevelList ( CHostAddress InetAddr );
     void CLRegisterServerResp ( CHostAddress InetAddr, ESvrRegResult eStatus );
 };

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -106,11 +106,11 @@
 #define PROTMESSID_CLM_REGISTER_SERVER_RESP   1016 // status of server registration request
 #define PROTMESSID_CLM_REGISTER_SERVER_EX     1017 // register server with extended information
 #define PROTMESSID_CLM_RED_SERVER_LIST        1018 // reduced server list
-#define PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST 1028 // request channel level list (connectionless)
 #define PROTMESSID_CLM_SERVER_FEATURES        1019 // server features message
 #define PROTMESSID_CLM_REQ_SERVER_FEATURES    1020 // request server features
 #define PROTMESSID_CLM_WELCOME_MESSAGE        1021 // server welcome message
 #define PROTMESSID_CLM_REQ_WELCOME_MESSAGE    1022 // request server welcome message
+#define PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST 1025 // request channel level list (connectionless)
 
 // special IDs
 #define PROTMESSID_SPECIAL_SPLIT_MESSAGE 2001 // a container for split messages

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -310,10 +310,10 @@ protected:
     bool EvaluateCLConnClientsListMes ( const CHostAddress& InetAddr, const CVector<uint8_t>& vecData );
     bool EvaluateCLReqConnClientsListMes ( const CHostAddress& InetAddr );
     bool EvaluateCLChannelLevelListMes ( const CHostAddress& InetAddr, const CVector<uint8_t>& vecData );
-    bool EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr );
     bool EvaluateCLRegisterServerResp ( const CHostAddress& InetAddr, const CVector<uint8_t>& vecData );
     bool EvaluateCLReqServerFeaturesMes ( const CHostAddress& InetAddr );
     bool EvaluateCLReqWelcomeMessageMes ( const CHostAddress& InetAddr );
+    bool EvaluateCLReqChannelLevelListMes ( const CHostAddress& InetAddr );
 
     int iOldRecID;
     int iOldRecCnt;
@@ -380,8 +380,8 @@ signals:
     void CLConnClientsListMesReceived ( CHostAddress InetAddr, CVector<CChannelInfo> vecChanInfo );
     void CLReqConnClientsList ( CHostAddress InetAddr );
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
-    void CLReqChannelLevelList ( CHostAddress InetAddr );
     void CLRegisterServerResp ( CHostAddress InetAddr, ESvrRegResult eStatus );
     void CLReqServerFeatures ( CHostAddress InetAddr );
     void CLReqWelcomeMessage ( CHostAddress InetAddr );
+    void CLReqChannelLevelList ( CHostAddress InetAddr );
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -280,6 +280,8 @@ CServer::CServer ( const int          iNewMaxNumChan,
 
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqConnClientsList, this, &CServer::OnCLReqConnClientsList );
 
+    QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqChannelLevelList, this, &CServer::OnCLReqChannelLevelList );
+
     QObject::connect ( &ServerListManager, &CServerListManager::SvrRegStatusChanged, this, &CServer::SvrRegStatusChanged );
 
     QObject::connect ( &JamController, &recorder::CJamController::RestartRecorder, this, &CServer::RestartRecorder );

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -292,10 +292,11 @@ CServer::CServer ( const int          iNewMaxNumChan,
 
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqConnClientsList, this, &CServer::OnCLReqConnClientsList );
 
-    QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqChannelLevelList, this, &CServer::OnCLReqChannelLevelList );
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqServerFeatures, this, &CServer::OnCLReqServerFeatures );
 
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqWelcomeMessage, this, &CServer::OnCLReqWelcomeMessage );
+
+    QObject::connect ( &ConnLessProtocol, &CProtocol::CLReqChannelLevelList, this, &CServer::OnCLReqChannelLevelList );
 
     QObject::connect ( &ServerListManager, &CServerListManager::SvrRegStatusChanged, this, &CServer::SvrRegStatusChanged );
 

--- a/src/server.h
+++ b/src/server.h
@@ -366,6 +366,8 @@ public slots:
 
     void OnCLReqConnClientsList ( CHostAddress InetAddr ) { ConnLessProtocol.CreateCLConnClientsListMes ( InetAddr, CreateChannelList() ); }
 
+    void OnCLReqChannelLevelList ( CHostAddress InetAddr ) { ConnLessProtocol.CreateCLChannelLevelListMes ( InetAddr, vecChannelLevels, GetNumberOfConnectedClients() ); }
+
     void OnCLRegisterServerReceived ( CHostAddress InetAddr, CHostAddress LInetAddr, CServerCoreInfo ServerInfo )
     {
         ServerListManager.Append ( InetAddr, LInetAddr, ServerInfo );

--- a/src/server.h
+++ b/src/server.h
@@ -366,7 +366,10 @@ public slots:
 
     void OnCLReqConnClientsList ( CHostAddress InetAddr ) { ConnLessProtocol.CreateCLConnClientsListMes ( InetAddr, CreateChannelList() ); }
 
-    void OnCLReqChannelLevelList ( CHostAddress InetAddr ) { ConnLessProtocol.CreateCLChannelLevelListMes ( InetAddr, vecChannelLevels, GetNumberOfConnectedClients() ); }
+    void OnCLReqChannelLevelList ( CHostAddress InetAddr )
+    {
+        ConnLessProtocol.CreateCLChannelLevelListMes ( InetAddr, vecChannelLevels, GetNumberOfConnectedClients() );
+    }
 
     void OnCLRegisterServerReceived ( CHostAddress InetAddr, CHostAddress LInetAddr, CServerCoreInfo ServerInfo )
     {

--- a/src/server.h
+++ b/src/server.h
@@ -383,11 +383,6 @@ public slots:
 
     void OnCLReqConnClientsList ( CHostAddress InetAddr ) { ConnLessProtocol.CreateCLConnClientsListMes ( InetAddr, CreateChannelList() ); }
 
-    void OnCLReqChannelLevelList ( CHostAddress InetAddr )
-    {
-        ConnLessProtocol.CreateCLChannelLevelListMes ( InetAddr, vecChannelLevels, GetNumberOfConnectedClients() );
-    }
-
     void OnCLRegisterServerReceived ( CHostAddress InetAddr, CHostAddress LInetAddr, CServerCoreInfo ServerInfo )
     {
         ServerListManager.Append ( InetAddr, LInetAddr, ServerInfo );
@@ -409,6 +404,11 @@ public slots:
     void OnCLReqServerFeatures ( CHostAddress InetAddr );
 
     void OnCLReqWelcomeMessage ( CHostAddress InetAddr );
+
+    void OnCLReqChannelLevelList ( CHostAddress InetAddr )
+    {
+        ConnLessProtocol.CreateCLChannelLevelListMes ( InetAddr, vecChannelLevels, GetNumberOfConnectedClients() );
+    }
 
     void OnCLDisconnection ( CHostAddress InetAddr );
 


### PR DESCRIPTION
**🤖 AI:** Adds `PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST` (ID 1025): a new connectionless message that causes a server to immediately reply with the existing `PROTMESSID_CLM_CHANNEL_LEVEL_LIST` (ID 1015) response.

This follows the established CLM request/response pattern used by:
- `CLReqConnClientsList` (1014) → `CLConnClientsList` (1013)
- `CLReqVersionAndOS` (1012) → `CLVersionAndOS` (1011)
- `CLReqServerList` (1007) → `CLRedServerList` (1018) and `CLServerList` (1006)

Numbered 1025: the CLM block runs 1001 to 1022 with no gaps, and 1023 and 1024 are taken by #3636.

The name is not new. The protocol documentation in `protocol.cpp` has referred to `PROTMESSID_CLM_REQ_CHANNEL_LEVEL_LIST` since a7a1549f (2020), at lines 437 and 440, for a message that was never defined. Message 28 is its connected-mode counterpart: `CClient::OnNewConnection` still sends it, and it is kept only for servers 3.4.6 to 3.5.12.

## Implementation

4 files, 28 lines:

- `protocol.h` — define ID 1025, declare evaluator, declare signal
- `protocol.cpp` — document the message in the reference block, add switch case, and one-line `EvaluateCLReqChannelLevelListMes` that emits the signal
- `server.h` — one-line `OnCLReqChannelLevelList` slot that calls the existing `CreateCLChannelLevelListMes`
- `server.cpp` — connect signal to slot

**Zero additional computation.** `vecChannelLevels` is already computed every server tick in `OnTimer()`. The handler simply forwards that existing data to the requester.

## Use case

A monitoring tool can poll the activity level on any Jamulus server by sending a single UDP datagram to the server's game port and reading the nibble-packed level list in the 1015 response. No audio connection, no additional open ports, no configuration required.

The 1015 response already encodes the number of connected clients implicitly (the list length), so the caller can detect idle servers (no clients) versus quiet ones (clients present but all levels ≤ threshold).

## Relation to prior PR

This supersedes #3724.

---

🤖 *This message was written by AI and reviewed by @mcfnord.*