### PR TITLE
chatdlg: replace QTextBrowser with QListView for screen reader accessibility

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -65,15 +65,23 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
 
     edtLocalInputText->setAccessibleName ( tr ( "New chat text edit box" ) );
 
-    // clear chat window and edit line
-    txvChatWindow->clear();
+    // clear edit line
     edtLocalInputText->clear();
-
-    // we do not want to show a cursor in the chat history
-    txvChatWindow->setCursorWidth ( 0 );
 
     // set a placeholder text to make sure where to type the message in (#384)
     edtLocalInputText->setPlaceholderText ( tr ( "Type a message here" ) );
+
+    // Set up the list model and delegate for accessible per-message rows ------
+    m_pChatModel = new QStandardItemModel ( this );
+    txvChatWindow->setModel ( m_pChatModel );
+    txvChatWindow->setItemDelegate ( new ChatDelegate ( txvChatWindow ) );
+    txvChatWindow->setSelectionMode ( QAbstractItemView::SingleSelection );
+    txvChatWindow->setEditTriggers ( QAbstractItemView::NoEditTriggers );
+    txvChatWindow->setWordWrap ( true );
+    txvChatWindow->setResizeMode ( QListView::Adjust );
+    txvChatWindow->setContextMenuPolicy ( Qt::CustomContextMenu );
+    txvChatWindow->installEventFilter ( this );
+    txvChatWindow->viewport()->installEventFilter ( this );
 
     // Menu  -------------------------------------------------------------------
     QMenuBar* pMenu     = new QMenuBar ( this );
@@ -98,7 +106,7 @@ CChatDlg::CChatDlg ( QWidget* parent ) : CBaseDlg ( parent, Qt::Window ) // use 
 
     QObject::connect ( butSend, &QPushButton::clicked, this, &CChatDlg::OnSendText );
 
-    QObject::connect ( txvChatWindow, &QTextBrowser::anchorClicked, this, &CChatDlg::OnAnchorClicked );
+    QObject::connect ( txvChatWindow, &QListView::customContextMenuRequested, this, &CChatDlg::OnChatContextMenu );
 
 #if defined( Q_OS_IOS )
     QObject::connect ( closeAction, &QAction::triggered, this, &CChatDlg::OnCloseClicked );
@@ -127,15 +135,11 @@ void CChatDlg::OnSendText()
 
 void CChatDlg::OnClearChatHistory()
 {
-    // clear chat window
-    txvChatWindow->clear();
+    m_pChatModel->clear();
 }
 
 void CChatDlg::AddChatText ( QString strChatText )
 {
-    // notify accessibility plugin that text has changed
-    QAccessible::updateAccessibility ( new QAccessibleValueChangeEvent ( txvChatWindow, strChatText ) );
-
     // analyze strChatText to check if hyperlink (limit ourselves to http(s)://) but do not
     // replace the hyperlinks if any HTML code for a hyperlink was found (the user has done the HTML
     // coding hisself and we should not mess with that)
@@ -156,8 +160,49 @@ void CChatDlg::AddChatText ( QString strChatText )
                               "<a href=\"\\1\">\\1</a>" );
     }
 
-    // add new text in chat window
-    txvChatWindow->append ( strChatText );
+    // DisplayRole stores HTML; AccessibleTextRole gives screen readers clean text
+    // without angle-bracket markup (VoiceOver reads this role when narrating list items)
+    QTextDocument plainDoc;
+    plainDoc.setHtml ( strChatText );
+    QString strPlainText = plainDoc.toPlainText();
+
+    QStandardItem* pItem = new QStandardItem ( strChatText );
+    pItem->setData ( strPlainText, Qt::AccessibleTextRole );
+    m_pChatModel->appendRow ( pItem );
+    txvChatWindow->scrollToBottom();
+
+    // tell screen readers a new row was inserted, then announce its text as the
+    // list's current value — drives VoiceOver live-region-style announcement on macOS
+    int row = m_pChatModel->rowCount() - 1;
+    QAccessibleTableModelChangeEvent* pChangeEvent =
+        new QAccessibleTableModelChangeEvent ( txvChatWindow, QAccessibleTableModelChangeEvent::RowsInserted );
+    pChangeEvent->setFirstRow ( row );
+    pChangeEvent->setLastRow ( row );
+    pChangeEvent->setFirstColumn ( 0 );
+    pChangeEvent->setLastColumn ( 0 );
+    QAccessible::updateAccessibility ( pChangeEvent );
+    QAccessible::updateAccessibility ( new QAccessibleValueChangeEvent ( txvChatWindow, strPlainText ) );
+}
+
+void CChatDlg::OnCopyChatMessage()
+{
+    QModelIndexList sel = txvChatWindow->selectionModel()->selectedIndexes();
+    if ( sel.isEmpty() )
+        return;
+    QTextDocument doc;
+    doc.setHtml ( sel.first().data ( Qt::DisplayRole ).toString() );
+    QApplication::clipboard()->setText ( doc.toPlainText() );
+}
+
+void CChatDlg::OnChatContextMenu ( const QPoint& pos )
+{
+    QModelIndex idx = txvChatWindow->indexAt ( pos );
+    if ( !idx.isValid() )
+        return;
+    txvChatWindow->setCurrentIndex ( idx );
+    QMenu menu ( this );
+    menu.addAction ( tr ( "Copy message" ), this, &CChatDlg::OnCopyChatMessage );
+    menu.exec ( txvChatWindow->viewport()->mapToGlobal ( pos ) );
 }
 
 void CChatDlg::OnAnchorClicked ( const QUrl& Url )
