### PR TITLE
Add IPv6 support for Directories (still incomplete)

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -376,6 +376,34 @@ Results:
 | result | string | Always "ok". |
 
 
+### jamulusdirectory/getServerList
+
+Returns the list of registered servers along with details about them.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params | object | No parameters (empty object). |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result.numservers | number | The number of registered servers. |
+| result.servers | array | The list of registered servers. |
+| result.servers[*].id | number | The server's index. |
+| result.servers[*].name | string | The server's name. |
+| result.servers[*].countryName | string | The text name of the country specified by the user for this channel (see QLocale::Country). |
+| result.servers[*].city | string | The city name provided by the operator of this server. |
+| result.servers[*].maxClients | number | The max number of clients supported by the server. |
+| result.servers[*].permanent | bool | The permanent status of the server. |
+| result.servers[*].ipv4addr | string | The IPv4 address the server registered from (ip:port) |
+| result.servers[*].ipv4addrLocal | string | The local IPv4 address provided by the server (ip:port) |
+| result.servers[*].ipv6addr | string | The IPv6 address the server registered from ([ipv6]:port) |
+| result.servers[*].ipv6addrLocal | string | The local IPv6 address provided by the server ([ipv6]:port) |
+
+
 ### jamulusserver/broadcastChatMessage
 
 Sends a message (as the server) to all connected clients. This can be used to broadcast messages from external sources (e.g. scripts or monitoring tools).

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -189,8 +189,8 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
 
         CHostAddress haDirectoryAddress;
 
-        // Allow IPv4 only for communicating with Directories
-        if ( !NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
+        // Allow IPv4 and IPv6 for communicating with Directories
+        if ( !NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, pClient->IsIPv6Available() ) )
         {
             response["error"] =
                 CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: directory is not a valid socket address" );

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -137,14 +137,14 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
                   for ( const auto& serverInfo : vecServerInfo )
                   {
                       QJsonObject objServerInfo{
-                          { "address", serverInfo.HostAddr.toString() },
+                          { "address", serverInfo.HostAddr4.toString() },
                           { "name", serverInfo.strName },
                           { "countryId", serverInfo.eCountry },
                           { "country", QLocale::countryToString ( serverInfo.eCountry ) },
                           { "city", serverInfo.strCity },
                       };
                       arrServerInfo.append ( objServerInfo );
-                      pClient->CreateCLServerListPingMes ( serverInfo.HostAddr );
+                      pClient->CreateCLServerListPingMes ( serverInfo.HostAddr4 );
                   }
                   pRpcServer->BroadcastNotification ( "jamulusclient/serverListReceived",
                                                       QJsonObject{

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -190,7 +190,7 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
         CHostAddress haDirectoryAddress;
 
         // Allow IPv4 only for communicating with Directories
-        if ( !NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
+        if ( !NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, pClient->IsIPv6Available() ) )
         {
             response["error"] =
                 CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: directory is not a valid socket address" );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -457,7 +457,7 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
 
         if ( iIdx > 0 )
         {
-            CurHostAddress = vecServerInfo[iIdx].HostAddr;
+            CurHostAddress = vecServerInfo[iIdx].HostAddr4;
         }
         else
         {
@@ -485,7 +485,7 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
             // IP address and port (use IP number without last byte)
             // Definition: If the port number is the default port number, we do
             // not show it.
-            if ( vecServerInfo[iIdx].HostAddr.iPort == DEFAULT_PORT_NUMBER )
+            if ( vecServerInfo[iIdx].HostAddr4.iPort == DEFAULT_PORT_NUMBER )
             {
                 // only show IP number, no port number
                 pNewListViewItem->setText ( LVC_NAME, CurHostAddress.toString ( CHostAddress::SM_IP_NO_LAST_BYTE ) );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -419,7 +419,7 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
 
         if ( iIdx > 0 )
         {
-            CurHostAddress = vecServerInfo[iIdx].HostAddr;
+            CurHostAddress = vecServerInfo[iIdx].HostAddr4;
         }
         else
         {
@@ -447,7 +447,7 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
             // IP address and port (use IP number without last byte)
             // Definition: If the port number is the default port number, we do
             // not show it.
-            if ( vecServerInfo[iIdx].HostAddr.iPort == DEFAULT_PORT_NUMBER )
+            if ( vecServerInfo[iIdx].HostAddr4.iPort == DEFAULT_PORT_NUMBER )
             {
                 // only show IP number, no port number
                 pNewListViewItem->setText ( LVC_NAME, CurHostAddress.toString ( CHostAddress::SM_IP_NO_LAST_BYTE ) );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -319,7 +319,7 @@ void CConnectDlg::RequestServerList()
     if ( NetworkUtil::ParseNetworkAddress (
              NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
              haDirectoryAddress,
-             false ) )
+             pClient->IsIPv6Available() ) )
     {
         // send the request for the server list
         emit ReqServerListQuery ( haDirectoryAddress );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -358,7 +358,7 @@ void CConnectDlg::RequestServerList()
     if ( NetworkUtil::ParseNetworkAddress (
              NetworkUtil::GetDirectoryAddress ( pSettings->eDirectoryType, pSettings->vstrDirectoryAddress[pSettings->iCustomDirectoryIndex] ),
              haDirectoryAddress,
-             false ) )
+             pClient->IsIPv6Available() ) )
     {
         // send the request for the server list
         emit ReqServerListQuery ( haDirectoryAddress );

--- a/src/global.h
+++ b/src/global.h
@@ -285,7 +285,7 @@ LED bar:      lbr
 #define MAX_LEN_CHAT_TEXT           1600
 #define MAX_LEN_CHAT_TEXT_PLUS_HTML 1800
 #define MAX_LEN_SERVER_NAME         20
-#define MAX_LEN_IP_ADDRESS          15
+#define MAX_LEN_IP_ADDRESS          39 // 15 for IPv4, 39 for IPv6
 #define MAX_LEN_SERVER_CITY         20
 #define MAX_LEN_VERSION_TEXT        50
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -2109,11 +2109,11 @@ void CProtocol::CreateCLServerListMes ( const CHostAddress& InetAddr, const CVec
 
         // IP address (4 bytes)
         // note the Server List manager has put the internal details in HostAddr where required
-        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr.InetAddr.toIPv4Address() ), 4 );
+        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr4.InetAddr.toIPv4Address() ), 4 );
 
         // port number (2 bytes)
         // note the Server List manager has put the internal details in HostAddr where required
-        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr.iPort ), 2 );
+        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr4.iPort ), 2 );
 
         // country (2 bytes)
         PutCountryOnStream ( vecData, iPos, vecServerInfo[i].eCountry );
