### PR TITLE
Add profile checkbox to enable/disable tooltips (rebase of #3446)

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -104,11 +104,13 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     lbrInputLevelL->setAccessibleName ( strInpLevHAccText );
     lbrInputLevelL->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelL->setToolTip ( strInpLevHTT );
+    lbrInputLevelL->installEventFilter ( this ); // install event filter for tooltips
     lbrInputLevelL->setEnabled ( false );
     lbrInputLevelR->setWhatsThis ( strInpLevH );
     lbrInputLevelR->setAccessibleName ( strInpLevHAccText );
     lbrInputLevelR->setAccessibleDescription ( strInpLevHAccDescr );
     lbrInputLevelR->setToolTip ( strInpLevHTT );
+    lbrInputLevelR->installEventFilter ( this ); // install event filter for tooltips
     lbrInputLevelR->setEnabled ( false );
 
     // connect/disconnect button
@@ -173,6 +175,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
                                 "you will not have much fun using %1." )
                                .arg ( APP_NAME ) +
                            TOOLTIP_COM_END_TEXT );
+    ledDelay->installEventFilter ( this ); // install event filter for tooltips
 
     ledDelay->setAccessibleName ( tr ( "Delay status LED indicator" ) );
 
@@ -204,6 +207,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     ledBuffers->setToolTip ( tr ( "If this LED indicator turns red, "
                                   "the audio stream is interrupted." ) +
                              TOOLTIP_COM_END_TEXT );
+    ledBuffers->installEventFilter ( this ); // install event filter for tooltips
 
     ledBuffers->setAccessibleName ( tr ( "Local Jitter Buffer status LED indicator" ) );
 
@@ -1557,4 +1561,16 @@ void CClientDlg::OnMIDIControllerUsageChanged ( bool bEnabled )
 
     // Enable/disable runtime MIDI via the sound interface through the public CClient interface
     pClient->EnableMIDI ( bEnabled );
+}
+
+bool CClientDlg::eventFilter ( QObject* obj, QEvent* event )
+{
+    if ( event->type() == QEvent::ToolTip )
+    {
+        // return true to suppress tooltip, false to allow it
+        return !pSettings->bShowToolTips;
+    }
+
+    // continue with normal processing for other events
+    return QObject::eventFilter ( obj, event );
 }

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -142,6 +142,8 @@ protected:
     virtual void dropEvent ( QDropEvent* Event ) { ManageDragNDrop ( Event, false ); }
     void         UpdateDisplay();
 
+    bool eventFilter ( QObject* obj, QEvent* event );
+
     CClientSettingsDlg ClientSettingsDlg;
     CChatDlg           ChatDlg;
     CConnectDlg        ConnectDlg;

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -477,6 +477,11 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     butLearnSoloOffset->setAccessibleName ( tr ( "Solo offset MIDI learn button" ) );
     butLearnMuteOffset->setAccessibleName ( tr ( "Mute offset MIDI learn button" ) );
 
+    // show tooltips
+    chbShowToolTips->setWhatsThis ( "<b>" + tr ( "Show ToolTips" ) + ":</b> " +
+                                    tr ( "Enable or disable the showing of ToolTips when the mouse points to certain items." ) );
+    chbShowToolTips->setAccessibleName ( tr ( "Show ToolTips check box" ) );
+
     // init driver button
 #if defined( _WIN32 ) && !defined( WITH_JACK )
     butDriverSetup->setText ( tr ( "ASIO Device Settings" ) );
@@ -560,6 +565,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     // init audio alerts
     chbAudioAlerts->setCheckState ( pSettings->bEnableAudioAlerts ? Qt::Checked : Qt::Unchecked );
+
+    // init show tooltips
+    chbShowToolTips->setCheckState ( pSettings->bShowToolTips ? Qt::Checked : Qt::Unchecked );
 
     // update feedback detection
     chbDetectFeedback->setCheckState ( pSettings->bEnableFeedbackDetection ? Qt::Checked : Qt::Unchecked );
@@ -725,6 +733,8 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     QObject::connect ( chbDetectFeedback, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnFeedbackDetectionChanged );
 
     QObject::connect ( chbAudioAlerts, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnAudioAlertsChanged );
