### PR TITLE
Refactor Connect/Disconnect out to CClient with an explicit connection state

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1159,7 +1159,7 @@ void CClient::Disconnect()
 ///       Use to display error message in CClientDlg
 /// @param strServerAddress - the server address to connect to
 /// @param strServerName - the human readable server name passed to Connecting()
-void CClient::Connect ( QString strServerAddress, QString strServerName )
+void CClient::Connect ( const QString& strServerAddress, const QString& strServerName )
 {
     try
     {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -145,7 +145,7 @@ CClient::CClient ( const quint16  iPortNumber,
     // The first ConClientListMesReceived handler performs the necessary cleanup and has to run first:
     QObject::connect ( &Channel, &CChannel::ConClientListMesReceived, this, &CClient::OnConClientListMesReceived );
 
-    QObject::connect ( &Channel, &CChannel::Disconnected, this, &CClient::Disconnected );
+    QObject::connect ( &Channel, &CChannel::Disconnected, this, &CClient::Stop );
 
     QObject::connect ( &Channel, &CChannel::NewConnection, this, &CClient::OnNewConnection );
 
@@ -626,6 +626,9 @@ bool CClient::SetServerAddr ( QString strNAddr )
         // apply address to the channel
         Channel.SetAddress ( HostAddress );
 
+        // By default, set server name to HostAddress. If using the Connect() method, this may be overwritten
+        SetConnectedServerName ( HostAddress.toString() );
+
         return true;
     }
     else
@@ -929,11 +932,8 @@ void CClient::OnHandledSignal ( int sigNum )
     {
     case SIGINT:
     case SIGTERM:
-        // if connected, terminate connection (needed for headless mode)
-        if ( IsRunning() )
-        {
-            Stop();
-        }
+        // if connected, Stop client (needed for headless mode)
+        Stop();
 
         // this should trigger OnAboutToQuit
         QCoreApplication::instance()->exit();
@@ -1069,8 +1069,14 @@ void CClient::Start()
     // Disable hibernation or display dimming if the app is running on Windows
     SetThreadExecutionState ( ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED );
 #endif
+
+    emit Connected ( GetConnectedServerName() );
 }
 
+/// @method
+/// @brief Stops client and disconnects from server
+/// @emit Disconnected
+///       Use to set CClientDlg to show not being connected
 void CClient::Stop()
 {
     // stop audio interface
@@ -1112,6 +1118,53 @@ void CClient::Stop()
     // Allow hibernation or display dimming if the app is running again (Windows)
     SetThreadExecutionState ( ES_CONTINUOUS );
 #endif
+
+    // emit Disconnected() to inform UI of disconnection
+    emit Disconnected();
+}
+
+/// @method
+/// @brief Stops the client if the client is running
+/// @emit Disconnected
+void CClient::Disconnect()
+{
+    if ( IsRunning() )
+    {
+        Stop();
+    }
+}
+
+/// @method
+/// @brief Connects to strServerAddress
+/// @emit Connected (strServerName) if the client wasn't running and SetServerAddr was valid. emit happens through Start().
+///       Use to set CClientDlg to show being connected
+/// @emit ConnectingFailed (error) if an error occurred
+///       Use to display error message in CClientDlg
+/// @param strServerAddress - the server address to connect to
+/// @param strServerName - the String argument to be passed to Connecting()
+void CClient::Connect ( QString strServerAddress, QString strServerName )
+{
+    try
+    {
+        if ( !IsRunning() )
+        {
+            // Set server address and connect if valid address was supplied
+            if ( SetServerAddr ( strServerAddress ) )
+            {
+                SetConnectedServerName ( strServerName );
+                Start();
+            }
+            else
+            {
+                throw CGenErr ( tr ( "Received invalid server address. Please check for typos in the provided server address." ) );
+            }
+        }
+    }
+    catch ( const CGenErr& generr )
+    {
+        Stop();
+        emit ConnectingFailed ( generr.GetErrorText() );
+    }
 }
 
 void CClient::Init()

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -937,6 +937,7 @@ void CClient::OnHandledSignal ( int sigNum )
         // is notified we are leaving (Disconnect() is a no-op if not connected)
         Disconnect();
 
+        // this should trigger OnAboutToQuit
         QCoreApplication::instance()->exit();
         break;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1097,7 +1097,15 @@ void CClient::Stop()
 
     // Fall back to opus in case raw was used
     bRawAudioIsSupported = false;
-    Init();
+    try
+    {
+        Init();
+    }
+    catch ( const CGenErr& )
+    {
+        // a dead audio backend (e.g. JACK was shut down) must not prevent the
+        // disconnect message below from reaching the server
+    }
 
     // wait for approx. 100 ms to make sure no audio packet is still in the
     // network queue causing the channel to be reconnected right after having

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -933,10 +933,10 @@ void CClient::OnHandledSignal ( int sigNum )
     {
     case SIGINT:
     case SIGTERM:
-        // if connected, Stop client (needed for headless mode)
-        Stop();
+        // tear down any pending or established connection first, so the server
+        // is notified we are leaving (Disconnect() is a no-op if not connected)
+        Disconnect();
 
-        // this should trigger OnAboutToQuit
         QCoreApplication::instance()->exit();
         break;
 
@@ -1135,11 +1135,15 @@ void CClient::Stop()
 }
 
 /// @method
-/// @brief Stops the client if the client is running
+/// @brief Disconnects from the server if a connection is requested or established.
+///        Idempotent: a no-op when already disconnected.
 /// @emit Disconnected
 void CClient::Disconnect()
 {
-    if ( IsRunning() )
+    // Key off the connection state, not IsRunning() (which tracks the audio
+    // device): the two diverge while connecting and in headless mode, and on
+    // SIGTERM we must still send the disconnect message to the server.
+    if ( GetConnectionState() != CS_DISCONNECTED )
     {
         Stop();
     }
@@ -1180,6 +1184,10 @@ void CClient::Connect ( QString strServerAddress, QString strServerName )
     }
 }
 
+/// @method
+/// @brief Updates the connection state and, if it changed, notifies observers.
+/// @emit ConnectionStateChanged (state) when the state actually changes
+/// @param eNewConnectionState - the state to transition to
 void CClient::SetConnectionState ( const EConnectionState eNewConnectionState )
 {
     if ( eConnectionState != eNewConnectionState )

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -59,6 +59,7 @@ CClient::CClient ( const quint16  iPortNumber,
     strClientName ( strNClientName ),
     pSignalHandler ( CSignalHandler::getSingletonP() ),
     pSettings ( nullptr ),
+    eConnectionState ( CS_DISCONNECTED ),
     Channel ( false ), /* we need a client channel -> "false" */
     CurOpusEncoder ( nullptr ),
     CurOpusDecoder ( nullptr ),
@@ -1027,6 +1028,9 @@ void CClient::OnClientIDReceived ( int iServerChanID )
         SetRemoteChanGain ( iChanID, 0, false );
     }
 
+    // the server has assigned us a channel ID, so the connection is established
+    SetConnectionState ( CS_CONNECTED );
+
     emit ClientIDReceived ( iChanID );
 }
 
@@ -1070,7 +1074,12 @@ void CClient::Start()
     SetThreadExecutionState ( ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED );
 #endif
 
-    emit Connected ( GetConnectedServerName() );
+    // the connection is requested now but not yet established: the transition
+    // to CS_CONNECTED happens when the server assigns our channel ID
+    // (see OnClientIDReceived)
+    SetConnectionState ( CS_CONNECTING );
+
+    emit Connecting ( GetConnectedServerName() );
 }
 
 /// @method