@@ -2232,11 +2232,11 @@ void CProtocol::CreateCLRedServerListMes ( const CHostAddress& InetAddr, const C
 
         // IP address (4 bytes)
         // note the Server List manager has put the internal details in HostAddr where required
-        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr.InetAddr.toIPv4Address() ), 4 );
+        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr4.InetAddr.toIPv4Address() ), 4 );
 
         // port number (2 bytes)
         // note the Server List manager has put the internal details in HostAddr where required
-        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr.iPort ), 2 );
+        PutValOnStream ( vecData, iPos, static_cast<uint32_t> ( vecServerInfo[i].HostAddr4.iPort ), 2 );
 
         // name (note that the string length indicator is 1 in this special case)
         PutStringUTF8OnStream ( vecData, iPos, strUTF8Name, 1 );

--- a/src/server.h
+++ b/src/server.h
@@ -166,6 +166,8 @@ public:
     void             SetServerCountry ( const QLocale::Country eNewCountry ) { ServerListManager.SetServerCountry ( eNewCountry ); }
     QLocale::Country GetServerCountry() { return ServerListManager.GetServerCountry(); }
 
+    bool GetDirectoryServerList ( CVector<CServerInfo>& vecServerInfo ) { return ServerListManager.GetDirectoryServerList ( vecServerInfo ); }
+
     bool    GetRecorderInitialised() { return JamController.GetRecorderInitialised(); }
     void    SetEnableRecording ( bool bNewEnableRecording );
     bool    GetDisableRecording() { return bDisableRecording; }

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -1027,7 +1027,18 @@ void CServerListManager::SetRegistered ( const bool bIsRegister )
             // For a registered server, the server properties are stored in the
             // very first item in the server list (which is actually no server list
             // but just one item long for the registered server).
