### PR TITLE
Add linux/debian/README.md: packaging overview and headless service

### DIFF
--- a/linux/debian/README.md
+++ b/linux/debian/README.md
@@ -1,0 +1,34 @@
+# Debian packaging
+
+Author(s):
+* The Jamulus Development Team
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see [<https://www.gnu.org/licenses/>](https://www.gnu.org/licenses/).
+
+---
+
+## Files in this folder
+
+`linux/deploy_deb.sh` (run from the repository root) uses this directory to build two packages with `debuild`:
+
+- **jamulus** — the desktop client/server (built with `CONFIG+=noupcasename`, which renames the target from `Jamulus` to `jamulus`).
+- **jamulus-headless** — a server-only binary (`CONFIG+=headless serveronly` with `TARGET=jamulus-headless`) with no GUI library dependencies, plus a systemd service.
+
+Most files here are standard Debian packaging (`control`, `rules`, `copyright`, `*.install`, …). `changelog` is regenerated at build time from the top-level `ChangeLog` — don't edit it by hand.
+
+## jamulus-headless.service
+
+Installed to `lib/systemd/system` by the headless package. It runs `/usr/bin/jamulus-headless -s -n` as the unprivileged `jamulus` system user (created in `jamulus-headless.postinst`), restarts on failure, and raises CPU and I/O scheduling priority for real-time audio.
+
+Start it with `sudo systemctl enable --now jamulus-headless`. To name, publish or otherwise configure the server, adjust the `ExecStart=` options — see https://jamulus.io/wiki/Running-a-Server#server-mode-related-options.


### PR DESCRIPTION
Requested by @ann0see in https://github.com/jamulussoftware/jamulus/pull/3790#discussion_r3606115668 ("Add a README.md to linux/debian explaining this then").

One new file. Explains what `deploy_deb.sh` builds from this directory (the two packages and their qmake configs), notes that `changelog` is generated at build time, and documents `jamulus-headless.service`: what it runs, as which user, and where to configure it — linking to the server options page on jamulus.io rather than duplicating it.

CHANGELOG: SKIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)