### PR TITLE
Server: avoid per-frame deep copy of audio buffers in CreateLevelsForAllConChannels

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -732,7 +732,7 @@ void CServer::OnTimer()
     if ( iNumClients > 0 )
     {
         // calculate levels for all connected clients
-        const bool bSendChannelLevels = CreateLevelsForAllConChannels ( iNumClients, vecNumAudioChannels, vecvecsData, vecChannelLevels );
+        const bool bSendChannelLevels = CreateLevelsForAllConChannels ( iNumClients );
 
         for ( int iChanCnt = 0; iChanCnt < iNumClients; iChanCnt++ )
         {
@@ -1673,10 +1673,7 @@ void CServer::customEvent ( QEvent* pEvent )
 }
 
 /// @brief Compute frame peak level for each client
-bool CServer::CreateLevelsForAllConChannels ( const int                        iNumClients,
-                                              const CVector<int>&              vecNumAudioChannels,
-                                              const CVector<CVector<int16_t>>& vecvecsData,
-                                              CVector<uint16_t>&               vecLevelsOut )
+bool CServer::CreateLevelsForAllConChannels ( const int iNumClients )
 {
     bool bLevelsWereUpdated = false;
 
@@ -1694,7 +1691,7 @@ bool CServer::CreateLevelsForAllConChannels ( const int                        i
                                                                                                                      vecNumAudioChannels[j] > 1 );
 
             // map value to integer for transmission via the protocol (4 bit available)
-            vecLevelsOut[j] = static_cast<uint16_t> ( std::ceil ( dCurSigLevelForMeterdB ) );
+            vecChannelLevels[j] = static_cast<uint16_t> ( std::ceil ( dCurSigLevelForMeterdB ) );
         }
     }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1673,10 +1673,10 @@ void CServer::customEvent ( QEvent* pEvent )
 }
 
 /// @brief Compute frame peak level for each client
-bool CServer::CreateLevelsForAllConChannels ( const int                       iNumClients,
-                                              const CVector<int>&             vecNumAudioChannels,
-                                              const CVector<CVector<int16_t>> vecvecsData,
-                                              CVector<uint16_t>&              vecLevelsOut )
+bool CServer::CreateLevelsForAllConChannels ( const int                        iNumClients,
+                                              const CVector<int>&              vecNumAudioChannels,
+                                              const CVector<CVector<int16_t>>& vecvecsData,
+                                              CVector<uint16_t>&               vecLevelsOut )
 {
     bool bLevelsWereUpdated = false;
 

--- a/src/server.h
+++ b/src/server.h
@@ -240,10 +240,7 @@ protected:
     int                        iMaxNumThreads;
     CVector<std::future<void>> Futures;
 
-    bool CreateLevelsForAllConChannels ( const int                        iNumClients,
-                                         const CVector<int>&              vecNumAudioChannels,
-                                         const CVector<CVector<int16_t>>& vecvecsData,
-                                         CVector<uint16_t>&               vecLevelsOut );
+    bool CreateLevelsForAllConChannels ( const int iNumClients );
 
     // do not use the vector class since CChannel does not have appropriate
     // copy constructor/operator

--- a/src/server.h
+++ b/src/server.h
@@ -240,10 +240,10 @@ protected:
     int                        iMaxNumThreads;
     CVector<std::future<void>> Futures;
 
-    bool CreateLevelsForAllConChannels ( const int                       iNumClients,
-                                         const CVector<int>&             vecNumAudioChannels,
-                                         const CVector<CVector<int16_t>> vecvecsData,
-                                         CVector<uint16_t>&              vecLevelsOut );
+    bool CreateLevelsForAllConChannels ( const int                        iNumClients,
+                                         const CVector<int>&              vecNumAudioChannels,
+                                         const CVector<CVector<int16_t>>& vecvecsData,
+                                         CVector<uint16_t>&               vecLevelsOut );
 
     // do not use the vector class since CChannel does not have appropriate
     // copy constructor/operator


### PR DESCRIPTION
## What

`CServer::CreateLevelsForAllConChannels()` declares its `vecvecsData` parameter as

```cpp
const CVector<CVector<int16_t>> vecvecsData   // by value
```

This PR changes it to `const CVector<CVector<int16_t>>&` (by const reference), matching the neighbouring `vecNumAudioChannels` parameter.

## Why

The function is called from `CServer::OnTimer()` — the realtime audio timer thread — on **every frame in which at least one client is connected**:

```cpp
const bool bSendChannelLevels = CreateLevelsForAllConChannels ( iNumClients, vecNumAudioChannels, vecvecsData, vecChannelLevels );
```

Because `CVector` derives from `std::vector`, passing by value deep-copies the entire pre-allocated member vector every frame. `vecvecsData` is initialized in the `CServer` constructor to `iMaxNumChannels` (the `-u` setting) worst-case stereo buffers and is never shrunk, so the copy always covers the full configured channel limit — even a nearly empty server pays it in full. This both allocates on the audio thread (which the codebase otherwise takes care to avoid — see the "no memory must be allocated" comments in the `CServer` constructor) and burns memory bandwidth.

A small allocation-counting reproduction of the exact copy (150 channels = `-u 150`, 2×128 int16 per buffer, 375 frames/s) measured **~56,600 heap allocations/s and ~30 MB/s copied**, purely from the by-value parameter; at the default `-u 10` it is still ~4,100 allocations/s and ~2 MB/s. The copy is not elided at `-O2`.

## Change

One parameter, declaration + definition — no behavioural change. The function only reads `vecvecsData`.

## Testing

- Headless build (`CONFIG+=headless`, Qt 5.15) is clean.
- Server starts, runs, and shuts down cleanly on SIGTERM (`OnHandledSignal: 15`).
- `clang-format-14` applied to the touched files.

See #3804 for the analysis.