-            pConnLessProtocol->CreateCLRegisterServerExMes ( DirectoryAddress, ServerList[0].LHostAddr, ServerList[0] );
+            if ( DirectoryAddress.InetAddr.protocol() == QAbstractSocket::IPv4Protocol )
+            {
+                pConnLessProtocol->CreateCLRegisterServerExMes ( DirectoryAddress, ServerPublicIP, ServerList[0] );
+            }
+            else if ( DirectoryAddress.InetAddr.protocol() == QAbstractSocket::IPv6Protocol )
+            {
+                pConnLessProtocol->CreateCLRegisterServerExMes ( DirectoryAddress, ServerPublicIP6, ServerList[0] );
+            }
+            else
+            {
+                SetSvrRegStatus ( SRS_BAD_ADDRESS );
+            }
         }
         else
         {

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -1012,7 +1012,7 @@ void CServerListManager::SetRegistered ( const bool bIsRegister )
     // Allow IPv4 only for communicating with Directories
     // Use SRV DNS discovery for directory connections, fallback to A/AAAA if none.
     const QString strNetworkAddress      = NetworkUtil::GetDirectoryAddress ( DirectoryType, strDirectoryAddress );
-    const bool    bDirectoryAddressValid = NetworkUtil::ParseNetworkAddress ( strNetworkAddress, DirectoryAddress, false );
+    const bool    bDirectoryAddressValid = NetworkUtil::ParseNetworkAddress ( strNetworkAddress, DirectoryAddress, pServer->IsIPv6Available() );
 
     // lock the mutex again now that the address has been resolved.
     locker.relock();

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -77,6 +77,20 @@ from clients not on the same LAN as the directory.
 /* Implementation *************************************************************/
 
 // --- CServerListEntry ---
+CServerListEntry::CServerListEntry() : CServerInfo ( CHostAddress(), CHostAddress(), "", QLocale::AnyCountry, "", 0, false ) { UpdateRegistration(); }
+
+CServerListEntry::CServerListEntry ( const CHostAddress& NHAddr, const CHostAddress& NLHAddr, const CServerCoreInfo& NewCoreServerInfo ) :
+    CServerInfo ( NHAddr,
+                  NLHAddr,
+                  NewCoreServerInfo.strName,
+                  NewCoreServerInfo.eCountry,
+                  NewCoreServerInfo.strCity,
+                  NewCoreServerInfo.iMaxNumClients,
+                  NewCoreServerInfo.bPermanentOnline )
+{
+    UpdateRegistration();
+}
+
 CServerListEntry CServerListEntry::parse ( QString strHAddr,
                                            QString strLHAddr,
                                            QString sName,

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -799,7 +799,11 @@ int CServerListManager::IndexOf ( const CHostAddress& haSearchTerm )
     // (i.e., this server).
     for ( int iIdx = ServerList.size() - 1; iIdx > 0; iIdx-- )
     {
-        if ( ServerList[iIdx].HostAddr4 == haSearchTerm )
+        if ( haSearchTerm.InetAddr.protocol() == QAbstractSocket::IPv4Protocol && ServerList[iIdx].HostAddr4 == haSearchTerm )
+        {
+            return iIdx;
+        }
+        if ( haSearchTerm.InetAddr.protocol() == QAbstractSocket::IPv6Protocol && ServerList[iIdx].HostAddr6 == haSearchTerm )
         {
             return iIdx;
         }

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -86,7 +86,8 @@ CServerListEntry::CServerListEntry ( const CHostAddress& NHAddr, const CHostAddr
                   NewCoreServerInfo.eCountry,
                   NewCoreServerInfo.strCity,
                   NewCoreServerInfo.iMaxNumClients,
-                  NewCoreServerInfo.bPermanentOnline )
+                  NewCoreServerInfo.bPermanentOnline ),
+    token ( QRandomGenerator::system()->generate() )
 {
     UpdateRegistration();
 }

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -130,8 +130,8 @@ QString CServerListEntry::toCSV()
 {
     QStringList sl;
 
-    sl.append ( this->HostAddr.toString() );
-    sl.append ( this->LHostAddr.toString() );
+    sl.append ( this->HostAddr4.toString() );
+    sl.append ( this->LHostAddr4.toString() );
     sl.append ( ToBase64 ( this->strName ) );
     sl.append ( ToBase64 ( this->strCity ) );
     sl.append ( QString::number ( this->eCountry ) );
@@ -543,7 +543,7 @@ void CServerListManager::OnTimerPingServerInList()
     for ( int iIdx = 1; iIdx < iCurServerListSize; iIdx++ )
     {
         // send empty message to keep NAT port open at registered server
-        pConnLessProtocol->CreateCLEmptyMes ( ServerList[iIdx].HostAddr );
+        pConnLessProtocol->CreateCLEmptyMes ( ServerList[iIdx].HostAddr4 );
     }
 }
 
@@ -560,7 +560,7 @@ void CServerListManager::OnTimerPollList()
         if ( ServerList[iIdx].RegisterTime.elapsed() > ( SERVLIST_TIME_OUT_MINUTES * 60000 ) )
         {
             // remove this list entry
-            vecRemovedHostAddr.Add ( ServerList[iIdx].HostAddr );
+            vecRemovedHostAddr.Add ( ServerList[iIdx].HostAddr4 );
             ServerList.removeAt ( iIdx );
         }
     }
@@ -637,7 +637,7 @@ void CServerListManager::Append ( const CHostAddress&    InetAddr,
         else
         {
             // update all data and call update registration function
-            ServerList[iSelIdx].LHostAddr        = LInetAddr;
+            ServerList[iSelIdx].LHostAddr4       = LInetAddr;
             ServerList[iSelIdx].strName          = ServerInfo.strName;
             ServerList[iSelIdx].eCountry         = ServerInfo.eCountry;
             ServerList[iSelIdx].strCity          = ServerInfo.strCity;
@@ -695,12 +695,12 @@ void CServerListManager::RetrieveAll ( const CHostAddress& InetAddr )
         bool clientIsInternal = NetworkUtil::IsPrivateNetworkIP ( InetAddr.InetAddr );
 
         CHostAddress clientPublicAddr = InetAddr;
-        if ( clientIsInternal && CHostAddress().InetAddr != ServerList[0].LHostAddr.InetAddr &&
-             !NetworkUtil::IsPrivateNetworkIP ( ServerList[0].LHostAddr.InetAddr ) )
+        if ( clientIsInternal && CHostAddress().InetAddr != ServerList[0].LHostAddr4.InetAddr &&
+             !NetworkUtil::IsPrivateNetworkIP ( ServerList[0].LHostAddr4.InetAddr ) )
         {
             // client and directory on same LAN, directory has public IP set, that should be suitable for the
             // client, too (i.e. same router with same public IP will be used for both), so use it for client public IP
-            clientPublicAddr.InetAddr = ServerList[0].LHostAddr.InetAddr;
+            clientPublicAddr.InetAddr = ServerList[0].LHostAddr4.InetAddr;
         }
 
         const ushort iCurServerListSize = static_cast<ushort> ( ServerList.size() );
@@ -709,8 +709,8 @@ void CServerListManager::RetrieveAll ( const CHostAddress& InetAddr )
         CVector<CServerInfo> vecServerInfo ( iCurServerListSize );
 
         // copy list item for the directory and just let the protocol sort out the actual details
-        vecServerInfo[0]          = ServerList[0];
-        vecServerInfo[0].HostAddr = CHostAddress();
+        vecServerInfo[0]           = ServerList[0];
+        vecServerInfo[0].HostAddr4 = CHostAddress();
 
         // copy the list (we have to copy it since the message requires a vector but the list is actually stored in a QList object
         // and not in a vector object)
@@ -719,25 +719,25 @@ void CServerListManager::RetrieveAll ( const CHostAddress& InetAddr )
             // copy list item
             CServerInfo& siCurListEntry = vecServerInfo[iIdx] = ServerList[iIdx];
 
-            bool serverIsInternal = NetworkUtil::IsPrivateNetworkIP ( siCurListEntry.HostAddr.InetAddr );
+            bool serverIsInternal = NetworkUtil::IsPrivateNetworkIP ( siCurListEntry.HostAddr4.InetAddr );
 
-            bool wantHostAddr = clientIsInternal /* HostAddr is local IP if local server else external IP, so do not replace */ ||
+            bool wantHostAddr = clientIsInternal /* HostAddr4 is local IP if local server else external IP, so do not replace */ ||
                                 ( !serverIsInternal &&
-                                  InetAddr.InetAddr != siCurListEntry.HostAddr.InetAddr /* external server and client have different public IPs */ );
+                                  InetAddr.InetAddr != siCurListEntry.HostAddr4.InetAddr /* external server and client have different public IPs */ );
 
             if ( !wantHostAddr )
             {
-                vecServerInfo[iIdx].HostAddr = siCurListEntry.LHostAddr;
+                vecServerInfo[iIdx].HostAddr4 = siCurListEntry.LHostAddr4;
             }
 
             // do not send a "ping" to a server local to the directory (no need)
             if ( !serverIsInternal )
             {
                 // create "send empty message" for all other registered servers
-                // this causes the server (vecServerInfo[iIdx].HostAddr)
+                // this causes the server (vecServerInfo[iIdx].HostAddr4)
                 // to send a "reply" to the client (InetAddr or best guess public IP address if internal to directory)
                 // - with the intent of opening the server firewall for the client
-                pConnLessProtocol->CreateCLSendEmptyMesMes ( siCurListEntry.HostAddr, clientPublicAddr );
+                pConnLessProtocol->CreateCLSendEmptyMesMes ( siCurListEntry.HostAddr4, clientPublicAddr );
             }
         }
 
@@ -758,7 +758,7 @@ int CServerListManager::IndexOf ( const CHostAddress& haSearchTerm )
     // (i.e., this server).
     for ( int iIdx = ServerList.size() - 1; iIdx > 0; iIdx-- )
     {
-        if ( ServerList[iIdx].HostAddr == haSearchTerm )
+        if ( ServerList[iIdx].HostAddr4 == haSearchTerm )
         {
             return iIdx;
         }
@@ -847,15 +847,15 @@ bool CServerListManager::Load()
                                                     pServer->IsIPv6Available() );
 
         // We expect servers to have addresses...
-        if ( ( CHostAddress() == serverListEntry.HostAddr ) )
+        if ( ( CHostAddress() == serverListEntry.HostAddr4 ) )
         {
             qWarning() << qUtf8Printable ( QString ( "Could not parse '%1' successfully - invalid host" ).arg ( line ) );
             continue;
         }
 
         qInfo() << qUtf8Printable ( QString ( "Loading registration for %1 (%2): %3" )
-                                        .arg ( serverListEntry.HostAddr.toString() )
-                                        .arg ( serverListEntry.LHostAddr.toString() )
+                                        .arg ( serverListEntry.HostAddr4.toString() )
+                                        .arg ( serverListEntry.LHostAddr4.toString() )
                                         .arg ( serverListEntry.strName ) );
         ServerList.append ( serverListEntry );
     }