@@ -1119,6 +1128,8 @@ void CClient::Stop()
     SetThreadExecutionState ( ES_CONTINUOUS );
 #endif
 
+    SetConnectionState ( CS_DISCONNECTED );
+
     // emit Disconnected() to inform UI of disconnection
     emit Disconnected();
 }
@@ -1135,35 +1146,46 @@ void CClient::Disconnect()
 }
 
 /// @method
-/// @brief Connects to strServerAddress
-/// @emit Connected (strServerName) if the client wasn't running and SetServerAddr was valid. emit happens through Start().
+/// @brief Connects to strServerAddress. If a connection is currently requested
+///        or established, that connection is terminated first.
+/// @emit Connecting (strServerName) if SetServerAddr was valid. emit happens through Start().
 ///       Use to set CClientDlg to show being connected
 /// @emit ConnectingFailed (error) if an error occurred
 ///       Use to display error message in CClientDlg
 /// @param strServerAddress - the server address to connect to
-/// @param strServerName - the String argument to be passed to Connecting()
+/// @param strServerName - the human readable server name passed to Connecting()
 void CClient::Connect ( QString strServerAddress, QString strServerName )
 {
     try
     {
-        if ( !IsRunning() )
+        // disconnect from any current server first so that connecting to a
+        // different server while connected behaves as a reconnect
+        Disconnect();
+
+        // Set server address and connect if valid address was supplied
+        if ( SetServerAddr ( strServerAddress ) )
         {
-            // Set server address and connect if valid address was supplied
-            if ( SetServerAddr ( strServerAddress ) )
-            {
-                SetConnectedServerName ( strServerName );
-                Start();
-            }
-            else
-            {
-                throw CGenErr ( tr ( "Received invalid server address. Please check for typos in the provided server address." ) );
-            }
+            SetConnectedServerName ( strServerName );
+            Start();
+        }
+        else
+        {
+            throw CGenErr ( tr ( "Received invalid server address. Please check for typos in the provided server address." ) );
         }
     }
     catch ( const CGenErr& generr )
     {
         Stop();
         emit ConnectingFailed ( generr.GetErrorText() );
+    }
+}
+
+void CClient::SetConnectionState ( const EConnectionState eNewConnectionState )
+{
+    if ( eConnectionState != eNewConnectionState )
+    {
+        eConnectionState = eNewConnectionState;
+        emit ConnectionStateChanged ( eConnectionState );
     }
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1101,10 +1101,11 @@ void CClient::Stop()
     {
         Init();
     }
-    catch ( const CGenErr& )
+    catch ( const CGenErr& generr )
     {
         // a dead audio backend (e.g. JACK was shut down) must not prevent the
         // disconnect message below from reaching the server
+        qWarning() << "Could not reinitialise the sound device while disconnecting:" << generr.GetErrorText();
     }
 
     // wait for approx. 100 ms to make sure no audio packet is still in the

--- a/src/client.h
+++ b/src/client.h
@@ -160,6 +160,13 @@ public:
 
     void Start();
     void Stop();
+    void Disconnect();
+    void Connect ( QString strServerAddress, QString strServerName );
+
+    // The ConnectedServerName is emitted by Connected() to update the UI with a human readable server name
+    void    SetConnectedServerName ( const QString strServerName ) { strConnectedServerName = strServerName; };
+    QString GetConnectedServerName() const { return strConnectedServerName; };
+
     bool IsRunning() { return Sound.IsRunning(); }
     bool IsCallbackEntered() const { return Sound.IsCallbackEntered(); }
     bool SetServerAddr ( QString strNAddr );
@@ -354,6 +361,9 @@ protected:
     void FreeClientChannel ( const int iServerChannelID );
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
     bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
+    // information for the connected server
+
+    QString strConnectedServerName;
 
     // only one channel is needed for client application
     CChannel  Channel;
@@ -465,7 +475,8 @@ protected slots:
     {
         if ( InetAddr == Channel.GetAddress() )
         {
-            emit Disconnected();
+            // Stop client in case it received a Disconnection request
+            Stop();
         }
     }
     void OnCLPingReceived ( CHostAddress InetAddr, int iMs );
@@ -508,7 +519,11 @@ signals:
 
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
 
+    void Connected ( QString strServerName );
+    void ConnectingFailed ( QString errorMessage );
+    void DisconnectClient();
     void Disconnected();
+
     void SoundDeviceChanged ( QString strError );
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );
     void ControllerInPanValue ( int iChannelIdx, int iValue );

