### PR TITLE
Fix extra space generated by "generate_json_rpc_docs.py"

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -258,7 +258,7 @@ Results:
 
 ### jamulusclient/setFaderLevel
 
-Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level":  50}}.
+Sets the fader level. Example: {"id":1,"jsonrpc":"2.0","method":"jamulusclient/setFaderLevel","params":{"channelIndex": 0,"level": 50}}.
 
 Parameters:
 
@@ -391,7 +391,7 @@ Results:
 | result.countryId | number | The server country ID (see QLocale::Country). |
 | result.welcomeMessage | string | The server welcome message. |
 | result.directoryType | string | The directory type as a string (see EDirectoryType and SerializeDirectoryType). |
-| result.directoryAddress | string | The string used to look up the directory address (only assume valid if directoryType is "custom"  and registrationStatus is "registered"). |
+| result.directoryAddress | string | The string used to look up the directory address (only assume valid if directoryType is "custom" and registrationStatus is "registered"). |
 | result.directory | string | The directory with which this server requested registration, or blank if none. |
 | result.registrationStatus | string | The server registration status as string (see ESvrRegStatus and SerializeRegistrationStatus). |
 
@@ -410,7 +410,7 @@ Results:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| result | string | Always "acknowledged".   To check if the recording was restarted or if there is any error, call `jamulusserver/getRecorderStatus` again. |
+| result | string | Always "acknowledged". To check if the recording was restarted or if there is any error, call `jamulusserver/getRecorderStatus` again. |
 
 
 ### jamulusserver/setDirectory
@@ -445,7 +445,7 @@ Results:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| result | string | Always "acknowledged".   To check if the directory was changed, call `jamulusserver/getRecorderStatus` again. |
+| result | string | Always "acknowledged". To check if the directory was changed, call `jamulusserver/getRecorderStatus` again. |
 
 
 ### jamulusserver/setServerName
@@ -496,7 +496,7 @@ Results:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| result | string | Always "acknowledged".   To check if the recording was enabled, call `jamulusserver/getRecorderStatus` again. |
+| result | string | Always "acknowledged". To check if the recording was enabled, call `jamulusserver/getRecorderStatus` again. |
 
 
 ### jamulusserver/stopRecording
@@ -513,7 +513,7 @@ Results:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| result | string | Always "acknowledged".   To check if the recording was disabled, call `jamulusserver/getRecorderStatus` again. |
+| result | string | Always "acknowledged". To check if the recording was disabled, call `jamulusserver/getRecorderStatus` again. |
 
 
 ## Notification reference
@@ -525,7 +525,7 @@ Parameters:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| params.channelLevelList | array | The channel level list.   Each item corresponds to the respective client retrieved from the jamulusclient/clientListReceived notification. |
+| params.channelLevelList | array | The channel level list. Each item corresponds to the respective client retrieved from the jamulusclient/clientListReceived notification. |
 | params.channelLevelList[*] | number | The channel level, an integer between 0 and 9. |
 
 

--- a/tools/generate_json_rpc_docs.py
+++ b/tools/generate_json_rpc_docs.py
@@ -219,7 +219,7 @@ for source_file in source_files:
                 current_item.handle_tag("result")
                 current_item.handle_text(line[len("/// @result "):])
             elif line.startswith("///"):
-                current_item.handle_text(line[len("///"):])
+                current_item.handle_text(line[len("///"):].lstrip())
             elif line == "":
                 pass
             else:


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

The python tool for generating the RPC documentation adds an extra space character after line breaks starting with /// because it treats the first space character as part of the string, this PR fixes it.

<!-- Explain what your PR does -->

CHANGELOG: Build: Fix extra space generated by "generate_json_rpc_docs.py" in multi line comments

**Does this change need documentation? What needs to be documented and how?**
No

**Status of this Pull Request**

Ready to be merged


## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
