### PR TITLE
Check for half open interval in MathUtils::InRange

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1382,7 +1382,8 @@ void CServer::SendChatTextToAllConChannels ( const int iSendingChanID, const QSt
 
 bool CServer::SendChatTextToConChannel ( const int iCurChanID, const QString& strChatText )
 {
-    if ( !MathUtils::InRange<int> ( iCurChanID, 0, iMaxNumChannels - 1 ) || !vecChannels[iCurChanID].IsConnected() )
+    // Check if iCurChanID is in range [0, iMaxNumChannels)
+    if ( !MathUtils::InRange<int> ( iCurChanID, 0, iMaxNumChannels ) || !vecChannels[iCurChanID].IsConnected() )
     {
         return false;
     }

--- a/src/util.h
+++ b/src/util.h
@@ -1247,7 +1247,7 @@ public:
     template<typename T>
     static inline bool InRange ( T value, T lower /* inclusive */, T upper /* exclusive */ )
     {
-        return !( value < lower || value >= upper );
+        return value >= lower && value < upper ;
     }
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -1243,11 +1243,11 @@ public:
         }
     }
 
-    // return true if a value is within the lower and upper bounds (inclusively), otherwise false
+    // Returns true if value is in [lower, upper) (inclusive lower, exclusive upper).
     template<typename T>
-    static inline bool InRange ( T value, T lower, T upper )
+    static inline bool InRange ( T value, T lower /* inclusive */, T upper /* exclusive */ )
     {
-        return !( value < lower || value > upper );
+        return !( value < lower || value >= upper );
     }
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -1247,7 +1247,7 @@ public:
     template<typename T>
     static inline bool InRange ( T value, T lower /* inclusive */, T upper /* exclusive */ )
     {
-        return value >= lower && value < upper ;
+        return value >= lower && value < upper;
     }
 };
 


### PR DESCRIPTION
Fix its usage in server.cpp

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

As requested in #3810 make the interval half open for MathsUtils::InRange

CHANGELOG: Check for half open interval in MathUtils::InRange

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**
No
<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**
Ready
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Approval
<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