+
+    QObject::connect ( chbShowToolTips, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnShowToolTipsChanged );
 
     // line edits
     QObject::connect ( edtNewClientLevel, &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnNewClientLevelEditingFinished );
@@ -1274,6 +1284,8 @@ void CClientSettingsDlg::OnMeterStyleActivated ( int iMeterStyleIdx )
 }
 
 void CClientSettingsDlg::OnAudioAlertsChanged ( int value ) { pSettings->bEnableAudioAlerts = value == Qt::Checked; }
+
+void CClientSettingsDlg::OnShowToolTipsChanged ( int value ) { pSettings->bShowToolTips = value == Qt::Checked; }
 
 void CClientSettingsDlg::OnAutoJitBufStateChanged ( int value )
 {

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -1056,6 +1056,12 @@ void CClientSettingsDlg::showEvent ( QShowEvent* event )
 
 bool CClientSettingsDlg::eventFilter ( QObject* obj, QEvent* event )
 {
+    if ( event->type() == QEvent::ToolTip )
+    {
+        // return true to suppress tooltip, false to allow it
+        return !pSettings->bShowToolTips;
+    }
+
     // Refresh MIDI device list when user clicks on the dropdown
     if ( obj == cbxMidiDevice )
     {
@@ -1718,15 +1724,3 @@ void CClientSettingsDlg::OnMidiCCReceived ( int ccNumber )
 }
 
 void CClientSettingsDlg::OnMIDIPickupModeToggled ( bool checked ) { pSettings->bMIDIPickupMode = checked; }
-
-bool CClientSettingsDlg::eventFilter ( QObject* obj, QEvent* event )
-{
-    if ( event->type() == QEvent::ToolTip )
-    {
-        // return true to suppress tooltip, false to allow it
-        return !pSettings->bShowToolTips;
-    }
-
-    // continue with normal processing for other events
-    return QObject::eventFilter ( obj, event );
-}

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -129,16 +129,21 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
     lblNetBuf->setWhatsThis ( strJitterBufferSize );
     lblNetBuf->setToolTip ( strJitterBufferSizeTT );
+    lblNetBuf->installEventFilter ( this ); // install event filter for tooltips
     grbJitterBuffer->setWhatsThis ( strJitterBufferSize );
     grbJitterBuffer->setToolTip ( strJitterBufferSizeTT );
+    grbJitterBuffer->installEventFilter ( this ); // install event filter for tooltips
     sldNetBuf->setWhatsThis ( strJitterBufferSize );
     sldNetBuf->setAccessibleName ( tr ( "Local jitter buffer slider control" ) );
     sldNetBuf->setToolTip ( strJitterBufferSizeTT );
+    sldNetBuf->installEventFilter ( this ); // install event filter for tooltips
     sldNetBufServer->setWhatsThis ( strJitterBufferSize );
     sldNetBufServer->setAccessibleName ( tr ( "Server jitter buffer slider control" ) );
     sldNetBufServer->setToolTip ( strJitterBufferSizeTT );
+    sldNetBufServer->installEventFilter ( this ); // install event filter for tooltips
     chbAutoJitBuf->setAccessibleName ( tr ( "Auto jitter buffer check box" ) );
     chbAutoJitBuf->setToolTip ( strJitterBufferSizeTT );
+    chbAutoJitBuf->installEventFilter ( this ); // install event filter for tooltips
 
 #if !defined( WITH_JACK )
     // sound card device
@@ -166,6 +171,7 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                                     "driver, make sure to connect the ASIO inputs in the kX DSP settings "
                                     "panel." ) +
                                TOOLTIP_COM_END_TEXT );
+    cbxSoundcard->installEventFilter ( this ); // install event filter for tooltips
 #    endif
 
     // sound card input/output channel mapping
@@ -272,17 +278,21 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     rbtBufferDelayPreferred->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayPreferred->setAccessibleName ( tr ( "64 samples setting radio button" ) );
     rbtBufferDelayPreferred->setToolTip ( strSndCrdBufDelayTT );