--- a/src/client.h
+++ b/src/client.h
@@ -169,8 +169,6 @@ public:
 
     virtual ~CClient();
 
-    void Start();
-    void Stop();
     void Disconnect();
     void Connect ( const QString& strServerAddress, const QString& strServerName );
 
@@ -361,6 +359,9 @@ protected:
     CClientSettings* pSettings;
     // callback function must be static, otherwise it does not work
     static void AudioCallback ( CVector<short>& psData, void* arg );
+
+    void Start();
+    void Stop();
 
     void Init();
     void ProcessSndCrdAudioData ( CVector<short>& vecsStereoSndCrd );

--- a/src/client.h
+++ b/src/client.h
@@ -89,6 +89,17 @@
 #endif
 
 /* Definitions ****************************************************************/
+// Client connection state -----------------------------------------------------
+enum EConnectionState
+{
+    // a connection is "requested" as soon as the client starts the audio
+    // stream towards the configured server and "established" once the server
+    // has assigned a channel ID to the client
+    CS_DISCONNECTED = 0, // no connection requested or established
+    CS_CONNECTING   = 1, // connection requested but not yet established
+    CS_CONNECTED    = 2  // connection established and current
+};
+
 // audio in fader range
 #define AUD_FADER_IN_MIN    0
 #define AUD_FADER_IN_MAX    100