@@ -889,8 +889,8 @@ void CServerListManager::Save()
     for ( int iIdx = ServerList.size() - 1; iIdx > 0; iIdx-- )
     {
         qInfo() << qUtf8Printable ( QString ( tr ( "Saving registration for %1 (%2): %3" ) )
-                                        .arg ( ServerList[iIdx].HostAddr.toString() )
-                                        .arg ( ServerList[iIdx].LHostAddr.toString() )
+                                        .arg ( ServerList[iIdx].HostAddr4.toString() )
+                                        .arg ( ServerList[iIdx].LHostAddr4.toString() )
                                         .arg ( ServerList[iIdx].strName ) );
         out << ServerList[iIdx].toCSV() << '\n';
     }

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -749,6 +749,31 @@ void CServerListManager::RetrieveAll ( const CHostAddress& InetAddr )
     }
 }
 
+// fetch copy of registered server list for use by JSON-RPC
+// return false if not a directory
+bool CServerListManager::GetDirectoryServerList ( CVector<CServerInfo>& vecServerInfo )
+{
+    QMutexLocker locker ( &Mutex );
+
+    if ( !bIsDirectory )
+    {
+        return false;
+    }
+
+    const ushort iCurServerListSize = static_cast<ushort> ( ServerList.size() );
+
+    // allocate memory for the entire list
+    vecServerInfo.Init ( iCurServerListSize );
+
+    // copy the list
+    for ( int iIdx = 0; iIdx < iCurServerListSize; iIdx++ )
+    {
+        vecServerInfo[iIdx] = ServerList[iIdx];
+    }
+
+    return true;
+}
+
 int CServerListManager::IndexOf ( const CHostAddress& haSearchTerm )
 {
     // Called with lock set.

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -212,7 +212,9 @@ CServerListManager::CServerListManager ( CServer*       pServer,
      *
      * If we are a directory, we assume that we are a permanent server.
      */
-    CServerListEntry ThisServerListEntry ( haServerAddr, ServerPublicIP, "", QLocale::system().country(), "", iNumChannels, bIsDirectory );
+    CServerListEntry ThisServerListEntry ( haServerAddr,
+                                           ServerPublicIP,
+                                           CServerCoreInfo ( "", QLocale::system().country(), "", iNumChannels, bIsDirectory ) );
 
     // parse the server info string according to definition:
     // [this server name];[this server city];[this server country as QLocale ID] (; ... ignored)

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -139,7 +139,7 @@ public:
                                     QString strCountry,
                                     QString strNumClients,
                                     bool    isPermanent,
-                                    bool    bEnableIPv6 );
+                                    bool    bIPv6Available );
     QString                 toCSV();
 
     // time on which the entry was registered

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -104,19 +104,8 @@ class CServer;
 class CServerListEntry : public CServerInfo
 {
 public:
-    CServerListEntry() : CServerInfo ( CHostAddress(), CHostAddress(), "", QLocale::AnyCountry, "", 0, false ) { UpdateRegistration(); }
-
-    CServerListEntry ( const CHostAddress& NHAddr, const CHostAddress& NLHAddr, const CServerCoreInfo& NewCoreServerInfo ) :
-        CServerInfo ( NHAddr,
-                      NLHAddr,
-                      NewCoreServerInfo.strName,
-                      NewCoreServerInfo.eCountry,
-                      NewCoreServerInfo.strCity,
-                      NewCoreServerInfo.iMaxNumClients,
-                      NewCoreServerInfo.bPermanentOnline )
-    {
-        UpdateRegistration();
-    }
+    CServerListEntry();
+    CServerListEntry ( const CHostAddress& NHAddr, const CHostAddress& NLHAddr, const CServerCoreInfo& NewCoreServerInfo );
 
     void UpdateRegistration() { RegisterTime.start(); }
 

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -89,6 +89,7 @@ Note: this mechanism will not work in a private network.
 #include <QLocale>
 #include <QList>
 #include <QElapsedTimer>
+#include <QRandomGenerator>
 #include <QMutex>
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 )
 #    include <QVersionNumber>
