### PR TITLE
Add jamulusserver/privateChatMessage RPC method for sending messages to single channels

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -344,7 +344,7 @@ Results:
 
 ### jamulusserver/broadcastChatMessage
 
-Sends a message (as the server) to all connected clients. This can be used to broadcast messages from external sources (e.g. scripts or  monitoring tools).
+Sends a message (as the server) to all connected clients. This can be used to broadcast messages from external sources (e.g. scripts or monitoring tools).
 
 Parameters:
 
@@ -445,7 +445,7 @@ Results:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| result | string | Always "ok". |
+| result | string | "ok" or "error" if bad arguments. |
 
 
 ### jamulusserver/restartRecording

--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -430,6 +430,24 @@ Results:
 | result.registrationStatus | string | The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus). |
 
 
+### jamulusserver/privateChatMessage
+
+Sends a chat message to a single connected client.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.chatMessage | string | The chat message text. |
+| params.id | number | The client's channel id. |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | Always "ok". |
+
+
 ### jamulusserver/restartRecording
 
 Restarts the recording into a new directory.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1381,16 +1381,13 @@ void CServer::SendChatTextToAllConChannels ( const int iSendingChanID, const QSt
 
 bool CServer::SendChatTextToConChannel ( const int iCurChanID, const QString& strChatText )
 {
-    if ( MathUtils::InRange<int> ( iCurChanID, 0, iMaxNumChannels - 1 ) && vecChannels[iCurChanID].IsConnected() )
+    if ( !MathUtils::InRange<int> ( iCurChanID, 0, iMaxNumChannels - 1 ) || !vecChannels[iCurChanID].IsConnected() )
     {
-        // send message
-        vecChannels[iCurChanID].CreateChatTextMes ( strChatText );
+        return false;
     }
-    else
-    {
-        return true;
-    }
-    return false;
+    // send message
+    vecChannels[iCurChanID].CreateChatTextMes ( strChatText );
+    return true;
 }
 
 void CServer::CreateAndSendRecorderStateForAllConChannels()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1379,13 +1379,18 @@ void CServer::SendChatTextToAllConChannels ( const int iSendingChanID, const QSt
     emit sentChatMessage ( iSendingChanID, strChatText );
 }
 
-void CServer::SendChatTextToConChannel ( const int iCurChanID, const QString& strChatText )
+bool CServer::SendChatTextToConChannel ( const int iCurChanID, const QString& strChatText )
 {
     if ( MathUtils::InRange<int> ( iCurChanID, 0, iMaxNumChannels - 1 ) && vecChannels[iCurChanID].IsConnected() )
     {
         // send message
         vecChannels[iCurChanID].CreateChatTextMes ( strChatText );
     }
+    else
+    {
+        return true;
+    }
+    return false;
 }
 
 void CServer::CreateAndSendRecorderStateForAllConChannels()

--- a/src/server.h
+++ b/src/server.h
@@ -192,7 +192,7 @@ public:
     bool IsDelayPanningEnabled() { return bDelayPan; }
 
     void SendChatTextToAllConChannels ( const int iSendingChanID, const QString& strChatText );
-    void SendChatTextToConChannel ( const int iCurChanID, const QString& strChatText );
+    bool SendChatTextToConChannel ( const int iCurChanID, const QString& strChatText );
 
 protected:
     // access functions for actual channels

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -113,6 +113,28 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
         response["result"] = "ok";
     } );
 
+    /// @rpc_method jamulusserver/privateChatMessage
+    /// @brief Sends a chat message to a single connected client.
+    /// @param {string} params.chatMessage - The chat message text.
+    /// @param {number} params.id - The client's channel id.
+    /// @result {string} result - Always "ok".
+    pRpcServer->HandleMethod ( "jamulusserver/privateChatMessage", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        auto      jsonChatMessage = params["chatMessage"];
+        const int id              = params["id"].toInt();
+        if ( !jsonChatMessage.isString() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: chatMessage is not a string" );
+            return;
+        }
+
+        if ( pServer->SendChatTextToConChannel ( id, jsonChatMessage.toString() ) )
+        {
+            response["error"] = "invalid channel ID";
+            return;
+        }
+        response["result"] = "ok";
+    } );
+
     /// @rpc_method jamulusserver/getRecorderStatus
     /// @brief Returns the recorder state.
     /// @param {object} params - No parameters (empty object).