@@ -363,11 +374,10 @@ protected:
     void FreeClientChannel ( const int iServerChannelID );
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
     bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
-    // information for the connected server
+    // human-readable name of the current server, shown in the UI
     QString strConnectedServerName;
 
-    // single source of truth for the connection state, only to be modified
-    // via SetConnectionState() so that every change emits ConnectionStateChanged()
+    // current connection state; set only via SetConnectionState()
     EConnectionState eConnectionState;
 
     void SetConnectionState ( const EConnectionState eNewConnectionState );

--- a/src/client.h
+++ b/src/client.h
@@ -163,9 +163,11 @@ public:
     void Disconnect();
     void Connect ( QString strServerAddress, QString strServerName );
 
-    // The ConnectedServerName is emitted by Connected() to update the UI with a human readable server name
+    // The ConnectedServerName is emitted by Connecting() to update the UI with a human readable server name
     void    SetConnectedServerName ( const QString strServerName ) { strConnectedServerName = strServerName; };
     QString GetConnectedServerName() const { return strConnectedServerName; };
+
+    EConnectionState GetConnectionState() const { return eConnectionState; }
 
     bool IsRunning() { return Sound.IsRunning(); }
     bool IsCallbackEntered() const { return Sound.IsCallbackEntered(); }
@@ -362,8 +364,13 @@ protected:
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
     bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
     // information for the connected server
-
     QString strConnectedServerName;
+
+    // single source of truth for the connection state, only to be modified
+    // via SetConnectionState() so that every change emits ConnectionStateChanged()
+    EConnectionState eConnectionState;
+
+    void SetConnectionState ( const EConnectionState eNewConnectionState );
 
     // only one channel is needed for client application
     CChannel  Channel;
@@ -519,9 +526,9 @@ signals:
 
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
 
-    void Connected ( QString strServerName );
+    void ConnectionStateChanged ( EConnectionState eConnectionState );
+    void Connecting ( QString strServerName );
     void ConnectingFailed ( QString errorMessage );
-    void DisconnectClient();
     void Disconnected();
 
     void SoundDeviceChanged ( QString strError );

--- a/src/client.h
+++ b/src/client.h
@@ -172,10 +172,10 @@ public:
     void Start();
     void Stop();
     void Disconnect();
-    void Connect ( QString strServerAddress, QString strServerName );
+    void Connect ( const QString& strServerAddress, const QString& strServerName );
 
     // The ConnectedServerName is emitted by Connecting() to update the UI with a human readable server name
-    void    SetConnectedServerName ( const QString strServerName ) { strConnectedServerName = strServerName; };
+    void    SetConnectedServerName ( const QString& strServerName ) { strConnectedServerName = strServerName; };
     QString GetConnectedServerName() const { return strConnectedServerName; };
 
     EConnectionState GetConnectionState() const { return eConnectionState; }
@@ -537,8 +537,8 @@ signals:
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
 
     void ConnectionStateChanged ( EConnectionState eConnectionState );