@@ -128,6 +129,8 @@ protected:
     static QString    ToBase64 ( const QString strIn ) { return ToBase64 ( strIn.toUtf8() ); }
     static QByteArray FromBase64ToByteArray ( const QString strIn ) { return QByteArray::fromBase64 ( strIn.toLatin1() ); }
     static QString    FromBase64ToString ( const QString strIn ) { return QString::fromUtf8 ( FromBase64ToByteArray ( strIn ) ); }
+
+    quint32 token;
 };
 
 class CServerListManager : public QObject

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -195,6 +195,8 @@ public:
     void Remove ( const CHostAddress& InetAddr );
     void RetrieveAll ( const CHostAddress& InetAddr );
 
+    bool GetDirectoryServerList ( CVector<CServerInfo>& vecServerInfo );
+
     void StoreRegistrationResult ( ESvrRegResult eStatus );
 
     QString GetServerListFileName() { return ServerListFileName; }

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -106,18 +106,6 @@ class CServerListEntry : public CServerInfo
 public:
     CServerListEntry() : CServerInfo ( CHostAddress(), CHostAddress(), "", QLocale::AnyCountry, "", 0, false ) { UpdateRegistration(); }
 
-    CServerListEntry ( const CHostAddress&     NHAddr,
-                       const CHostAddress&     NLHAddr,
-                       const QString&          NsName,
-                       const QLocale::Country& NeCountry,
-                       const QString&          NsCity,
-                       const int               NiMaxNumClients,
-                       const bool              NbPermOnline ) :
-        CServerInfo ( NHAddr, NLHAddr, NsName, NeCountry, NsCity, NiMaxNumClients, NbPermOnline )
-    {
-        UpdateRegistration();
-    }
-
     CServerListEntry ( const CHostAddress& NHAddr, const CHostAddress& NLHAddr, const CServerCoreInfo& NewCoreServerInfo ) :
         CServerInfo ( NHAddr,
                       NLHAddr,

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -384,6 +384,92 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
         response["result"] = "acknowledged";
         Q_UNUSED ( params );
     } );