@@ -348,24 +370,6 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
         pServer->RequestNewRecording();
         response["result"] = "acknowledged";
         Q_UNUSED ( params );
-    } );
-
-    /// @rpc_method jamulusserver/privateChatMessage
-    /// @brief Sends a chat message to a single connected client.
-    /// @param {string} params.chatMessage - The chat message text.
-    /// @param {number} params.id - The client's channel id.
-    /// @result {string} result - Always "ok".
-    pRpcServer->HandleMethod ( "jamulusserver/privateChatMessage", [=] ( const QJsonObject& params, QJsonObject& response ) {
-        auto      jsonChatMessage = params["chatMessage"];
-        const int id              = params["id"].toInt();
-        if ( !jsonChatMessage.isString() )
-        {
-            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: chatMessage is not a string" );
-            return;
-        }
-
-        pServer->SendChatTextToConChannel ( id, jsonChatMessage.toString() );
-        response["result"] = "ok";
     } );
 }
 

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -117,7 +117,7 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
     /// @brief Sends a chat message to a single connected client.
     /// @param {string} params.chatMessage - The chat message text.
     /// @param {number} params.id - The client's channel id.
-    /// @result {string} result - Always "ok".
+    /// @result {string} result - "ok" or "error" if bad arguments.
     pRpcServer->HandleMethod ( "jamulusserver/privateChatMessage", [=] ( const QJsonObject& params, QJsonObject& response ) {
         auto          jsonChatMessage = params["chatMessage"];
         const int     id              = params["id"].toInt ( INVALID_CLIENT_ID );

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -349,6 +349,24 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
         response["result"] = "acknowledged";
         Q_UNUSED ( params );
     } );
+
+    /// @rpc_method jamulusserver/privateChatMessage
+    /// @brief Sends a chat message to a single connected client.
+    /// @param {string} params.chatMessage - The chat message text.
+    /// @param {number} params.id - The client's channel id.
+    /// @result {string} result - Always "ok".
+    pRpcServer->HandleMethod ( "jamulusserver/privateChatMessage", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        auto      jsonChatMessage = params["chatMessage"];
+        const int id              = params["id"].toInt();
+        if ( !jsonChatMessage.isString() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: chatMessage is not a string" );
+            return;
+        }
+
+        pServer->SendChatTextToConChannel ( id, jsonChatMessage.toString() );
+        response["result"] = "ok";
+    } );
 }
 
 #if defined( Q_OS_MACOS ) && QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -129,7 +129,7 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
             return;
         }
 
-        if ( pServer->SendChatTextToConChannel ( id, chatMessage ) )
+        if ( !pServer->SendChatTextToConChannel ( id, chatMessage ) )
         {
             response["error"] = "invalid channel ID";
             return;

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -119,15 +119,17 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
     /// @param {number} params.id - The client's channel id.
     /// @result {string} result - Always "ok".
     pRpcServer->HandleMethod ( "jamulusserver/privateChatMessage", [=] ( const QJsonObject& params, QJsonObject& response ) {
-        auto      jsonChatMessage = params["chatMessage"];
-        const int id              = params["id"].toInt();
-        if ( !jsonChatMessage.isString() )
+        auto          jsonChatMessage = params["chatMessage"];
+        const int     id              = params["id"].toInt ( INVALID_CLIENT_ID );
+        const QString chatMessage     = jsonChatMessage.toString();
+        if ( chatMessage.isEmpty() || chatMessage.size() > MAX_LEN_CHAT_TEXT )
         {
-            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: chatMessage is not a string" );
+            response["error"] =
+                CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: chatMessage is not a string or malformed" );
             return;
         }
 
-        if ( pServer->SendChatTextToConChannel ( id, jsonChatMessage.toString() ) )
+        if ( pServer->SendChatTextToConChannel ( id, chatMessage ) )
         {
             response["error"] = "invalid channel ID";
             return;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This makes it possible to query the server over RPC to send a chat text to a connected channel. The method takes the chat text and the channel id as arguments.

CHANGELOG: Add jamulusserver/privateChatMessage RPC method for sending messages to single channels

**Context: Fixes an issue?**
No

**Does this change need documentation? What needs to be documented and how?**

Part of auto generated RPC docs

**Status of this Pull Request**

Requesting review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [X] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [X] I tested my code and it does what I want
-  [X] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [X] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
