### PR TITLE
Make bRun atomic

### DIFF
--- a/src/socket.h
+++ b/src/socket.h
@@ -50,6 +50,7 @@
 #include <QThread>
 #include <QMutex>
 #include <vector>
+#include <atomic>
 #include "global.h"
 #include "protocol.h"
 #include "util.h"
@@ -210,7 +211,7 @@ protected:
         void Stop()
         {
             // disable run flag so that the thread loop can be exit
-            bRun = false;
+            bRun.store ( false );
 
             // to leave blocking wait for receive
             pSocket->Close();
@@ -228,7 +229,7 @@ protected:
             // case)
             if ( pSocket != nullptr )
             {
-                while ( bRun )
+                while ( bRun.load() )
                 {
                     // this function is a blocking function (waiting for network
                     // packets to be received and processed)
@@ -237,8 +238,8 @@ protected:
             }
         }
 
-        CSocket* pSocket;
-        bool     bRun;
+        CSocket*          pSocket;
+        std::atomic<bool> bRun;
     };
 
     void Init()


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/jamulussoftware/jamulus/security/quality/ai-findings)._

It's very likely that we have various places where we have bugs due to assuming bools are atomic while they are not. 