### PR TITLE
Add bounds check iChanID before array access

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1349,9 +1349,12 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
 
         for ( size_t iFader = 0; iFader < iNumConnectedClients; iFader++ )
         {
-            // ideally "iChanID" in CChannelInfo would be size_t if it can never be INVALID_INDEX
-            // as assumed here
-            iFaderNumber[vecChanInfo[iFader].iChanID] = static_cast<int> ( iFader );
+            const int iChanID = vecChanInfo[iFader].iChanID;
+
+            if ( MathUtils::InRange<int> ( iChanID, 0, MAX_NUM_CHANNELS ) )
+            {
+                iFaderNumber[iChanID] = static_cast<int> ( iFader );
+            }
         }
 
         // Hide all unused faders and initialize used ones


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Guards iChanId to definitely be in bounds. Checking the flow revealed that there is indeed no other bounds check and we may have INVALID_INDEX (=-1) which would yield to an invalid access (found by AI review)

CHANGELOG: Resolve out of bounds access issue

**Context: Fixes an issue?**

No. Only discussed internally.

**Does this change need documentation? What needs to be documented and how?**



**Status of this Pull Request**

Ready for *quick* !! review. This is a potentially severe bug (as discussed internally)

**What is missing until this pull request can be merged?**

Review and testing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