-    void Connecting ( QString strServerName );
-    void ConnectingFailed ( QString errorMessage );
+    void Connecting ( const QString& strServerName );
+    void ConnectingFailed ( const QString& errorMessage );
     void Disconnected();
 
     void SoundDeviceChanged ( QString strError );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -50,7 +50,6 @@
 /* Implementation *************************************************************/
 CClientDlg::CClientDlg ( CClient*         pNCliP,
                          CClientSettings* pNSetP,
-                         const QString&   strConnOnStartupAddress,
                          const bool       bNewShowComplRegConnList,
                          const bool       bShowAnalyzerConsole,
                          const bool       bMuteStream,
@@ -292,14 +291,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     TimerCheckAudioDeviceOk.setSingleShot ( true ); // only check once after connection
     TimerDetectFeedback.setSingleShot ( true );
 
-    // Connect on startup ------------------------------------------------------
-    if ( !strConnOnStartupAddress.isEmpty() )
-    {
-        // initiate connection (always show the address in the mixer board
-        // (no alias))
-        Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
-    }
-
     // File menu  --------------------------------------------------------------
     QMenu* pFileMenu = new QMenu ( tr ( "&File" ), this );
 
@@ -507,7 +498,11 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // other
     QObject::connect ( pClient, &CClient::ConClientListMesReceived, this, &CClientDlg::OnConClientListMesReceived );
 
-    QObject::connect ( pClient, &CClient::Disconnected, this, &CClientDlg::OnDisconnected );
+    QObject::connect ( pClient, &CClient::Connected, this, &CClientDlg::OnConnect );
+
+    QObject::connect ( pClient, &CClient::ConnectingFailed, this, &CClientDlg::OnConnectingFailed );
+
+    QObject::connect ( pClient, &CClient::Disconnected, this, &CClientDlg::OnDisconnect );
 
     QObject::connect ( pClient, &CClient::ChatTextReceived, this, &CClientDlg::OnChatTextReceived );
 
@@ -646,11 +641,8 @@ void CClientDlg::closeEvent ( QCloseEvent* Event )
     ConnectDlg.close();
     AnalyzerConsole.close();
 
-    // if connected, terminate connection
-    if ( pClient->IsRunning() )
-    {
-        pClient->Stop();
-    }
+    // Disconnect if needed
+    pClient->Disconnect();
 
     // make sure all current fader settings are applied to the settings struct
     MainMixerBoard->StoreAllFaderSettings();
@@ -768,15 +760,11 @@ void CClientDlg::OnConnectDlgAccepted()
             }
         }
 
-        // first check if we are already connected, if this is the case we have to
-        // disconnect the old server first
-        if ( pClient->IsRunning() )
-        {
-            Disconnect();
-        }
+        // Disconnect the client. We could be currently connected.
+        pClient->Disconnect();
 
         // initiate connection
-        Connect ( strSelectedAddress, strMixerBoardLabel );
+        pClient->Connect ( strSelectedAddress, strMixerBoardLabel );
 
         // reset flag
         bConnectDlgWasShown = false;
@@ -788,11 +776,12 @@ void CClientDlg::OnConnectDisconBut()
     // the connect/disconnect button implements a toggle functionality
     if ( pClient->IsRunning() )
     {
-        Disconnect();
-        SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
+        pClient->Stop();
     }
     else
     {
+        // If the client isn't running, we assume that we weren't connected. Thus show the connect dialog
+        // TODO: Refactor to have robust error handling
         ShowConnectionSetupDialog();
     }
 }
@@ -905,7 +894,7 @@ void CClientDlg::OnLicenceRequired ( ELicenceType eLicenceType )
         // disconnect from that server.
         if ( !LicenceDlg.exec() )
         {
-            Disconnect();
+            pClient->Disconnect();
         }
 
         // unmute the client output stream if local mute button is not pressed