@@ -173,6 +218,59 @@ void CChatDlg::OnAnchorClicked ( const QUrl& Url )
             QDesktopServices::openUrl ( Url );
         }
     }
+}
+
+bool CChatDlg::eventFilter ( QObject* obj, QEvent* event )
+{
+    if ( obj == txvChatWindow && event->type() == QEvent::KeyPress )
+    {
+        QKeyEvent* ke = static_cast<QKeyEvent*> ( event );
+        if ( ke->matches ( QKeySequence::Copy ) )
+        {
+            OnCopyChatMessage();
+            return true;
+        }
+    }
+    if ( obj == txvChatWindow->viewport() )
+    {
+        if ( event->type() == QEvent::MouseMove )
+        {
+            QMouseEvent*  me  = static_cast<QMouseEvent*> ( event );
+            QModelIndex   idx = txvChatWindow->indexAt ( me->pos() );
+            if ( idx.isValid() )
+            {
+                QRect         rect = txvChatWindow->visualRect ( idx );
+                QTextDocument doc;
+                doc.setHtml ( idx.data ( Qt::DisplayRole ).toString() );
+                doc.setTextWidth ( rect.width() );
+                QString anchor = doc.documentLayout()->anchorAt ( me->pos() - rect.topLeft() );
+                txvChatWindow->viewport()->setCursor ( anchor.isEmpty() ? Qt::ArrowCursor : Qt::PointingHandCursor );
+            }
+            else
+            {
+                txvChatWindow->viewport()->setCursor ( Qt::ArrowCursor );
+            }
+        }
+        if ( event->type() == QEvent::MouseButtonPress )
+        {
+            QMouseEvent*  me  = static_cast<QMouseEvent*> ( event );
+            QModelIndex   idx = txvChatWindow->indexAt ( me->pos() );
+            if ( idx.isValid() )
+            {
+                QRect         rect = txvChatWindow->visualRect ( idx );
+                QTextDocument doc;
+                doc.setHtml ( idx.data ( Qt::DisplayRole ).toString() );
+                doc.setTextWidth ( rect.width() );
+                QString anchor = doc.documentLayout()->anchorAt ( me->pos() - rect.topLeft() );
+                if ( !anchor.isEmpty() )
+                {
+                    OnAnchorClicked ( QUrl ( anchor ) );
+                    return true;
+                }
+            }
+        }
+    }
+    return CBaseDlg::eventFilter ( obj, event );
 }
 
 #if defined( Q_OS_IOS ) || defined( ANDROID ) || defined( Q_OS_ANDROID )

--- a/src/chatdlg.h
+++ b/src/chatdlg.h
@@ -57,9 +57,51 @@
 #include <QDesktopServices>
 #include <QMessageBox>
 #include <QRegularExpression>
+#include <QListView>
+#include <QStandardItemModel>
+#include <QStyledItemDelegate>
+#include <QTextDocument>
+#include <QAbstractTextDocumentLayout>
+#include <QPainter>
+#include <QStyle>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QClipboard>
+#include <QApplication>
 #include "global.h"
 #include "util.h"
 #include "ui_chatdlgbase.h"
