### PR TITLE
Make cross-thread run/status flags std::atomic (#3798 batches A/B)

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -631,14 +631,12 @@ bool CClient::GetAndResetbJitterBufferOKFlag()
     // get the socket buffer put status flag and reset it
     const bool bSocketJitBufOKFlag = Socket.GetAndResetbJitterBufferOKFlag();
 
-    if ( !bJitterBufferOK )
+    // atomically read our own get status flag and reset it to OK
+    if ( !bJitterBufferOK.exchange ( true ) )
     {
         // our jitter buffer get status is not OK so the overall status of the
         // jitter buffer is also not OK (we do not have to consider the status
         // of the socket buffer put status flag)
-
-        // reset flag before returning the function
-        bJitterBufferOK = true;
         return false;
     }
 

--- a/src/client.h
+++ b/src/client.h
@@ -51,6 +51,7 @@
 #include <QString>
 #include <QDateTime>
 #include <QMutex>
+#include <atomic>
 #ifdef USE_OPUS_SHARED_LIB
 #    include "opus/opus_custom.h"
 #else
@@ -431,9 +432,9 @@ protected:
     bool        bEnableAudioAlerts;
     bool        bEnableOPUS64;
 
-    bool   bJitterBufferOK;
-    bool   bMuteMeInPersonalMix;
-    QMutex MutexDriverReinit;
+    std::atomic<bool> bJitterBufferOK;
+    bool              bMuteMeInPersonalMix;
+    QMutex            MutexDriverReinit;
 
     // server settings
     int  iServerSockBufNumFrames;

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -518,17 +518,10 @@ void CSocket::SendPacket ( const CVector<uint8_t>& vecbySendBuf, const CHostAddr
 
 bool CSocket::GetAndResetbJitterBufferOKFlag()
 {
-    // check jitter buffer status
-    if ( !bJitterBufferOK )
-    {
-        // reset flag and return "not OK" status
-        bJitterBufferOK = true;
-        return false;
-    }
-
-    // the buffer was OK, we do not have to reset anything and just return the
-    // OK status
-    return true;
+    // atomically read the jitter buffer status and reset it to OK so that a
+    // "not OK" set by the socket thread between a separate read and reset
+    // cannot be lost
+    return bJitterBufferOK.exchange ( true );
 }
 
 void CSocket::OnDataReceived()

--- a/src/socket.h
+++ b/src/socket.h
@@ -49,8 +49,8 @@
 #include <QObject>
 #include <QThread>
 #include <QMutex>
-#include <atomic>
 #include <vector>
+#include <atomic>
 #include "global.h"
 #include "protocol.h"
 #include "util.h"
@@ -238,8 +238,8 @@ protected:
             }
         }
 
-        CSocket*          pSocket;
-        std::atomic<bool> bRun;
+        CSocket* pSocket;
+        bool     bRun;
     };
 
     void Init()

--- a/src/socket.h
+++ b/src/socket.h
@@ -49,6 +49,7 @@
 #include <QObject>
 #include <QThread>
 #include <QMutex>
+#include <atomic>
 #include <vector>
 #include "global.h"
 #include "protocol.h"
@@ -124,7 +125,7 @@ protected:
 
     bool bIsClient;
 
-    bool bJitterBufferOK;
+    std::atomic<bool> bJitterBufferOK;
 
     // This is a reference to CClient::bIPv6Available or CServer::bIPv6Available,
     // to inform the Client or Server which type of socket was created at startup.
@@ -237,8 +238,8 @@ protected:
             }
         }
 
-        CSocket* pSocket;
-        bool     bRun;
+        CSocket*          pSocket;
+        std::atomic<bool> bRun;
     };
 
     void Init()

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -49,6 +49,7 @@
 #include <QThread>
 #include <QString>
 #include <QMutex>
+#include <atomic>
 #ifndef HEADLESS
 #    include <QMessageBox>
 #endif
@@ -193,10 +194,10 @@ protected:
         ( *fpProcessCallback ) ( psData, pProcessCallbackArg );
     }
 
-    bool   bRun;
-    bool   bCallbackEntered;
-    QMutex MutexAudioProcessCallback;
-    QMutex MutexDevProperties;
+    std::atomic<bool> bRun;
+    std::atomic<bool> bCallbackEntered;
+    QMutex            MutexAudioProcessCallback;
+    QMutex            MutexDevProperties;
 
     QString                strSystemDriverTechniqueName;
     int                    iCtrlMIDIChannel;

--- a/src/util.h
+++ b/src/util.h
@@ -47,6 +47,7 @@
 #pragma once
 #include <vector>
 #include <algorithm>
+#include <atomic>
 #ifdef _WIN32
 #    include <winsock2.h>
 #    include <ws2tcpip.h>
@@ -1352,11 +1353,11 @@ public:
 protected:
     virtual void run();
 
-    bool     bRun;
+    std::atomic<bool> bRun;
 
 #    if defined( __APPLE__ ) || defined( __MACOSX )
-    uint64_t Delay;
-    uint64_t NextEnd;
+    uint64_t          Delay;
+    uint64_t          NextEnd;
 #    else
     long     Delay;
     timespec NextEnd;


### PR DESCRIPTION
This follows up on the discussion in #3786 and covers batches **A** and **B** of the audit in #3798 — the thread-lifecycle `bRun` flags and the jitter-buffer status flags. Offering it as an **experiment**: it is the least invasive slice of #3798, intended to establish the `std::atomic` pattern in the codebase and let us observe it through CI and normal use before deciding whether the more involved findings (C–F) are worth touching.

### What changes

Five members become `std::atomic<bool>`, keeping plain operator syntax at every call site (per the conclusion in #3786 that the overloaded operators are simplest, and the default sequentially-consistent operations cost nothing at these rates):

| Member | Written by | Read by |
|---|---|---|
| `CHighPrecisionTimer::bRun` (Mac/Linux variant) | main thread (`Start()`/`Stop()`) | timer thread loop; socket thread via `IsRunning()` |
| `CSoundBase::bRun` | main thread (`Start()`/`Stop()`) | audio callback thread (JACK/CoreAudio/Oboe/ASIO) |
| `CSoundBase::bCallbackEntered` | audio callback thread | GUI sound-device check |
| `CSocket::bJitterBufferOK` | socket thread | GUI read-and-reset |
| `CClient::bJitterBufferOK` | sound thread | GUI read-and-reset |

A sixth member, `CSocketThread::bRun` (the exact #3786 case), was originally part of this PR but has been dropped: #3788 already converts it — and removes `CSocket::Close()` in favour of non-blocking reads, which also disposes of finding F1 in #3798. The `<atomic>` include added to `socket.h` here matches #3788's placement so the two branches merge cleanly in either order.

The only non-declaration change: the two `GetAndResetbJitterBufferOKFlag()` functions now use `exchange ( true )` instead of a separate read and reset. Behavior is the same, and it closes a small lost-update window — a "not OK" written by the socket/sound thread between the read and the reset used to be dropped silently.

### Behavior

No intended behavior change. On x86 these compile to essentially the same instructions; the difference is that the compiler may no longer cache the flag across loop iterations, and on weakly-ordered CPUs (Apple Silicon, Android, ARM Linux servers) the cross-thread store is guaranteed to become visible and correctly ordered.

### Tested

- Full Linux client+server build (Qt 5.15, JACK enabled): compiles with no new warnings.
- Headless server smoke test: starts, runs, exits cleanly on SIGTERM — this exercises the modified `Stop()` paths of the socket and timer threads.
- macOS / Windows / Android builds not tested locally (relying on CI); the touched accesses in those backends are plain reads/writes covered by the operator overloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
