### PR TITLE
Atomic bRun in socket

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -531,7 +531,7 @@ bool CSocket::GetAndResetbJitterBufferOKFlag()
     return true;
 }
 
-void CSocket::OnDataReceived()
+void CSocket::OnDataReceived ( std::atomic<bool>& bRun )
 {
     /*
        The strategy of this function is that only the "put audio" function is
@@ -585,7 +585,7 @@ void CSocket::OnDataReceived()
             sockaddr_in sa4;
             socklen_t   sa4len = sizeof ( sa4 );
 
-            while ( true )
+            while ( bRun )
             {
                 const long iNumBytesRead =
                     recvfrom ( UdpSocket4, (char*) &vecbyRecBuf[0], MAX_SIZE_BYTES_NETW_BUF, 0, (struct sockaddr*) &sa4, &sa4len );
@@ -634,7 +634,7 @@ void CSocket::OnDataReceived()
             sockaddr_in6 sa6;
             socklen_t    sa6len = sizeof ( sa6 );
 
-            while ( true )
+            while ( bRun )
             {
                 const long iNumBytesRead =
                     recvfrom ( UdpSocket6, (char*) &vecbyRecBuf[0], MAX_SIZE_BYTES_NETW_BUF, 0, (struct sockaddr*) &sa6, &sa6len );

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -386,41 +386,6 @@ void CSocket::Init ( const quint16  iNewPortNumber,
     }
 }
 
-void CSocket::Close()
-{
-    if ( UdpSocket4 != INVALID_SOCKET )
-    {
-#ifdef _WIN32
-        // closesocket will cause recvfrom to return with an error because the
-        // socket is closed -> then the thread can safely be shut down
-        closesocket ( UdpSocket4 );
-#elif defined( __APPLE__ ) || defined( __MACOSX )
-        // on Mac the general close has the same effect as closesocket on Windows
-        close ( UdpSocket4 );
-#else
-        // on Linux the shutdown call cancels the recvfrom
-        shutdown ( UdpSocket4, SHUT_RDWR );
-#endif
-        UdpSocket4 = INVALID_SOCKET;
-    }
-
-    if ( UdpSocket6 != INVALID_SOCKET )
-    {
-#ifdef _WIN32
-        // closesocket will cause recvfrom to return with an error because the
-        // socket is closed -> then the thread can safely be shut down
-        closesocket ( UdpSocket6 );
-#elif defined( __APPLE__ ) || defined( __MACOSX )
-        // on Mac the general close has the same effect as closesocket on Windows
-        close ( UdpSocket6 );
-#else
-        // on Linux the shutdown call cancels the recvfrom
-        shutdown ( UdpSocket6, SHUT_RDWR );
-#endif
-        UdpSocket6 = INVALID_SOCKET;
-    }
-}
-
 CSocket::~CSocket()
 {
     // cleanup the socket (on Windows the WSA cleanup must also be called)

--- a/src/socket.h
+++ b/src/socket.h
@@ -100,7 +100,6 @@ public:
     void SendPacket ( const CVector<uint8_t>& vecbySendBuf, const CHostAddress& HostAddr );
 
     bool GetAndResetbJitterBufferOKFlag();
-    void Close();
 
 protected:
     void    Init ( const quint16  iPortNumber,

--- a/src/socket.h
+++ b/src/socket.h
@@ -50,6 +50,7 @@
 #include <QThread>
 #include <QMutex>
 #include <vector>
+#include <atomic>
 #include "global.h"
 #include "protocol.h"
 #include "util.h"
@@ -134,7 +135,7 @@ private:
     void ProcessPacket ( const CHostAddress& RecHostAddr, const int iNumBytesRead );
 
 public:
-    void OnDataReceived();
+    void OnDataReceived ( std::atomic<bool>& bRun );
 
 signals:
     void NewConnection(); // for the client
@@ -212,9 +213,6 @@ protected:
             // disable run flag so that the thread loop can be exit
             bRun = false;
 
-            // to leave blocking wait for receive
-            pSocket->Close();
-
             // give thread some time to terminate
             wait ( 5000 );
         }
@@ -232,13 +230,13 @@ protected:
                 {
                     // this function is a blocking function (waiting for network
                     // packets to be received and processed)
-                    pSocket->OnDataReceived();
+                    pSocket->OnDataReceived ( bRun );
                 }
             }
         }
 
-        CSocket* pSocket;
-        bool     bRun;
+        CSocket*          pSocket;
+        std::atomic<bool> bRun; // atomic, as it is set and tested by different threads
     };
 
     void Init()


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Make the bRun boolean in the socket class atomic, for thread safety. Also remove the CSocket::Close method, as it is no longer needed with non-blocking socket reads.

CHANGELOG: Internal: Improve thread safety in socket handling

**Context: Fixes an issue?**

Replaces #3786 and expands on it, following on from #3774

**Does this change need documentation? What needs to be documented and how?**

No, bug fix and refactor only

**Status of this Pull Request**

Ready for review

**What is missing until this pull request can be merged?**

Checking on all main platforms

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