+    rbtBufferDelayPreferred->installEventFilter ( this ); // install event filter for tooltips
     rbtBufferDelayDefault->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelayDefault->setAccessibleName ( tr ( "128 samples setting radio button" ) );
     rbtBufferDelayDefault->setToolTip ( strSndCrdBufDelayTT );
+    rbtBufferDelayDefault->installEventFilter ( this ); // install event filter for tooltips
     rbtBufferDelaySafe->setWhatsThis ( strSndCrdBufDelay );
     rbtBufferDelaySafe->setAccessibleName ( tr ( "256 samples setting radio button" ) );
     rbtBufferDelaySafe->setToolTip ( strSndCrdBufDelayTT );
+    rbtBufferDelaySafe->installEventFilter ( this ); // install event filter for tooltips
 
 #if defined( _WIN32 ) && !defined( WITH_JACK )
     butDriverSetup->setWhatsThis ( strSndCardDriverSetup );
     butDriverSetup->setAccessibleName ( tr ( "ASIO Device Settings push button" ) );
     butDriverSetup->setToolTip ( strSndCardDriverSetupTT );
+    butDriverSetup->installEventFilter ( this ); // install event filter for tooltips
 #endif
 
     // fancy skin
@@ -478,9 +488,9 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     butLearnMuteOffset->setAccessibleName ( tr ( "Mute offset MIDI learn button" ) );
 
     // show tooltips
-    chbShowToolTips->setWhatsThis ( "<b>" + tr ( "Show ToolTips" ) + ":</b> " +
-                                    tr ( "Enable or disable the showing of ToolTips when the mouse points to certain items." ) );
-    chbShowToolTips->setAccessibleName ( tr ( "Show ToolTips check box" ) );
+    chbShowToolTips->setWhatsThis ( "<b>" + tr ( "Show tool tips" ) + ":</b> " +
+                                    tr ( "Enable or disable the showing of tool tips when the mouse points to certain items." ) );
+    chbShowToolTips->setAccessibleName ( tr ( "Show tool tips check box" ) );
 
     // init driver button
 #if defined( _WIN32 ) && !defined( WITH_JACK )
@@ -1708,3 +1718,15 @@ void CClientSettingsDlg::OnMidiCCReceived ( int ccNumber )
 }
 
 void CClientSettingsDlg::OnMIDIPickupModeToggled ( bool checked ) { pSettings->bMIDIPickupMode = checked; }
+
+bool CClientSettingsDlg::eventFilter ( QObject* obj, QEvent* event )
+{
+    if ( event->type() == QEvent::ToolTip )
+    {
+        // return true to suppress tooltip, false to allow it
+        return !pSettings->bShowToolTips;
+    }
+
+    // continue with normal processing for other events
+    return QObject::eventFilter ( obj, event );
+}

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -94,8 +94,6 @@ protected:
     virtual void showEvent ( QShowEvent* ) override;
     virtual bool eventFilter ( QObject* obj, QEvent* event ) override;
 
-    bool eventFilter ( QObject* obj, QEvent* event );
-
     CClient*         pClient;
     CClientSettings* pSettings;
     QTimer           TimerStatus;

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -94,6 +94,8 @@ protected:
     virtual void showEvent ( QShowEvent* ) override;
     virtual bool eventFilter ( QObject* obj, QEvent* event ) override;
 
+    bool eventFilter ( QObject* obj, QEvent* event );
+
     CClient*         pClient;
     CClientSettings* pSettings;
     QTimer           TimerStatus;

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -120,6 +120,7 @@ public slots:
     void OnGUIDesignActivated ( int iDesignIdx );
     void OnMeterStyleActivated ( int iMeterStyleIdx );
     void OnAudioAlertsChanged ( int value );
+    void OnShowToolTipsChanged ( int value );
     void OnLanguageChanged ( QString strLanguage ) { pSettings->strLanguage = strLanguage; }
     void OnAliasTextChanged ( const QString& strNewName );
     void OnInstrumentActivated ( int iCntryListItem );
@@ -140,6 +141,7 @@ signals:
     void GUIDesignChanged();
     void MeterStyleChanged();
     void AudioAlertsChanged();
+    void ShowToolTipsChanged();
     void AudioChannelsChanged();
     void CustomDirectoriesChanged();
     void NumMixerPanelRowsChanged ( int value );

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -332,7 +332,7 @@
                   <item>
                    <widget class="QCheckBox" name="chbShowToolTips">
                     <property name="text">