@@ -1206,10 +1195,7 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
     if ( !strError.isEmpty() )
     {
         // the sound device setup has a problem, disconnect any active connection
-        if ( pClient->IsRunning() )
-        {
-            Disconnect();
-        }
+        pClient->Disconnect();
 
         // show the error message of the device setup
         QMessageBox::critical ( this, APP_NAME, strError, tr ( "Ok" ), nullptr );
@@ -1237,65 +1223,38 @@ void CClientDlg::OnCLPingTimeWithNumClientsReceived ( CHostAddress InetAddr, int
     ConnectDlg.SetPingTimeAndNumClientsResult ( InetAddr, iPingTime, iNumClients );
 }
 
-void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& strMixerBoardLabel )
+void CClientDlg::OnConnect ( const QString& strMixerBoardLabel )
 {
-    // set address and check if address is valid
-    if ( pClient->SetServerAddr ( strSelectedAddress ) )
+
+    // hide label connect to server
+    lblConnectToServer->hide();
+    lbrInputLevelL->setEnabled ( true );
+    lbrInputLevelR->setEnabled ( true );
+
+    // change connect button text to "disconnect"
+    butConnect->setText ( tr ( "&Disconnect" ) );
+
+    // set server name in audio mixer group box title
+    MainMixerBoard->SetServerName ( strMixerBoardLabel );
+
+    // start timer for level meter bar and ping time measurement
+    TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );
+    TimerBuffersLED.start ( BUFFER_LED_UPDATE_TIME_MS );
+    TimerPing.start ( PING_UPDATE_TIME_MS );
+    TimerCheckAudioDeviceOk.start ( CHECK_AUDIO_DEV_OK_TIME_MS ); // is single shot timer
+
+    // audio feedback detection
+    if ( pSettings->bEnableFeedbackDetection )
     {
-        // try to start client, if error occurred, do not go in
-        // running state but show error message
-        try
-        {
-            if ( !pClient->IsRunning() )
-            {
-                pClient->Start();
-            }
-        }
-
-        catch ( const CGenErr& generr )
-        {
-            // show error message and return the function
-            QMessageBox::critical ( this, APP_NAME, generr.GetErrorText(), "Close", nullptr );
-            return;
-        }
-
-        // hide label connect to server
-        lblConnectToServer->hide();
-        lbrInputLevelL->setEnabled ( true );
-        lbrInputLevelR->setEnabled ( true );
-
-        // change connect button text to "disconnect"
-        butConnect->setText ( tr ( "&Disconnect" ) );
-
-        // set server name in audio mixer group box title
-        MainMixerBoard->SetServerName ( strMixerBoardLabel );
-
-        // start timer for level meter bar and ping time measurement
-        TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );
-        TimerBuffersLED.start ( BUFFER_LED_UPDATE_TIME_MS );
-        TimerPing.start ( PING_UPDATE_TIME_MS );
-        TimerCheckAudioDeviceOk.start ( CHECK_AUDIO_DEV_OK_TIME_MS ); // is single shot timer
-
-        // audio feedback detection
-        if ( pSettings->bEnableFeedbackDetection )
-        {
-            TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
-            bDetectFeedback = true;
-        }
+        TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
+        bDetectFeedback = true;
     }
 }
 
-void CClientDlg::Disconnect()
-{
-    // only stop client if currently running, in case we received
-    // the stopped message, the client is already stopped but the
-    // connect/disconnect button and other GUI controls must be
-    // updated
-    if ( pClient->IsRunning() )
-    {
-        pClient->Stop();
-    }
+void CClientDlg::OnConnectingFailed ( const QString& strError ) { QMessageBox::critical ( this, APP_NAME, strError, tr ( "Close" ), nullptr ); }
 
+void CClientDlg::OnDisconnect()
+{
     // change connect button text to "connect"
     butConnect->setText ( tr ( "C&onnect" ) );
 
@@ -1337,6 +1296,9 @@ void CClientDlg::Disconnect()
 
     // clear mixer board (remove all faders)
     MainMixerBoard->HideAll();
+
+    // Reset the deco
+    SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
 }
 
 void CClientDlg::UpdateDisplay()

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -498,7 +498,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // other
     QObject::connect ( pClient, &CClient::ConClientListMesReceived, this, &CClientDlg::OnConClientListMesReceived );
 
-    QObject::connect ( pClient, &CClient::Connected, this, &CClientDlg::OnConnect );
+    QObject::connect ( pClient, &CClient::Connecting, this, &CClientDlg::OnConnecting );
 
     QObject::connect ( pClient, &CClient::ConnectingFailed, this, &CClientDlg::OnConnectingFailed );
 
@@ -760,10 +760,7 @@ void CClientDlg::OnConnectDlgAccepted()
             }
         }
 