+
+    /// @rpc_method jamulusdirectory/getServerList
+    /// @brief Returns the list of registered servers along with details about them.
+    /// @param {object} params - No parameters (empty object).
+    /// @result {number} result.numservers - The number of registered servers.
+    /// @result {array}  result.servers - The list of registered servers.
+    /// @result {number} result.servers[*].id - The server's index.
+    /// @result {string} result.servers[*].name - The server's name.
+    /// @result {string} result.servers[*].countryName - The text name of the country specified by the user for this channel (see
+    /// QLocale::Country).
+    /// @result {string} result.servers[*].city - The city name provided by the operator of this server.
+    /// @result {number} result.servers[*].maxClients - The max number of clients supported by the server.
+    /// @result {bool}   result.servers[*].permanent - The permanent status of the server.
+    /// @result {string} result.servers[*].ipv4addr - The IPv4 address the server registered from (ip:port)
+    /// @result {string} result.servers[*].ipv4addrLocal - The local IPv4 address provided by the server (ip:port)
+    /// @result {string} result.servers[*].ipv6addr - The IPv6 address the server registered from ([ipv6]:port)
+    /// @result {string} result.servers[*].ipv6addrLocal - The local IPv6 address provided by the server ([ipv6]:port)
+    pRpcServer->HandleMethod ( "jamulusdirectory/getServerList", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        QJsonArray           servers;
+        CVector<CServerInfo> vecServerInfo;
+
+        int isDirectory = pServer->GetDirectoryServerList ( vecServerInfo );
+
+        if ( !isDirectory )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Server is not a directory" );
+            return;
+        }
+
+        const int iNumServers = vecServerInfo.Size();
+
+        // fill list with connected clients
+        for ( int i = 0; i < iNumServers; i++ )
+        {
+
+            // name of the server
+            // QString strName;
+
+            // country in which the server is located
+            // QLocale::Country eCountry;
+
+            // city in which the server is located
+            // QString strCity;
+
+            // maximum number of clients which can connect to the server at the same
+            // time
+            // int iMaxNumClients;
+
+            // is the server permanently online or not (flag)
+            // bool bPermanentOnline;
+
+            // IPv4 address of the server
+            // CHostAddress HostAddr4;
+
+            // IPv4 internal address of the server
+            // CHostAddress LHostAddr4;
+
+            // IPv6 address of the server
+            // CHostAddress HostAddr6;
+
+            // IPv6 internal address of the server
+            // CHostAddress LHostAddr6;
+
+            QJsonObject server{
+                { "id", i },
+                { "name", vecServerInfo[i].strName },
+                { "countryName", QLocale::countryToString ( vecServerInfo[i].eCountry ) },
+                { "city", vecServerInfo[i].strCity },
+                { "maxClients", vecServerInfo[i].iMaxNumClients },
+                { "permanent", vecServerInfo[i].bPermanentOnline },
+                { "ipv4addr", vecServerInfo[i].HostAddr4.toString() },
+                { "ipv4addrLocal", vecServerInfo[i].LHostAddr4.toString() },
+                { "ipv6addr", vecServerInfo[i].HostAddr6.toString() },
+                { "ipv6addrLocal", vecServerInfo[i].LHostAddr6.toString() },
+            };
+            servers.append ( server );
+        }
+
+        // create result object
+        QJsonObject result{
+            { "numservers", iNumServers },
+            { "servers", servers },
+        };
+        response["result"] = result;
+        Q_UNUSED ( params );
+    } );
 }
 
 #if defined( Q_OS_MACOS ) && QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )

