### PR TITLE
Load client settings before --connect startup

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -51,7 +51,6 @@
 /* Implementation *************************************************************/
 CClient::CClient ( const quint16  iPortNumber,
                    const quint16  iQosNumber,
-                   const QString& strConnOnStartupAddress,
                    const bool     bNoAutoJackConnect,
                    const QString& strNClientName,
                    const bool     bNDisableIPv6,
@@ -212,13 +211,6 @@ CClient::CClient ( const quint16  iPortNumber,
     // start the socket (it is important to start the socket after all
     // initializations and connections)
     Socket.Start();
-
-    // do an immediate start if a server address is given
-    if ( !strConnOnStartupAddress.isEmpty() )
-    {
-        SetServerAddr ( strConnOnStartupAddress );
-        Start();
-    }
 }
 
 // MIDI setup will be handled after settings are assigned

--- a/src/client.h
+++ b/src/client.h
@@ -150,7 +150,6 @@ class CClient : public QObject
 public:
     CClient ( const quint16  iPortNumber,
               const quint16  iQosNumber,
-              const QString& strConnOnStartupAddress,
               const bool     bNoAutoJackConnect,
               const QString& strNClientName,
               const bool     bNDisableIPv6,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -951,8 +951,7 @@ int main ( int argc, char** argv )
 #ifndef SERVER_ONLY
         if ( bIsClient )
         {
-            CClient
-                Client ( iPortNumber, iQosNumber, strConnOnStartupAddress, bNoAutoJackConnect, strClientName, bDisableIPv6, bMuteMeInPersonalMix );
+            CClient Client ( iPortNumber, iQosNumber, bNoAutoJackConnect, strClientName, bDisableIPv6, bMuteMeInPersonalMix );
 
             // Create Settings with the client pointer
             CClientSettings Settings ( &Client, strIniFileName );
@@ -988,6 +987,12 @@ int main ( int argc, char** argv )
             else
 #    endif
             {
+                if ( !strConnOnStartupAddress.isEmpty() )
+                {
+                    Client.SetServerAddr ( strConnOnStartupAddress );
+                    Client.Start();
+                }
+
                 // only start application without using the GUI
                 qInfo() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
 


### PR DESCRIPTION
## Summary
- prevent --connect from starting the client from the CClient constructor before INI-backed settings are loaded
- remove the startup-address parameter from CClient so startup connection handling is owned by the post-settings startup paths
- keep GUI startup connection handling in CClientDlg, where the dialog is created after Settings.Load() and Client.SetSettings()
- start the client explicitly in the no-GUI path after settings have been loaded and attached to the client

This ensures startup connection negotiation uses the loaded client settings, including audio channel mode, so stereo-dependent UI/state such as pan controls is not initialized from constructor defaults.

CHANGELOG: Client: Ensure INI file settings are loaded before doing -c/--connect startup.

## Testing
- git diff --check
- make -j2

Fixes #3732