-        // Disconnect the client. We could be currently connected.
-        pClient->Disconnect();
-
-        // initiate connection
+        // initiate connection (terminates any current connection first)
         pClient->Connect ( strSelectedAddress, strMixerBoardLabel );
 
         // reset flag
@@ -776,7 +773,7 @@ void CClientDlg::OnConnectDisconBut()
     // the connect/disconnect button implements a toggle functionality
     if ( pClient->IsRunning() )
     {
-        pClient->Stop();
+        pClient->Disconnect();
     }
     else
     {
@@ -1223,7 +1220,7 @@ void CClientDlg::OnCLPingTimeWithNumClientsReceived ( CHostAddress InetAddr, int
     ConnectDlg.SetPingTimeAndNumClientsResult ( InetAddr, iPingTime, iNumClients );
 }
 
-void CClientDlg::OnConnect ( const QString& strMixerBoardLabel )
+void CClientDlg::OnConnecting ( const QString& strMixerBoardLabel )
 {
 
     // hide label connect to server

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -145,7 +145,7 @@ protected:
     CAnalyzerConsole   AnalyzerConsole;
 
 public slots:
-    void OnConnect ( const QString& strServerName );
+    void OnConnecting ( const QString& strServerName );
     void OnConnectingFailed ( const QString& strErrorText );
     void OnDisconnect();
     void OnConnectDisconBut();

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -100,7 +100,6 @@ class CClientDlg : public CBaseDlg, private Ui_CClientDlgBase
 public:
     CClientDlg ( CClient*         pNCliP,
                  CClientSettings* pNSetP,
-                 const QString&   strConnOnStartupAddress,
                  const bool       bNewShowComplRegConnList,
                  const bool       bShowAnalyzerConsole,
                  const bool       bMuteStream,
@@ -116,8 +115,6 @@ protected:
     void ShowAnalyzerConsole();
     void UpdateAudioFaderSlider();
     void UpdateRevSelection();
-    void Connect ( const QString& strSelectedAddress, const QString& strMixerBoardLabel );
-    void Disconnect();
     void ManageDragNDrop ( QDropEvent* Event, const bool bCheckAccept );
     void SetPingTime ( const int iPingTime, const int iOverallDelayMs, const CMultiColorLED::ELightColor eOverallDelayLEDColor );
 
@@ -148,6 +145,9 @@ protected:
     CAnalyzerConsole   AnalyzerConsole;
 
 public slots:
+    void OnConnect ( const QString& strServerName );
+    void OnConnectingFailed ( const QString& strErrorText );
+    void OnDisconnect();
     void OnConnectDisconBut();
     void OnTimerSigMet();
     void OnTimerBuffersLED();
@@ -254,7 +254,6 @@ public slots:
     }
 
     void OnConnectDlgAccepted();
-    void OnDisconnected() { Disconnect(); }
     void OnGUIDesignChanged();
     void OnMeterStyleChanged();
     void OnRecorderStateReceived ( ERecorderState eRecorderState );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1007,25 +1007,30 @@ int main ( int argc, char** argv )
                 }
 
                 // GUI object
-                CClientDlg
-                    ClientDlg ( &Client, &Settings, strConnOnStartupAddress, bShowComplRegConnList, bShowAnalyzerConsole, bMuteStream, nullptr );
+                CClientDlg ClientDlg ( &Client, &Settings, bShowComplRegConnList, bShowAnalyzerConsole, bMuteStream, nullptr );
 
                 // show dialog
                 ClientDlg.show();
+
+                // Connect on startup if requested
+                if ( !strConnOnStartupAddress.isEmpty() )
+                {
+                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
+                }
 
                 pApp->exec();
             }
             else
 #    endif
             {
-                if ( !strConnOnStartupAddress.isEmpty() )
-                {
-                    Client.SetServerAddr ( strConnOnStartupAddress );
-                    Client.Start();
-                }
-
                 // only start application without using the GUI
                 qInfo() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
+
+                // Connect on startup if requested
+                if ( !strConnOnStartupAddress.isEmpty() )
+                {
+                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
+                }
 
                 pApp->exec();
             }