-                     <string>Show Tooltips</string>
+                     <string>Show tool tips</string>
                     </property>
                    </widget>
                   </item>

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -276,6 +276,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <widget class="QLabel" name="lblShowToolTips">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </item>
                 <item>
@@ -319,6 +326,13 @@
                    <widget class="QCheckBox" name="chbAudioAlerts">
                     <property name="text">
                      <string>Audio Alerts</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="chbShowToolTips">
+                    <property name="text">
+                     <string>Show Tooltips</string>
                     </property>
                    </widget>
                   </item>
@@ -2266,6 +2280,7 @@
   <tabstop>cbxLanguage</tabstop>
   <tabstop>spnMixerRows</tabstop>
   <tabstop>chbAudioAlerts</tabstop>
+  <tabstop>chbShowToolTips</tabstop>
   <tabstop>cbxSoundcard</tabstop>
   <tabstop>butDriverSetup</tabstop>
   <tabstop>cbxLInChan</tabstop>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -460,6 +460,12 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
         bEnableAudioAlerts = bValue;
     }
 
+    // show tooltips
+    if ( GetFlagIniSet ( IniXMLDocument, "client", "showtooltips", bValue ) )
+    {
+        bShowToolTips = bValue;
+    }
+
     // name
     pClient->ChannelInfo.strName = FromBase64ToString (
         GetIniSetting ( IniXMLDocument, "client", "name_base64", ToBase64 ( QCoreApplication::translate ( "CMusProfDlg", "No Name" ) ) ) );
@@ -926,6 +932,9 @@ void CClientSettings::WriteSettingsToXML ( QDomDocument& IniXMLDocument, bool is
 
     // audio alerts
     SetFlagIniSet ( IniXMLDocument, "client", "enableaudioalerts", bEnableAudioAlerts );
+
+    // show tooltips
+    SetFlagIniSet ( IniXMLDocument, "client", "showtooltips", bShowToolTips );
 
     // name
     PutIniSetting ( IniXMLDocument, "client", "name_base64", ToBase64 ( pClient->ChannelInfo.strName ) );

--- a/src/settings.h
+++ b/src/settings.h
@@ -179,6 +179,7 @@ public:
         eDirectoryType ( AT_DEFAULT ),
         bEnableFeedbackDetection ( true ),
         bEnableAudioAlerts ( false ),
+        bShowToolTips ( true ),
         vecWindowPosSettings(), // empty array
         vecWindowPosChat(),     // empty array
         vecWindowPosConnect(),  // empty array
@@ -252,6 +253,7 @@ public:
     int              iCustomDirectoryIndex; // index of selected custom directory
     bool             bEnableFeedbackDetection;
     bool             bEnableAudioAlerts;
+    bool             bShowToolTips;
 
     // window position/state settings
     QByteArray vecWindowPosSettings;


### PR DESCRIPTION
**Short description of changes**

This supersedes (and is a rebase of) #3446 by @softins, which was approved by @ann0see but has since gone stale against `main`. It adds a "Show tool tips" checkbox to the Settings dialog; the setting is stored in the `.ini` file, and per-dialog event filters consume `QEvent::ToolTip` when tooltips are disabled.

softins' two commits are preserved unchanged (authorship intact). One adaptation commit on top resolves the drift since the PR was written: `main` now has its own `CClientSettingsDlg::eventFilter` override (MIDI device-list refresh, from the MIDI settings work), so the tooltip suppression check is folded into that existing filter instead of adding a duplicate.

CHANGELOG: Add profile checkbox to enable/disable tooltips

**Context: Fixes an issue?**

Supersedes #3446. Also unblocks #3252, whose approval was conditioned on this toggle existing.

**Does this change need documentation? What needs to be documented and how?**

Possibly a short note on the website settings docs for the new checkbox.

**Status of this Pull Request**

Ready for review. Builds clean with Qt 5.15 on Linux; clang-format-14 clean; headless SIGTERM smoke test passes. The functional behavior was already tested by @ann0see on Windows in the original PR ("On windows it works as expected").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
