### PR TITLE
Claude: add support for multichannel interfaces on iOS/iPadOS

### DIFF
--- a/src/sound/coreaudio-ios/sound.h
+++ b/src/sound/coreaudio-ios/sound.h
@@ -63,6 +63,14 @@ public:
     virtual void Stop();
     virtual void processBufferList ( AudioBufferList*, CSound* );
 
+    // channel selection (for multichannel input devices)
+    virtual int     GetNumInputChannels() override { return iNumInChan; }
+    virtual QString GetInputChannelName ( const int iDiD ) override { return sChannelNamesInput[iDiD]; }
+    virtual void    SetLeftInputChannel ( const int iNewChan ) override;
+    virtual void    SetRightInputChannel ( const int iNewChan ) override;
+    virtual int     GetLeftInputChannel() override { return iSelInputLeftChannel; }
+    virtual int     GetRightInputChannel() override { return iSelInputRightChannel; }
+
     AudioUnit audioUnit;
 
     // these variables/functions should be protected but cannot since we want
@@ -71,11 +79,16 @@ public:
     int            iCoreAudioBufferSizeMono;
     int            iCoreAudioBufferSizeStereo;
     bool           isInitialized;
+    int            iNumInChan;
+    int            iSelInputLeftChannel;
+    int            iSelInputRightChannel;
+    QString        sChannelNamesInput[MAX_NUM_IN_OUT_CHANNELS];
 
 protected:
     virtual QString LoadAndInitializeDriver ( QString strDriverName, bool );
     void            GetAvailableInOutDevices();
     void            SwitchDevice ( QString strDriverName );
+    void            UpdateInputChannelInfo();
 
     AudioBuffer     buffer;
     AudioBufferList bufferList;