--- a/src/util.h
+++ b/src/util.h
@@ -593,6 +593,17 @@ enum ERecorderState
     RS_RECORDING       = 3
 };
 
+// Client connection state -----------------------------------------------------
+enum EConnectionState
+{
+    // a connection is "requested" as soon as the client starts the audio
+    // stream towards the configured server and "established" once the server
+    // has assigned a channel ID to the client
+    CS_DISCONNECTED = 0, // no connection requested or established
+    CS_CONNECTING   = 1, // connection requested but not yet established
+    CS_CONNECTED    = 2  // connection established and current
+};
+
 // Channel sort type -----------------------------------------------------------
 enum EChSortType
 {

--- a/src/util.h
+++ b/src/util.h
@@ -593,17 +593,6 @@ enum ERecorderState
     RS_RECORDING       = 3
 };
 
-// Client connection state -----------------------------------------------------
-enum EConnectionState
-{
-    // a connection is "requested" as soon as the client starts the audio
-    // stream towards the configured server and "established" once the server
-    // has assigned a channel ID to the client
-    CS_DISCONNECTED = 0, // no connection requested or established
-    CS_CONNECTING   = 1, // connection requested but not yet established
-    CS_CONNECTED    = 2  // connection established and current
-};
-
 // Channel sort type -----------------------------------------------------------
 enum EChSortType
 {


### PR DESCRIPTION
**Short description of changes**

This picks up and finishes #3372 (@ann0see's extract of @pgScorpio's work in #2550), which had stalled on review discussion. It contains two commits:

1. **The original #3372 refactor, ported onto current `main`** (authorship preserved): `Connect()` / `Disconnect()` move out of `CClientDlg` into `CClient`, which emits signals the dialog consumes. `CClientDlg` no longer holds connection logic — it only reacts (`OnConnecting`, `OnConnectingFailed`, `OnDisconnect`). Connect-on-startup moves out of the dialog constructor into `main.cpp` via `Client.Connect(...)`, so it now also works identically in `--nogui` mode.

2. **An explicit connection state machine**, addressing the state-model review comments in #3372: a new `EConnectionState` (`CS_DISCONNECTED` / `CS_CONNECTING` / `CS_CONNECTED`) owned by `CClient` as the single source of truth, with every transition emitting `ConnectionStateChanged`. Following that discussion's definitions: a connection is *requested* (`CS_CONNECTING`) when the audio stream starts toward the configured server, and *established* (`CS_CONNECTED`) once the server assigns our channel ID. Accordingly, the signal formerly emitted from `Start()` as `Connected(name)` is renamed `Connecting(name)`, since at that point the connection is only requested. `CClient::Connect()` now terminates any current connection first, so connecting while connected behaves as a clean reconnect.

This is a step toward #3801 (CClient as the orchestration layer behind UI and JSON-RPC): a follow-up PR stacked on this one exposes connect/disconnect/state over JSON-RPC as symmetric consumers of the same signals.

**Context: Fixes an issue?**

Fixes #3367. Supersedes #3372 (both commits build on it; the first preserves its authorship).

**Does this change need documentation? What needs to be documented and how?**

No user-facing behavior change. The follow-up JSON-RPC PR updates `docs/JSON-RPC.md`.

**Status of this Pull Request**

Ready for review.

**What is missing until this pull request can be merged?**

Review.

Tested: full GUI build and `CONFIG+=headless` build on Linux/Qt 5.15; a `--nogui` client was driven through connect → reconnect-while-connected → disconnect cycles against a local server, observing the `Connecting`/`ConnectionStateChanged`/`Disconnected` signal sequence via the follow-up PR's JSON-RPC notifications (16/16 scripted checks pass); clean SIGTERM shutdown verified.

## Checklist

- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I tested my code and it does what I want
- [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I've filled all the content above

AUTOBUILD: Please build all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
