### PR TITLE
add bounds check for country code table

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1369,6 +1369,10 @@ QLocale::Country CLocale::WireFormatCountryCodeToQtCountry ( unsigned short iCou
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
     // The Jamulus protocol wire format gives us Qt5 country IDs.
     // Qt6 changed those IDs, so we have to convert back:
+    if ( iCountryCode >= qt6CountryToWireFormatLen )
+    {
+        return QLocale::AnyCountry;
+    }
     return (QLocale::Country) wireFormatToQt6Table[iCountryCode];
 #else
     return (QLocale::Country) iCountryCode;
@@ -1380,7 +1384,13 @@ unsigned short CLocale::QtCountryToWireFormatCountryCode ( const QLocale::Countr
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
     // The Jamulus protocol wire format expects Qt5 country IDs.
     // Qt6 changed those IDs, so we have to convert back:
-    return qt6CountryToWireFormat[(unsigned short) eCountry];
+    const unsigned short iIdx = static_cast<unsigned short> ( eCountry );
+
+    if ( iIdx >= qt6CountryToWireFormatLen )
+    {
+        return 0;
+    }
+    return qt6CountryToWireFormat[iIdx];
 #else
     return (unsigned short) eCountry;
 #endif


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds bounds check for qt6 country code conversion (also found like #3810 )

CHANGELOG: Add bounds checking for country code lookup

**Context: Fixes an issue?**

/

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready for review (didn't analyze this one deeply). The style follows isCountryCodeSupported. Alternatively, we could probably just call IsCountryCode supported as guard? 
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review, analysis.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want (as in - it compiles with qt6 and seemed to show countries correctly - but not 100% sure)
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