--- a/src/testbench.h
+++ b/src/testbench.h
@@ -234,8 +234,8 @@ public slots:
         case 19: // PROTMESSID_CLM_SERVER_LIST
             vecServerInfo[0].bPermanentOnline = static_cast<bool> ( GenRandomIntInRange ( 0, 1 ) );
             vecServerInfo[0].eCountry         = static_cast<QLocale::Country> ( GenRandomIntInRange ( 0, 100 ) );
-            vecServerInfo[0].HostAddr         = CurHostAddress;
-            vecServerInfo[0].LHostAddr        = CurLocalAddress;
+            vecServerInfo[0].HostAddr4        = CurHostAddress;
+            vecServerInfo[0].LHostAddr4       = CurLocalAddress;
             vecServerInfo[0].iMaxNumClients   = GenRandomIntInRange ( -2, 10000 );
             vecServerInfo[0].strCity          = GenRandomString();
             vecServerInfo[0].strName          = GenRandomString();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1187,35 +1187,39 @@ QString CHostAddress::toString ( const EStringMode eStringMode ) const
 {
     QString strReturn = InetAddr.toString();
 
-    // special case: for local host address, we do not replace the last byte
-    if ( ( ( eStringMode == SM_IP_NO_LAST_BYTE ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) ) &&
-         ( InetAddr != QHostAddress ( QHostAddress::LocalHost ) ) && ( InetAddr != QHostAddress ( QHostAddress::LocalHostIPv6 ) ) )
+    switch ( InetAddr.protocol() )
     {
-        // replace last part by an "x"
-        if ( strReturn.contains ( "." ) )
+    case QAbstractSocket::IPv4Protocol:
+        if ( ( ( eStringMode == SM_IP_NO_LAST_BYTE ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) ) &&
+             InetAddr != QHostAddress ( QHostAddress::LocalHost ) )
         {
-            // IPv4 or IPv4-mapped:
+            // replace last part by an "x"
             strReturn = strReturn.section ( ".", 0, -2 ) + ".x";
         }
-        else
+        if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
         {
-            // IPv6
+            // add port
+            strReturn = QString ( "%1:%2" ).arg ( strReturn ).arg ( iPort );
+        }
+        break;
+
+    case QAbstractSocket::IPv6Protocol:
+        if ( ( ( eStringMode == SM_IP_NO_LAST_BYTE ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) ) &&
+             InetAddr != QHostAddress ( QHostAddress::LocalHostIPv6 ) )
+        {
+            // replace last part by an "x"
             strReturn = strReturn.section ( ":", 0, -2 ) + ":x";
         }
-    }
-
-    if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
-    {
-        // add port number after a colon
-        if ( strReturn.contains ( "." ) )
-        {
-            strReturn += ":" + QString().setNum ( iPort );
-        }
-        else
+        if ( ( eStringMode == SM_IP_PORT ) || ( eStringMode == SM_IP_NO_LAST_BYTE_PORT ) )
         {
             // enclose pure IPv6 address in [ ] before adding port, to avoid ambiguity
-            strReturn = "[" + strReturn + "]:" + QString().setNum ( iPort );
+            strReturn = QString ( "[%1]:%2" ).arg ( strReturn ).arg ( iPort );
         }
+        break;
+
+    default:
+        // do not append port to an invalid address
+        break;
     }
 
     return strReturn;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -922,7 +922,7 @@ bool NetworkUtil::ParseNetworkAddressSrv ( QString strAddress, CHostAddress& Hos
         // need further testing to confirm.
         // End processing here (= return true), but pass back an
         // invalid HostAddress to let the connect logic fail properly.
-        HostAddress = CHostAddress ( QHostAddress ( "." ), 0 );
+        HostAddress = CHostAddress ( QHostAddress(), 0 );
         return true;
     }
     qDebug() << qUtf8Printable (

--- a/src/util.h
+++ b/src/util.h
@@ -804,7 +804,7 @@ public:
         SM_IP_NO_LAST_BYTE_PORT
     };
 
-    CHostAddress() : InetAddr ( static_cast<quint32> ( 0 ) ), iPort ( 0 ) {}
+    CHostAddress() : InetAddr(), iPort ( 0 ) {}
 
     CHostAddress ( const QHostAddress& NInetAddr, const quint16 iNPort ) : InetAddr ( NInetAddr ), iPort ( iNPort ) {}
 

--- a/src/util.h
+++ b/src/util.h
@@ -1038,7 +1038,7 @@ public:
 class CServerInfo : public CServerCoreInfo
 {
 public:
-    CServerInfo() : HostAddr ( CHostAddress() ), LHostAddr ( CHostAddress() ) {}
+    CServerInfo() : HostAddr4 ( CHostAddress() ), LHostAddr4 ( CHostAddress() ), HostAddr6 ( CHostAddress() ), LHostAddr6 ( CHostAddress() ) {}
 
     CServerInfo ( const CHostAddress&     NHAddr,
                   const CHostAddress&     NLAddr,
@@ -1047,16 +1047,40 @@ public:
                   const QString&          NsCity,
                   const int               NiMaxNumClients,
                   const bool              NbPermOnline ) :
-        CServerCoreInfo ( NsName, NeCountry, NsCity, NiMaxNumClients, NbPermOnline ),
-        HostAddr ( NHAddr ),
-        LHostAddr ( NLAddr )
-    {}
+        CServerCoreInfo ( NsName, NeCountry, NsCity, NiMaxNumClients, NbPermOnline )
+    {
+        if ( NHAddr.InetAddr.protocol() == QAbstractSocket::IPv4Protocol )
+        {
+            HostAddr4 = NHAddr;
+        }
 
-    // internet address of the server
-    CHostAddress HostAddr;
+        if ( NLAddr.InetAddr.protocol() == QAbstractSocket::IPv4Protocol )
+        {
+            LHostAddr4 = NLAddr;
+        }
 
-    // server internal address
-    CHostAddress LHostAddr;
+        if ( NHAddr.InetAddr.protocol() == QAbstractSocket::IPv6Protocol )
+        {
+            HostAddr6 = NHAddr;
+        }
+
+        if ( NLAddr.InetAddr.protocol() == QAbstractSocket::IPv6Protocol )
+        {
+            LHostAddr6 = NLAddr;
+        }
+    }
+
+    // IPv4 address of the server
+    CHostAddress HostAddr4;
+
+    // IPv4 internal address of the server
+    CHostAddress LHostAddr4;
+
+    // IPv6 address of the server
+    CHostAddress HostAddr6;
+
+    // IPv6 internal address of the server
+    CHostAddress LHostAddr6;
 };
 
 // Network transport properties ------------------------------------------------

--- a/src/util.h
+++ b/src/util.h
@@ -1035,7 +1035,7 @@ public:
 class CServerInfo : public CServerCoreInfo
 {
 public:
-    CServerInfo() : HostAddr ( CHostAddress() ), LHostAddr ( CHostAddress() ) {}
+    CServerInfo() : HostAddr4 ( CHostAddress() ), LHostAddr4 ( CHostAddress() ), HostAddr6 ( CHostAddress() ), LHostAddr6 ( CHostAddress() ) {}
 
     CServerInfo ( const CHostAddress&     NHAddr,
                   const CHostAddress&     NLAddr,
@@ -1044,16 +1044,40 @@ public:
                   const QString&          NsCity,
                   const int               NiMaxNumClients,
                   const bool              NbPermOnline ) :
-        CServerCoreInfo ( NsName, NeCountry, NsCity, NiMaxNumClients, NbPermOnline ),
-        HostAddr ( NHAddr ),
-        LHostAddr ( NLAddr )
-    {}
+        CServerCoreInfo ( NsName, NeCountry, NsCity, NiMaxNumClients, NbPermOnline )
+    {
+        if ( NHAddr.InetAddr.protocol() == QAbstractSocket::IPv4Protocol )
+        {
+            HostAddr4 = NHAddr;
+        }
 
-    // internet address of the server
-    CHostAddress HostAddr;
+        if ( NLAddr.InetAddr.protocol() == QAbstractSocket::IPv4Protocol )
+        {
+            LHostAddr4 = NLAddr;
+        }
 
-    // server internal address
-    CHostAddress LHostAddr;
+        if ( NHAddr.InetAddr.protocol() == QAbstractSocket::IPv6Protocol )
+        {
+            HostAddr6 = NHAddr;
+        }
+
+        if ( NLAddr.InetAddr.protocol() == QAbstractSocket::IPv6Protocol )
+        {
+            LHostAddr6 = NLAddr;
+        }
+    }
+
+    // IPv4 address of the server
+    CHostAddress HostAddr4;
+
+    // IPv4 internal address of the server
+    CHostAddress LHostAddr4;
+
+    // IPv6 address of the server
+    CHostAddress HostAddr6;
+
+    // IPv6 internal address of the server
+    CHostAddress LHostAddr6;
 };
 
 // Network transport properties ------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

When complete, this will allow servers with IPv6 addresses to register with a directory using both their IPv4 address and IPv6 address. It should also allow for a server that only has an IPv6 address to register, even though it will be inaccessible to clients that just have IPv4.

CHANGELOG: Server: Add IPv6 support to Directory operations.

**Context: Fixes an issue?**

No issue, but a long-standing discussion at #1950

**Does this change need documentation? What needs to be documented and how?**

It will do.

**Status of this Pull Request**

Incomplete work in progress, posted for visibility and comments

**What is missing until this pull request can be merged?**

To be completed

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
