### PR TITLE
Add bounds checking before indexing vecvecTempMemory

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -64,11 +64,13 @@ void CNetBuf::Init ( const int iNewBlockSize, const int iNewNumBlocks, const boo
         // extract all data from buffer in temporary storage
         CVector<CVector<uint8_t>> vecvecTempMemory = vecvecMemory; // allocate worst case memory by copying
 
+        int iTempSize = vecvecTempMemory.size(); // for bounds checking
+
         if ( !bNUseSequenceNumber )
         {
             int iPreviousDataCnt = 0;
 
-            while ( Get ( vecvecTempMemory[iPreviousDataCnt], iBlockSize ) )
+            while ( iPreviousDataCnt < iTempSize && Get ( vecvecTempMemory[iPreviousDataCnt], iBlockSize ) )
             {
                 iPreviousDataCnt++;
             }
@@ -80,6 +82,7 @@ void CNetBuf::Init ( const int iNewBlockSize, const int iNewNumBlocks, const boo
             // data back as the new buffer size can hold)
             int iDataCnt = 0;
 
+            // iPreviousDataCnt will be at most iTempSize, so an additional check on iDataCnt is not needed
             while ( ( iDataCnt < iPreviousDataCnt ) && Put ( vecvecTempMemory[iDataCnt], iBlockSize ) )
             {
                 iDataCnt++;
@@ -94,13 +97,13 @@ void CNetBuf::Init ( const int iNewBlockSize, const int iNewNumBlocks, const boo
             const int     iOldBlockGetPos            = iBlockGetPos;
             int           iCurBlockPos               = 0;
 
-            while ( iBlockGetPos < iNumBlocksMemory )
+            while ( iBlockGetPos < iNumBlocksMemory && iCurBlockPos < iTempSize )
             {
                 veciTempBlockValid[iCurBlockPos] = veciBlockValid[iBlockGetPos];
                 vecvecTempMemory[iCurBlockPos++] = vecvecMemory[iBlockGetPos++];
             }
 
-            for ( iBlockGetPos = 0; iBlockGetPos < iOldBlockGetPos; iBlockGetPos++ )
+            for ( iBlockGetPos = 0; iBlockGetPos < iOldBlockGetPos && iCurBlockPos < iTempSize; iBlockGetPos++ )
             {
                 veciTempBlockValid[iCurBlockPos] = veciBlockValid[iBlockGetPos];
                 vecvecTempMemory[iCurBlockPos++] = vecvecMemory[iBlockGetPos];
@@ -113,7 +116,7 @@ void CNetBuf::Init ( const int iNewBlockSize, const int iNewNumBlocks, const boo
             iSequenceNumberAtGetPos = iOldSequenceNumberAtGetPos;
             iBlockGetPos            = 0; // per definition
 
-            for ( int iCurPos = 0; iCurPos < std::min ( iNewNumBlocks, iOldNumBlocksMemory ); iCurPos++ )
+            for ( int iCurPos = 0; iCurPos < std::min ( iNewNumBlocks, iOldNumBlocksMemory ) && iCurPos < iTempSize; iCurPos++ )
             {
                 veciBlockValid[iCurPos] = veciTempBlockValid[iCurPos];
                 vecvecMemory[iCurPos]   = vecvecTempMemory[iCurPos];


### PR DESCRIPTION


<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Bug fix to add bounds checking to buffer initialisation when changing size of the server jitter buffer.

Some of the added tests might not be strictly necessary or reached, but they guarantee the bounds are checked.

CHANGELOG: Server: fix occasional crash seen when clients < 3.6 change jitter buffer size.

**Context: Fixes an issue?**

Fixes #3747

This has been raised against `main`, and it should be merged there first. We should then raise a branch for 3.12.2, starting at `release/3_12_1` (6953c57fb6a7737628dbcbaff017ba699f0a9e79) and do a 3.12.2 release by cherry-picking the commit from `main`.

**Does this change need documentation? What needs to be documented and how?**

No, bug fix only

**Status of this Pull Request**

Ready and tested

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