--- a/src/sound/coreaudio-ios/sound.mm
+++ b/src/sound/coreaudio-ios/sound.mm
@@ -79,7 +79,7 @@ CSound::CSound ( void ( *fpNewProcessCallback ) ( CVector<short>& psData, void* 
         QMessageBox::warning ( nullptr, "Sound exception", generr.GetErrorText() );
     }
 
-    // allocate the buffer large enough to hold the maximum number of input
+    // allocate the audio buffer large enough to hold the maximum number of input
     // channels we support (the actual channel count is only known once an
     // input device has been selected and negotiated, see UpdateInputChannelInfo)
     buffer.mNumberChannels    = iNumInChan;

--- a/src/sound/coreaudio-ios/sound.mm
+++ b/src/sound/coreaudio-ios/sound.mm
@@ -237,9 +237,9 @@ int CSound::Init ( const int iCoreAudioBufferSizeMono )
         // channels when a multichannel input device (e.g. a USB audio interface) is
         // selected. iNumInChan was negotiated above in SwitchDevice().
         AudioStreamBasicDescription inputAudioFormat = outputAudioFormat;
-        inputAudioFormat.mChannelsPerFrame            = iNumInChan;
-        inputAudioFormat.mBytesPerPacket              = 4 * iNumInChan; // (sizeof float32) * iNumInChan channels
-        inputAudioFormat.mBytesPerFrame               = 4 * iNumInChan; // (sizeof float32) * iNumInChan channels
+        inputAudioFormat.mChannelsPerFrame           = iNumInChan;
+        inputAudioFormat.mBytesPerPacket             = 4 * iNumInChan; // (sizeof float32) * iNumInChan channels
+        inputAudioFormat.mBytesPerFrame              = 4 * iNumInChan; // (sizeof float32) * iNumInChan channels
 
         // Apply formats
         status = AudioUnitSetProperty ( audioUnit,
@@ -412,8 +412,9 @@ void CSound::SwitchDevice ( QString strDriverName )
     // that multichannel input devices are not limited to stereo
     const NSInteger iMaxChannels = [sessionInstance maximumInputNumberOfChannels];
 
-    [sessionInstance setPreferredInputNumberOfChannels:qBound ( static_cast<NSInteger> ( 1 ), iMaxChannels, static_cast<NSInteger> ( MAX_NUM_IN_OUT_CHANNELS ) )
-                                                  error:&error];
+    [sessionInstance
+        setPreferredInputNumberOfChannels:qBound ( static_cast<NSInteger> ( 1 ), iMaxChannels, static_cast<NSInteger> ( MAX_NUM_IN_OUT_CHANNELS ) )
+                                    error:&error];
 
     UpdateInputChannelInfo();
 }
@@ -431,8 +432,8 @@ void CSound::UpdateInputChannelInfo()
     buffer.mNumberChannels = iNumInChan;
 
     // try to get descriptive names for each channel from the active input port
-    AVAudioSessionPortDescription* inputPort = sessionInstance.currentRoute.inputs.firstObject;
-    NSArray<AVAudioSessionChannelDescription*>* channels = inputPort.channels;
+    AVAudioSessionPortDescription*              inputPort = sessionInstance.currentRoute.inputs.firstObject;
+    NSArray<AVAudioSessionChannelDescription*>* channels  = inputPort.channels;
 
     for ( int i = 0; i < iNumInChan; i++ )
     {

--- a/src/sound/coreaudio-ios/sound.mm
+++ b/src/sound/coreaudio-ios/sound.mm
@@ -52,7 +52,10 @@
 /* Implementation *************************************************************/
 CSound::CSound ( void ( *fpNewProcessCallback ) ( CVector<short>& psData, void* arg ), void* arg, const bool, const QString& ) :
     CSoundBase ( "CoreAudio iOS", fpNewProcessCallback, arg ),
-    isInitialized ( false )
+    isInitialized ( false ),
+    iNumInChan ( 2 ),
+    iSelInputLeftChannel ( 0 ),
+    iSelInputRightChannel ( 1 )
 {
     try
     {
@@ -76,10 +79,18 @@ CSound::CSound ( void ( *fpNewProcessCallback ) ( CVector<short>& psData, void* 
         QMessageBox::warning ( nullptr, "Sound exception", generr.GetErrorText() );
     }
 
-    buffer.mNumberChannels    = 2;
-    buffer.mData              = malloc ( 256 * sizeof ( Float32 ) * buffer.mNumberChannels ); // max size
+    // allocate the buffer large enough to hold the maximum number of input
+    // channels we support (the actual channel count is only known once an
+    // input device has been selected and negotiated, see UpdateInputChannelInfo)
+    buffer.mNumberChannels    = iNumInChan;
+    buffer.mData              = malloc ( 256 * sizeof ( Float32 ) * MAX_NUM_IN_OUT_CHANNELS ); // max size
     bufferList.mNumberBuffers = 1;
     bufferList.mBuffers[0]    = buffer;
+
+    for ( int i = 0; i < MAX_NUM_IN_OUT_CHANNELS; i++ )
+    {
+        sChannelNamesInput[i] = QString ( "Channel %1" ).arg ( i + 1 );
+    }
 }
 
 CSound::~CSound() { free ( buffer.mData ); }
@@ -124,17 +135,24 @@ OSStatus CSound::recordingCallback ( void*                       inRefCon,
     return noErr;
 }
 
-void CSound::processBufferList ( AudioBufferList* inInputData, CSound* pSound ) // got stereo input data
+void CSound::processBufferList ( AudioBufferList* inInputData, CSound* pSound ) // got (possibly multichannel) input data
 {
     QMutexLocker locker ( &pSound->MutexAudioProcessCallback );
     Float32*     pData = static_cast<Float32*> ( inInputData->mBuffers[0].mData );
+
+    // the input device may provide more than two channels (e.g. a multichannel
+    // USB audio interface), in which case we pick the user-selected left and
+    // right channels out of the interleaved buffer
+    const int iNumChan = pSound->buffer.mNumberChannels;
+    const int iLeftCh  = pSound->iSelInputLeftChannel;
+    const int iRightCh = pSound->iSelInputRightChannel;
 
     // copy input data
     for ( int i = 0; i < pSound->iCoreAudioBufferSizeMono; i++ )
     {
         // copy left and right channels separately
-        pSound->vecsTmpAudioSndCrdStereo[2 * i]     = (short) ( pData[2 * i] * _MAXSHORT );     // left
-        pSound->vecsTmpAudioSndCrdStereo[2 * i + 1] = (short) ( pData[2 * i + 1] * _MAXSHORT ); // right
+        pSound->vecsTmpAudioSndCrdStereo[2 * i]     = (short) ( pData[iNumChan * i + iLeftCh] * _MAXSHORT );  // left
+        pSound->vecsTmpAudioSndCrdStereo[2 * i + 1] = (short) ( pData[iNumChan * i + iRightCh] * _MAXSHORT ); // right
     }
     pSound->ProcessCallback ( pSound->vecsTmpAudioSndCrdStereo );
 }
@@ -171,6 +189,12 @@ int CSound::Init ( const int iCoreAudioBufferSizeMono )
         [sessionInstance setPreferredSampleRate:SYSTEM_SAMPLE_RATE_HZ error:&error];
         [[AVAudioSession sharedInstance] setActive:YES error:&error];
 
+        // select the preferred input device (if any was chosen by the user) and
+        // negotiate the number of input channels with it. This must happen before
+        // we configure the audio unit's input stream format below since multichannel
+        // audio interfaces (e.g. USB audio interfaces) may offer more than 2 channels.
+        SwitchDevice ( strCurDevName );
+
         OSStatus status;
 
         // Describe audio component
@@ -197,31 +221,40 @@ int CSound::Init ( const int iCoreAudioBufferSizeMono )
         status = AudioUnitSetProperty ( audioUnit, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, kOutputBus, &flag, sizeof ( flag ) );
         checkStatus ( status );
 
-        // Describe format
-        AudioStreamBasicDescription audioFormat;
-        audioFormat.mSampleRate       = SYSTEM_SAMPLE_RATE_HZ;
-        audioFormat.mFormatID         = kAudioFormatLinearPCM;
-        audioFormat.mFormatFlags      = kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked;
-        audioFormat.mFramesPerPacket  = 1;
-        audioFormat.mChannelsPerFrame = 2;  // stereo, so 2 interleaved channels
-        audioFormat.mBitsPerChannel   = 32; // sizeof float32
-        audioFormat.mBytesPerPacket   = 8;  // (sizeof float32) * 2 channels
-        audioFormat.mBytesPerFrame    = 8;  //(sizeof float32) * 2 channels
+        // Describe playback format (output bus): always stereo, since the device's
+        // speaker/headphone output only ever has 2 channels
+        AudioStreamBasicDescription outputAudioFormat;
+        outputAudioFormat.mSampleRate       = SYSTEM_SAMPLE_RATE_HZ;
+        outputAudioFormat.mFormatID         = kAudioFormatLinearPCM;
+        outputAudioFormat.mFormatFlags      = kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked;
+        outputAudioFormat.mFramesPerPacket  = 1;
+        outputAudioFormat.mChannelsPerFrame = 2;  // stereo, so 2 interleaved channels
+        outputAudioFormat.mBitsPerChannel   = 32; // sizeof float32
+        outputAudioFormat.mBytesPerPacket   = 8;  // (sizeof float32) * 2 channels
+        outputAudioFormat.mBytesPerFrame    = 8;  //(sizeof float32) * 2 channels
 
-        // Apply format
+        // Describe recording format (input bus): may have more than 2 interleaved
+        // channels when a multichannel input device (e.g. a USB audio interface) is
+        // selected. iNumInChan was negotiated above in SwitchDevice().
+        AudioStreamBasicDescription inputAudioFormat = outputAudioFormat;
+        inputAudioFormat.mChannelsPerFrame            = iNumInChan;
+        inputAudioFormat.mBytesPerPacket              = 4 * iNumInChan; // (sizeof float32) * iNumInChan channels
+        inputAudioFormat.mBytesPerFrame               = 4 * iNumInChan; // (sizeof float32) * iNumInChan channels
+
+        // Apply formats
         status = AudioUnitSetProperty ( audioUnit,
                                         kAudioUnitProperty_StreamFormat,
                                         kAudioUnitScope_Output,
                                         kInputBus,
-                                        &audioFormat,
-                                        sizeof ( audioFormat ) );
+                                        &inputAudioFormat,
+                                        sizeof ( inputAudioFormat ) );
         checkStatus ( status );
         status = AudioUnitSetProperty ( audioUnit,
                                         kAudioUnitProperty_StreamFormat,
                                         kAudioUnitScope_Input,
                                         kOutputBus,
-                                        &audioFormat,
-                                        sizeof ( audioFormat ) );
+                                        &outputAudioFormat,
+                                        sizeof ( outputAudioFormat ) );
         checkStatus ( status );
 
         // Set callback
@@ -239,8 +272,6 @@ int CSound::Init ( const int iCoreAudioBufferSizeMono )
         // Initialise
         status = AudioUnitInitialize ( audioUnit );
         checkStatus ( status );
-
-        SwitchDevice ( strCurDevName );
 
         if ( !isInitialized )
         {
@@ -328,10 +359,19 @@ void CSound::GetAvailableInOutDevices()
 
     AVAudioSession* sessionInstance = [AVAudioSession sharedInstance];
 
-    if ( sessionInstance.availableInputs.count > 1 )
+    // list every available input port (e.g. built-in mic, headset mic, or an
+    // external/multichannel USB or Lightning audio interface) as a selectable
+    // device. Output always stays at the system default since iOS does not
+    // allow choosing a separate playback device.
+    for ( AVAudioSessionPortDescription* port in sessionInstance.availableInputs )
     {
-        lNumDevs          = 2;
-        strDriverNames[1] = "in: Built-in Mic/out: System Default";
+        if ( lNumDevs >= MAX_NUMBER_SOUND_CARDS )
+        {
+            break;
+        }
+
+        strDriverNames[lNumDevs] = QString ( "in: %1/out: System Default" ).arg ( QString::fromNSString ( port.portName ) );
+        lNumDevs++;
     }
 }
 
@@ -353,13 +393,86 @@ void CSound::SwitchDevice ( QString strDriverName )
 
     AVAudioSession* sessionInstance = [AVAudioSession sharedInstance];
 
-    if ( iDriverIdx == 0 ) // system default device
+    if ( iDriverIdx <= 0 ) // system default device (or not found -> fall back to default)
     {
-        unsigned long lastInput = sessionInstance.availableInputs.count - 1;
-        [sessionInstance setPreferredInput:sessionInstance.availableInputs[lastInput] error:&error];
+        [sessionInstance setPreferredInput:nil error:&error];
     }
-    else // built-in mic
+    else
     {
-        [sessionInstance setPreferredInput:sessionInstance.availableInputs[0] error:&error];
+        NSArray<AVAudioSessionPortDescription*>* availableInputs = sessionInstance.availableInputs;
+        const NSUInteger                         iPortIdx        = static_cast<NSUInteger> ( iDriverIdx - 1 );
+
+        if ( iPortIdx < availableInputs.count )
+        {
+            [sessionInstance setPreferredInput:availableInputs[iPortIdx] error:&error];
+        }
+    }
+
+    // ask for as many input channels as the now-selected device can provide so
+    // that multichannel input devices are not limited to stereo
+    const NSInteger iMaxChannels = [sessionInstance maximumInputNumberOfChannels];
+
+    [sessionInstance setPreferredInputNumberOfChannels:qBound ( static_cast<NSInteger> ( 1 ), iMaxChannels, static_cast<NSInteger> ( MAX_NUM_IN_OUT_CHANNELS ) )
+                                                  error:&error];
+
+    UpdateInputChannelInfo();
+}
+
+void CSound::UpdateInputChannelInfo()
+{
+    AVAudioSession* sessionInstance = [AVAudioSession sharedInstance];
+
+    // query how many input channels were actually negotiated with the device
+    int iNewNumInChan = static_cast<int> ( sessionInstance.inputNumberOfChannels );
+
+    iNewNumInChan = qBound ( 1, iNewNumInChan, MAX_NUM_IN_OUT_CHANNELS );
+
+    iNumInChan             = iNewNumInChan;
+    buffer.mNumberChannels = iNumInChan;
+
+    // try to get descriptive names for each channel from the active input port
+    AVAudioSessionPortDescription* inputPort = sessionInstance.currentRoute.inputs.firstObject;
+    NSArray<AVAudioSessionChannelDescription*>* channels = inputPort.channels;
+
+    for ( int i = 0; i < iNumInChan; i++ )
+    {
+        QString strChanName = QString ( "Channel %1" ).arg ( i + 1 );
+
+        if ( channels && ( static_cast<NSUInteger> ( i ) < channels.count ) && channels[i].channelName.length > 0 )
+        {
+            strChanName = QString::fromNSString ( channels[i].channelName );
+        }
+
+        sChannelNamesInput[i] = QString ( "%1: %2" ).arg ( i + 1 ).arg ( strChanName );
+    }
+
+    // if the new device has fewer channels than before, clamp the current
+    // selection back into range, defaulting to the first (two) channel(s)
+    if ( ( iSelInputLeftChannel < 0 ) || ( iSelInputLeftChannel >= iNumInChan ) )
+    {
+        iSelInputLeftChannel = 0;
+    }
+
+    if ( ( iSelInputRightChannel < 0 ) || ( iSelInputRightChannel >= iNumInChan ) )
+    {
+        iSelInputRightChannel = ( iNumInChan > 1 ) ? 1 : 0;
+    }
+}
+
+void CSound::SetLeftInputChannel ( const int iNewChan )
+{
+    // apply parameter after input parameter check
+    if ( ( iNewChan >= 0 ) && ( iNewChan < iNumInChan ) )
+    {
+        iSelInputLeftChannel = iNewChan;
+    }
+}
+
+void CSound::SetRightInputChannel ( const int iNewChan )
+{
+    // apply parameter after input parameter check
+    if ( ( iNewChan >= 0 ) && ( iNewChan < iNumInChan ) )
+    {
+        iSelInputRightChannel = iNewChan;
     }
 }


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds support for external multichannel interfaces and provides ability to choose inputs on iOS/iPadOS devices.

CHANGELOG: Added support for external multichannel interfaces and ability to choose inputs on iOS/iPadOS devices.
<!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**

Fixes: 3735
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

I don't know.
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

This absolutely needs testing as I have no means to do so.

I don't really expect this to work but hopefully it provides a starting point.

Claude summary:
What was missing: `src/sound/coreaudio-ios/sound.mm` hardcoded a 2-channel (stereo) input format on the RemoteIO audio unit and never queried `AVAudioSession` for a device's actual channel count, so any external multichannel interface (USB/Lightning audio interface) was silently truncated to its first two channels.

Changes (`src/sound/coreaudio-ios/sound.{h,mm}`):

- Negotiate channel count via `AVAudioSession.maximumInputNumberOfChannels` / `setPreferredInputNumberOfChannels:` / `inputNumberOfChannels` whenever a device is selected (`SwitchDevice`).
- Split the single audio format into separate input (now `iNumInChan`-wide) and output (still stereo, since iOS playback is always 2-channel) `AudioStreamBasicDescription`s applied to the RemoteIO unit.
- `GetAvailableInOutDevices()` now lists every `AVAudioSessionPortDescription` in availableInputs (built-in mic, headset, external interfaces) instead of just "default" vs "built-in mic".
- Added `UpdateInputChannelInfo()` to populate per-channel names (from `AVAudioSessionChannelDescription`) and clamp the current selection when the device changes.
- `processBufferList()` now indexes the interleaved N-channel buffer using the user-selected left/right channel instead of assuming channel 0/1.
- Implemented `GetNumInputChannels`, `GetInputChannelName`, `SetLeft/RightInputChannel`, `GetLeft/RightInputChannel` overrides — these plug straight into the existing generic channel-selection UI in `clientsettingsdlg.cpp`, which is already gated on `__APPLE__` (true for iOS) and just was never exercised because the backend always reported 2 channels.

No GUI changes were needed — the settings dialog's channel-selection frame already supports any platform reporting more than 2 channels.

Caveat: I don't have macOS/Xcode in this environment to actually build and run on a device, so this hasn't been compiled or tested against real hardware — please build it in Xcode and verify with an actual multichannel interface (e.g. plugged in via USB-C/Lightning) before merging.

END Summary
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