+
+class ChatDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+public:
+    explicit ChatDelegate ( QObject* parent = nullptr ) : QStyledItemDelegate ( parent ) {}
+
+    void paint ( QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index ) const override
+    {
+        painter->save();
+        if ( option.state & QStyle::State_Selected )
+            painter->fillRect ( option.rect, option.palette.highlight() );
+        QTextDocument doc;
+        doc.setHtml ( index.data ( Qt::DisplayRole ).toString() );
+        doc.setTextWidth ( option.rect.width() );
+        painter->translate ( option.rect.topLeft() );
+        doc.drawContents ( painter, option.rect.translated ( -option.rect.topLeft() ) );
+        painter->restore();
+    }
+
+    QSize sizeHint ( const QStyleOptionViewItem& option, const QModelIndex& index ) const override
+    {
+        QListView* view = qobject_cast<QListView*> ( parent() );
+        int        w    = ( view && view->viewport()->width() > 0 ) ? view->viewport()->width() : option.rect.width();
+        QTextDocument doc;
+        doc.setHtml ( index.data ( Qt::DisplayRole ).toString() );
+        doc.setTextWidth ( w > 0 ? w : 200 );
+        return QSize ( w, static_cast<int> ( doc.size().height() ) );
+    }
+};
 
 /* Classes ********************************************************************/
 class CChatDlg : public CBaseDlg, private Ui_CChatDlgBase
@@ -76,10 +118,18 @@ public slots:
     void OnLocalInputTextTextChanged ( const QString& strNewText );
     void OnClearChatHistory();
     void OnAnchorClicked ( const QUrl& Url );
+    void OnCopyChatMessage();
+    void OnChatContextMenu ( const QPoint& pos );
 #if defined( Q_OS_IOS ) || defined( ANDROID ) || defined( Q_OS_ANDROID )
     void OnCloseClicked();
 #endif
 
 signals:
     void NewLocalInputText ( QString strNewText );
+
+protected:
+    bool eventFilter ( QObject* obj, QEvent* event ) override;
+
+private:
+    QStandardItemModel* m_pChatModel;
 };

--- a/src/chatdlgbase.ui
+++ b/src/chatdlgbase.ui
@@ -28,17 +28,8 @@
   </property>
   <layout class="QVBoxLayout">
    <item>
-    <widget class="QTextBrowser" name="txvChatWindow">
+    <widget class="QListView" name="txvChatWindow">
      <property name="acceptDrops">
-      <bool>false</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
-     <property name="openExternalLinks">
-      <bool>false</bool>
-     </property>
-     <property name="openLinks">
       <bool>false</bool>
      </property>
     </widget>


### PR DESCRIPTION
Replaces `QTextBrowser` with `QListView` + `QStyledItemDelegate` in the chat dialog so that each message is a discrete item in the OS accessibility tree.

With `QTextBrowser`, VoiceOver (and other screen readers that consume `QAccessible`) sees the entire chat history as a single text block. With `QListView`, each appended message becomes a `QAccessible::ListItem`, letting the user arrow-key through individual messages.

`ChatDelegate` renders each item as HTML via `QTextDocument`, preserving the existing rich-text formatting. Link clicks are detected in `eventFilter` by installing a filter on the viewport and using `QTextDocument::documentLayout()->anchorAt()` to hit-test the click position. Hovering over a link shows a pointing-hand cursor. Clicking routes through the existing `OnAnchorClicked` confirmation dialog. Right-click or Ctrl+C copies the selected message's plain text to the clipboard.

## macOS VoiceOver fixes (addresses the silence reported in testing)

Two issues prevented VoiceOver from speaking on macOS:

1. **`Qt::AccessibleTextRole`** — `Qt::DisplayRole` stores raw HTML. VoiceOver reads this role verbatim and sees angle-bracket markup, producing silence or garbled output. Fix: `QTextDocument::toPlainText()` strips the tags, and the result is stored as `Qt::AccessibleTextRole` on each item — the role VoiceOver actually queries for the item's accessible name.

2. **Correct accessibility events** — Replaced the previous `QAccessibleValueChangeEvent` (which fired before HTML processing and before the row existed) with `QAccessibleTableModelChangeEvent::RowsInserted` targeting the exact new row, followed by `QAccessibleValueChangeEvent` carrying the plain text. This is the correct signal sequence for live-region-style auto-announcement of incoming messages on macOS.

**Fixes an issue?**

Addresses #3613.

**Does this change need documentation?**

No documentation changes needed.

**Status**

Builds and runs. VoiceOver on macOS should now speak individual messages when navigating the list and announce incoming messages automatically. Please test with VoiceOver — specifically: does arrowing to a message read it aloud, and does an incoming message get announced without user action?

## Checklist

- [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I tested my code and it does what I want
- [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.