### PR TITLE
Client: add --connectdirectory for directory-assisted hole punch on --connect

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -145,7 +145,7 @@ CClient::CClient ( const quint16  iPortNumber,
     // The first ConClientListMesReceived handler performs the necessary cleanup and has to run first:
     QObject::connect ( &Channel, &CChannel::ConClientListMesReceived, this, &CClient::OnConClientListMesReceived );
 
-    QObject::connect ( &Channel, &CChannel::Disconnected, this, &CClient::Disconnected );
+    QObject::connect ( &Channel, &CChannel::Disconnected, this, &CClient::Stop );
 
     QObject::connect ( &Channel, &CChannel::NewConnection, this, &CClient::OnNewConnection );
 
@@ -618,6 +618,9 @@ bool CClient::SetServerAddr ( QString strNAddr )
         // apply address to the channel
         Channel.SetAddress ( HostAddress );
 
+        // By default, set server name to HostAddress. If using the Connect() method, this may be overwritten
+        SetConnectedServerName ( HostAddress.toString() );
+
         return true;
     }
     else
@@ -905,11 +908,8 @@ void CClient::OnHandledSignal ( int sigNum )
     {
     case SIGINT:
     case SIGTERM:
-        // if connected, terminate connection (needed for headless mode)
-        if ( IsRunning() )
-        {
-            Stop();
-        }
+        // if connected, Stop client (needed for headless mode)
+        Stop();
 
         // this should trigger OnAboutToQuit
         QCoreApplication::instance()->exit();
@@ -1045,8 +1045,14 @@ void CClient::Start()
     // Disable hibernation or display dimming if the app is running on Windows
     SetThreadExecutionState ( ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED );
 #endif
+
+    emit Connected ( GetConnectedServerName() );
 }
 
+/// @method
+/// @brief Stops client and disconnects from server
+/// @emit Disconnected
+///       Use to set CClientDlg to show not being connected
 void CClient::Stop()
 {
     // stop audio interface
@@ -1088,6 +1094,53 @@ void CClient::Stop()
     // Allow hibernation or display dimming if the app is running again (Windows)
     SetThreadExecutionState ( ES_CONTINUOUS );
 #endif
+
+    // emit Disconnected() to inform UI of disconnection
+    emit Disconnected();
+}
+
+/// @method
+/// @brief Stops the client if the client is running
+/// @emit Disconnected
+void CClient::Disconnect()
+{
+    if ( IsRunning() )
+    {
+        Stop();
+    }
+}
+
+/// @method
+/// @brief Connects to strServerAddress
+/// @emit Connected (strServerName) if the client wasn't running and SetServerAddr was valid. emit happens through Start().
+///       Use to set CClientDlg to show being connected
+/// @emit ConnectingFailed (error) if an error occurred
+///       Use to display error message in CClientDlg
+/// @param strServerAddress - the server address to connect to
+/// @param strServerName - the String argument to be passed to Connecting()
+void CClient::Connect ( QString strServerAddress, QString strServerName )
+{
+    try
+    {
+        if ( !IsRunning() )
+        {
+            // Set server address and connect if valid address was supplied
+            if ( SetServerAddr ( strServerAddress ) )
+            {
+                SetConnectedServerName ( strServerName );
+                Start();
+            }
+            else
+            {
+                throw CGenErr ( tr ( "Received invalid server address. Please check for typos in the provided server address." ) );
+            }
+        }
+    }
+    catch ( const CGenErr& generr )
+    {
+        Stop();
+        emit ConnectingFailed ( generr.GetErrorText() );
+    }
 }
 
 void CClient::Init()

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1128,13 +1128,54 @@ void CClient::Disconnect()
 /// @method
 /// @brief Connects to strServerAddress. If a connection is currently requested
 ///        or established, that connection is terminated first.
+///
+///        If strDirectoryAddress is given, the server is assumed to be behind a
+///        firewall/NAT that requires directory-assisted UDP hole punching (the
+///        same mechanism the GUI directory list uses). We first ask that
+///        directory to poke its registered servers towards our socket, wait
+///        briefly for their replies to open the firewall, and only then connect.
+///        strServerAddress is always connected to verbatim and need not appear
+///        in the directory's server list.
 /// @emit Connecting (strServerName) if SetServerAddr was valid. emit happens through Start().
 ///       Use to set CClientDlg to show being connected
 /// @emit ConnectingFailed (error) if an error occurred
 ///       Use to display error message in CClientDlg
 /// @param strServerAddress - the server address to connect to
 /// @param strServerName - the human readable server name passed to Connecting()
-void CClient::Connect ( QString strServerAddress, QString strServerName )
+/// @param strDirectoryAddress - optional directory to hole-punch through first
+void CClient::Connect ( QString strServerAddress, QString strServerName, QString strDirectoryAddress )
+{
+    if ( strDirectoryAddress.isEmpty() )
+    {
+        // no hole punching requested: connect straight away
+        connectToServer ( strServerAddress, strServerName );
+        return;
+    }
+
+    CHostAddress haDirectoryAddress;
+
+    // directories are queried over IPv4 only (same as jamulusclient/pollServerList)
+    if ( !NetworkUtil::ParseNetworkAddress ( strDirectoryAddress, haDirectoryAddress, false ) )
+    {
+        emit ConnectingFailed ( tr ( "Received invalid directory address. Please check for typos in the provided directory address." ) );
+        return;
+    }
+
+    // Ask the directory for its server list. As a side effect the directory
+    // tells each registered server to send us an "empty message", which opens
+    // the server's firewall for our socket (UDP hole punching).
+    CreateCLReqServerListMes ( haDirectoryAddress );
+
+    // Defer the actual connect so the servers' replies have time to arrive and
+    // open the firewall before we send our first packet.
+    QTimer::singleShot ( HOLE_PUNCH_CONNECT_DELAY_MS, this, [this, strServerAddress, strServerName]() {
+        connectToServer ( strServerAddress, strServerName );
+    } );
+}
+
+/// @brief Performs the actual connect. See Connect(), which either calls this
+///        directly or after a directory hole-punch delay.
+void CClient::connectToServer ( QString strServerAddress, QString strServerName )
 {
     try
     {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -59,6 +59,7 @@ CClient::CClient ( const quint16  iPortNumber,
     strClientName ( strNClientName ),
     pSignalHandler ( CSignalHandler::getSingletonP() ),
     pSettings ( nullptr ),
+    eConnectionState ( CS_DISCONNECTED ),
     Channel ( false ), /* we need a client channel -> "false" */
     CurOpusEncoder ( nullptr ),
     CurOpusDecoder ( nullptr ),
@@ -1003,6 +1004,9 @@ void CClient::OnClientIDReceived ( int iServerChanID )
         SetRemoteChanGain ( iChanID, 0, false );
     }
 
+    // the server has assigned us a channel ID, so the connection is established
+    SetConnectionState ( CS_CONNECTED );
+
     emit ClientIDReceived ( iChanID );
 }
 
@@ -1046,7 +1050,12 @@ void CClient::Start()
     SetThreadExecutionState ( ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED );
 #endif
 
-    emit Connected ( GetConnectedServerName() );
+    // the connection is requested now but not yet established: the transition
+    // to CS_CONNECTED happens when the server assigns our channel ID
+    // (see OnClientIDReceived)
+    SetConnectionState ( CS_CONNECTING );
+
+    emit Connecting ( GetConnectedServerName() );
 }
 
 /// @method
@@ -1095,6 +1104,8 @@ void CClient::Stop()
     SetThreadExecutionState ( ES_CONTINUOUS );
 #endif
 
+    SetConnectionState ( CS_DISCONNECTED );
+
     // emit Disconnected() to inform UI of disconnection
     emit Disconnected();
 }
@@ -1111,35 +1122,46 @@ void CClient::Disconnect()
 }
 
 /// @method
-/// @brief Connects to strServerAddress
-/// @emit Connected (strServerName) if the client wasn't running and SetServerAddr was valid. emit happens through Start().
+/// @brief Connects to strServerAddress. If a connection is currently requested
+///        or established, that connection is terminated first.
+/// @emit Connecting (strServerName) if SetServerAddr was valid. emit happens through Start().
 ///       Use to set CClientDlg to show being connected
 /// @emit ConnectingFailed (error) if an error occurred
 ///       Use to display error message in CClientDlg
 /// @param strServerAddress - the server address to connect to
-/// @param strServerName - the String argument to be passed to Connecting()
+/// @param strServerName - the human readable server name passed to Connecting()
 void CClient::Connect ( QString strServerAddress, QString strServerName )
 {
     try
     {
-        if ( !IsRunning() )
+        // disconnect from any current server first so that connecting to a
+        // different server while connected behaves as a reconnect
+        Disconnect();
+
+        // Set server address and connect if valid address was supplied
+        if ( SetServerAddr ( strServerAddress ) )
         {
-            // Set server address and connect if valid address was supplied
-            if ( SetServerAddr ( strServerAddress ) )
-            {
-                SetConnectedServerName ( strServerName );
-                Start();
-            }
-            else
-            {
-                throw CGenErr ( tr ( "Received invalid server address. Please check for typos in the provided server address." ) );
-            }
+            SetConnectedServerName ( strServerName );
+            Start();
+        }
+        else
+        {
+            throw CGenErr ( tr ( "Received invalid server address. Please check for typos in the provided server address." ) );
         }
     }
     catch ( const CGenErr& generr )
     {
         Stop();
         emit ConnectingFailed ( generr.GetErrorText() );
+    }
+}
+
+void CClient::SetConnectionState ( const EConnectionState eNewConnectionState )
+{
+    if ( eConnectionState != eNewConnectionState )
+    {
+        eConnectionState = eNewConnectionState;
+        emit ConnectionStateChanged ( eConnectionState );
     }
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -909,10 +909,10 @@ void CClient::OnHandledSignal ( int sigNum )
     {
     case SIGINT:
     case SIGTERM:
-        // if connected, Stop client (needed for headless mode)
-        Stop();
+        // tear down any pending or established connection first, so the server
+        // is notified we are leaving (Disconnect() is a no-op if not connected)
+        Disconnect();
 
-        // this should trigger OnAboutToQuit
         QCoreApplication::instance()->exit();
         break;
 
@@ -1111,11 +1111,15 @@ void CClient::Stop()
 }
 
 /// @method
-/// @brief Stops the client if the client is running
+/// @brief Disconnects from the server if a connection is requested or established.
+///        Idempotent: a no-op when already disconnected.
 /// @emit Disconnected
 void CClient::Disconnect()
 {
-    if ( IsRunning() )
+    // Key off the connection state, not IsRunning() (which tracks the audio
+    // device): the two diverge while connecting and in headless mode, and on
+    // SIGTERM we must still send the disconnect message to the server.
+    if ( GetConnectionState() != CS_DISCONNECTED )
     {
         Stop();
     }
@@ -1156,6 +1160,10 @@ void CClient::Connect ( QString strServerAddress, QString strServerName )
     }
 }
 
+/// @method
+/// @brief Updates the connection state and, if it changed, notifies observers.
+/// @emit ConnectionStateChanged (state) when the state actually changes
+/// @param eNewConnectionState - the state to transition to
 void CClient::SetConnectionState ( const EConnectionState eNewConnectionState )
 {
     if ( eConnectionState != eNewConnectionState )

--- a/src/client.h
+++ b/src/client.h
@@ -171,7 +171,7 @@ public:
     void Start();
     void Stop();
     void Disconnect();
-    void Connect ( QString strServerAddress, QString strServerName );
+    void Connect ( QString strServerAddress, QString strServerName, QString strDirectoryAddress = "" );
 
     // The ConnectedServerName is emitted by Connecting() to update the UI with a human readable server name
     void    SetConnectedServerName ( const QString strServerName ) { strConnectedServerName = strServerName; };
@@ -380,6 +380,10 @@ protected:
     EConnectionState eConnectionState;
 
     void SetConnectionState ( const EConnectionState eNewConnectionState );
+
+    // performs the actual connect; Connect() calls this directly, or after a
+    // directory hole-punch delay when a directory address was supplied
+    void connectToServer ( QString strServerAddress, QString strServerName );
 
     // only one channel is needed for client application
     CChannel  Channel;

--- a/src/client.h
+++ b/src/client.h
@@ -159,6 +159,13 @@ public:
 
     void Start();
     void Stop();
+    void Disconnect();
+    void Connect ( QString strServerAddress, QString strServerName );
+
+    // The ConnectedServerName is emitted by Connected() to update the UI with a human readable server name
+    void    SetConnectedServerName ( const QString strServerName ) { strConnectedServerName = strServerName; };
+    QString GetConnectedServerName() const { return strConnectedServerName; };
+
     bool IsRunning() { return Sound.IsRunning(); }
     bool IsCallbackEntered() const { return Sound.IsCallbackEntered(); }
     bool SetServerAddr ( QString strNAddr );
@@ -353,6 +360,9 @@ protected:
     void FreeClientChannel ( const int iServerChannelID );
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
     bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
+    // information for the connected server
+
+    QString strConnectedServerName;
 
     // only one channel is needed for client application
     CChannel  Channel;
@@ -464,7 +474,8 @@ protected slots:
     {
         if ( InetAddr == Channel.GetAddress() )
         {
-            emit Disconnected();
+            // Stop client in case it received a Disconnection request
+            Stop();
         }
     }
     void OnCLPingReceived ( CHostAddress InetAddr, int iMs );
@@ -507,7 +518,11 @@ signals:
 
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
 
+    void Connected ( QString strServerName );
+    void ConnectingFailed ( QString errorMessage );
+    void DisconnectClient();
     void Disconnected();
+
     void SoundDeviceChanged ( QString strError );
     void ControllerInFaderLevel ( int iChannelIdx, int iValue );
     void ControllerInPanValue ( int iChannelIdx, int iValue );

--- a/src/client.h
+++ b/src/client.h
@@ -162,9 +162,11 @@ public:
     void Disconnect();
     void Connect ( QString strServerAddress, QString strServerName );
 
-    // The ConnectedServerName is emitted by Connected() to update the UI with a human readable server name
+    // The ConnectedServerName is emitted by Connecting() to update the UI with a human readable server name
     void    SetConnectedServerName ( const QString strServerName ) { strConnectedServerName = strServerName; };
     QString GetConnectedServerName() const { return strConnectedServerName; };
+
+    EConnectionState GetConnectionState() const { return eConnectionState; }
 
     bool IsRunning() { return Sound.IsRunning(); }
     bool IsCallbackEntered() const { return Sound.IsCallbackEntered(); }
@@ -361,8 +363,13 @@ protected:
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
     bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
     // information for the connected server
-
     QString strConnectedServerName;
+
+    // single source of truth for the connection state, only to be modified
+    // via SetConnectionState() so that every change emits ConnectionStateChanged()
+    EConnectionState eConnectionState;
+
+    void SetConnectionState ( const EConnectionState eNewConnectionState );
 
     // only one channel is needed for client application
     CChannel  Channel;
@@ -518,9 +525,9 @@ signals:
 
     void CLChannelLevelListReceived ( CHostAddress InetAddr, CVector<uint16_t> vecLevelList );
 
-    void Connected ( QString strServerName );
+    void ConnectionStateChanged ( EConnectionState eConnectionState );
+    void Connecting ( QString strServerName );
     void ConnectingFailed ( QString errorMessage );
-    void DisconnectClient();
     void Disconnected();
 
     void SoundDeviceChanged ( QString strError );

--- a/src/client.h
+++ b/src/client.h
@@ -88,6 +88,17 @@
 #endif
 
 /* Definitions ****************************************************************/
+// Client connection state -----------------------------------------------------
+enum EConnectionState
+{
+    // a connection is "requested" as soon as the client starts the audio
+    // stream towards the configured server and "established" once the server
+    // has assigned a channel ID to the client
+    CS_DISCONNECTED = 0, // no connection requested or established
+    CS_CONNECTING   = 1, // connection requested but not yet established
+    CS_CONNECTED    = 2  // connection established and current
+};
+
 // audio in fader range
 #define AUD_FADER_IN_MIN    0
 #define AUD_FADER_IN_MAX    100
@@ -362,11 +373,10 @@ protected:
     void FreeClientChannel ( const int iServerChannelID );
     int  FindClientChannel ( const int iServerChannelID, const bool bCreateIfNew ); // returns a client channel ID or INVALID_INDEX
     bool ReorderLevelList ( CVector<uint16_t>& vecLevelList );                      // modifies vecLevelList, passed by reference
-    // information for the connected server
+    // human-readable name of the current server, shown in the UI
     QString strConnectedServerName;
 
-    // single source of truth for the connection state, only to be modified
-    // via SetConnectionState() so that every change emits ConnectionStateChanged()
+    // current connection state; set only via SetConnectionState()
     EConnectionState eConnectionState;
 
     void SetConnectionState ( const EConnectionState eNewConnectionState );

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -50,7 +50,6 @@
 /* Implementation *************************************************************/
 CClientDlg::CClientDlg ( CClient*         pNCliP,
                          CClientSettings* pNSetP,
-                         const QString&   strConnOnStartupAddress,
                          const bool       bNewShowComplRegConnList,
                          const bool       bShowAnalyzerConsole,
                          const bool       bMuteStream,
@@ -292,14 +291,6 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     TimerCheckAudioDeviceOk.setSingleShot ( true ); // only check once after connection
     TimerDetectFeedback.setSingleShot ( true );
 
-    // Connect on startup ------------------------------------------------------
-    if ( !strConnOnStartupAddress.isEmpty() )
-    {
-        // initiate connection (always show the address in the mixer board
-        // (no alias))
-        Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
-    }
-
     // File menu  --------------------------------------------------------------
     QMenu* pFileMenu = new QMenu ( tr ( "&File" ), this );
 
@@ -507,7 +498,11 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // other
     QObject::connect ( pClient, &CClient::ConClientListMesReceived, this, &CClientDlg::OnConClientListMesReceived );
 
-    QObject::connect ( pClient, &CClient::Disconnected, this, &CClientDlg::OnDisconnected );
+    QObject::connect ( pClient, &CClient::Connected, this, &CClientDlg::OnConnect );
+
+    QObject::connect ( pClient, &CClient::ConnectingFailed, this, &CClientDlg::OnConnectingFailed );
+
+    QObject::connect ( pClient, &CClient::Disconnected, this, &CClientDlg::OnDisconnect );
 
     QObject::connect ( pClient, &CClient::ChatTextReceived, this, &CClientDlg::OnChatTextReceived );
 
@@ -646,11 +641,8 @@ void CClientDlg::closeEvent ( QCloseEvent* Event )
     ConnectDlg.close();
     AnalyzerConsole.close();
 
-    // if connected, terminate connection
-    if ( pClient->IsRunning() )
-    {
-        pClient->Stop();
-    }
+    // Disconnect if needed
+    pClient->Disconnect();
 
     // make sure all current fader settings are applied to the settings struct
     MainMixerBoard->StoreAllFaderSettings();
@@ -768,15 +760,11 @@ void CClientDlg::OnConnectDlgAccepted()
             }
         }
 
-        // first check if we are already connected, if this is the case we have to
-        // disconnect the old server first
-        if ( pClient->IsRunning() )
-        {
-            Disconnect();
-        }
+        // Disconnect the client. We could be currently connected.
+        pClient->Disconnect();
 
         // initiate connection
-        Connect ( strSelectedAddress, strMixerBoardLabel );
+        pClient->Connect ( strSelectedAddress, strMixerBoardLabel );
 
         // reset flag
         bConnectDlgWasShown = false;
@@ -788,11 +776,12 @@ void CClientDlg::OnConnectDisconBut()
     // the connect/disconnect button implements a toggle functionality
     if ( pClient->IsRunning() )
     {
-        Disconnect();
-        SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
+        pClient->Stop();
     }
     else
     {
+        // If the client isn't running, we assume that we weren't connected. Thus show the connect dialog
+        // TODO: Refactor to have robust error handling
         ShowConnectionSetupDialog();
     }
 }
@@ -904,7 +893,7 @@ void CClientDlg::OnLicenceRequired ( ELicenceType eLicenceType )
         // disconnect from that server.
         if ( !LicenceDlg.exec() )
         {
-            Disconnect();
+            pClient->Disconnect();
         }
 
         // unmute the client output stream if local mute button is not pressed
@@ -1205,10 +1194,7 @@ void CClientDlg::OnSoundDeviceChanged ( QString strError )
     if ( !strError.isEmpty() )
     {
         // the sound device setup has a problem, disconnect any active connection
-        if ( pClient->IsRunning() )
-        {
-            Disconnect();
-        }
+        pClient->Disconnect();
 
         // show the error message of the device setup
         QMessageBox::critical ( this, APP_NAME, strError, tr ( "Ok" ), nullptr );
@@ -1236,65 +1222,38 @@ void CClientDlg::OnCLPingTimeWithNumClientsReceived ( CHostAddress InetAddr, int
     ConnectDlg.SetPingTimeAndNumClientsResult ( InetAddr, iPingTime, iNumClients );
 }
 
-void CClientDlg::Connect ( const QString& strSelectedAddress, const QString& strMixerBoardLabel )
+void CClientDlg::OnConnect ( const QString& strMixerBoardLabel )
 {
-    // set address and check if address is valid
-    if ( pClient->SetServerAddr ( strSelectedAddress ) )
+
+    // hide label connect to server
+    lblConnectToServer->hide();
+    lbrInputLevelL->setEnabled ( true );
+    lbrInputLevelR->setEnabled ( true );
+
+    // change connect button text to "disconnect"
+    butConnect->setText ( tr ( "&Disconnect" ) );
+
+    // set server name in audio mixer group box title
+    MainMixerBoard->SetServerName ( strMixerBoardLabel );
+
+    // start timer for level meter bar and ping time measurement
+    TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );
+    TimerBuffersLED.start ( BUFFER_LED_UPDATE_TIME_MS );
+    TimerPing.start ( PING_UPDATE_TIME_MS );
+    TimerCheckAudioDeviceOk.start ( CHECK_AUDIO_DEV_OK_TIME_MS ); // is single shot timer
+
+    // audio feedback detection
+    if ( pSettings->bEnableFeedbackDetection )
     {
-        // try to start client, if error occurred, do not go in
-        // running state but show error message
-        try
-        {
-            if ( !pClient->IsRunning() )
-            {
-                pClient->Start();
-            }
-        }
-
-        catch ( const CGenErr& generr )
-        {
-            // show error message and return the function
-            QMessageBox::critical ( this, APP_NAME, generr.GetErrorText(), "Close", nullptr );
-            return;
-        }
-
-        // hide label connect to server
-        lblConnectToServer->hide();
-        lbrInputLevelL->setEnabled ( true );
-        lbrInputLevelR->setEnabled ( true );
-
-        // change connect button text to "disconnect"
-        butConnect->setText ( tr ( "&Disconnect" ) );
-
-        // set server name in audio mixer group box title
-        MainMixerBoard->SetServerName ( strMixerBoardLabel );
-
-        // start timer for level meter bar and ping time measurement
-        TimerSigMet.start ( LEVELMETER_UPDATE_TIME_MS );
-        TimerBuffersLED.start ( BUFFER_LED_UPDATE_TIME_MS );
-        TimerPing.start ( PING_UPDATE_TIME_MS );
-        TimerCheckAudioDeviceOk.start ( CHECK_AUDIO_DEV_OK_TIME_MS ); // is single shot timer
-
-        // audio feedback detection
-        if ( pSettings->bEnableFeedbackDetection )
-        {
-            TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
-            bDetectFeedback = true;
-        }
+        TimerDetectFeedback.start ( DETECT_FEEDBACK_TIME_MS ); // single shot timer
+        bDetectFeedback = true;
     }
 }
 
-void CClientDlg::Disconnect()
-{
-    // only stop client if currently running, in case we received
-    // the stopped message, the client is already stopped but the
-    // connect/disconnect button and other GUI controls must be
-    // updated
-    if ( pClient->IsRunning() )
-    {
-        pClient->Stop();
-    }
+void CClientDlg::OnConnectingFailed ( const QString& strError ) { QMessageBox::critical ( this, APP_NAME, strError, tr ( "Close" ), nullptr ); }
 
+void CClientDlg::OnDisconnect()
+{
     // change connect button text to "connect"
     butConnect->setText ( tr ( "C&onnect" ) );
 
@@ -1336,6 +1295,9 @@ void CClientDlg::Disconnect()
 
     // clear mixer board (remove all faders)
     MainMixerBoard->HideAll();
+
+    // Reset the deco
+    SetMixerBoardDeco ( RS_UNDEFINED, pClient->GetGUIDesign() );
 }
 
 void CClientDlg::UpdateDisplay()

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -498,7 +498,7 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     // other
     QObject::connect ( pClient, &CClient::ConClientListMesReceived, this, &CClientDlg::OnConClientListMesReceived );
 
-    QObject::connect ( pClient, &CClient::Connected, this, &CClientDlg::OnConnect );
+    QObject::connect ( pClient, &CClient::Connecting, this, &CClientDlg::OnConnecting );
 
     QObject::connect ( pClient, &CClient::ConnectingFailed, this, &CClientDlg::OnConnectingFailed );
 
@@ -760,10 +760,7 @@ void CClientDlg::OnConnectDlgAccepted()
             }
         }
 
-        // Disconnect the client. We could be currently connected.
-        pClient->Disconnect();
-
-        // initiate connection
+        // initiate connection (terminates any current connection first)
         pClient->Connect ( strSelectedAddress, strMixerBoardLabel );
 
         // reset flag
@@ -776,7 +773,7 @@ void CClientDlg::OnConnectDisconBut()
     // the connect/disconnect button implements a toggle functionality
     if ( pClient->IsRunning() )
     {
-        pClient->Stop();
+        pClient->Disconnect();
     }
     else
     {
@@ -1222,7 +1219,7 @@ void CClientDlg::OnCLPingTimeWithNumClientsReceived ( CHostAddress InetAddr, int
     ConnectDlg.SetPingTimeAndNumClientsResult ( InetAddr, iPingTime, iNumClients );
 }
 
-void CClientDlg::OnConnect ( const QString& strMixerBoardLabel )
+void CClientDlg::OnConnecting ( const QString& strMixerBoardLabel )
 {
 
     // hide label connect to server

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -145,7 +145,7 @@ protected:
     CAnalyzerConsole   AnalyzerConsole;
 
 public slots:
-    void OnConnect ( const QString& strServerName );
+    void OnConnecting ( const QString& strServerName );
     void OnConnectingFailed ( const QString& strErrorText );
     void OnDisconnect();
     void OnConnectDisconBut();

--- a/src/clientdlg.h
+++ b/src/clientdlg.h
@@ -100,7 +100,6 @@ class CClientDlg : public CBaseDlg, private Ui_CClientDlgBase
 public:
     CClientDlg ( CClient*         pNCliP,
                  CClientSettings* pNSetP,
-                 const QString&   strConnOnStartupAddress,
                  const bool       bNewShowComplRegConnList,
                  const bool       bShowAnalyzerConsole,
                  const bool       bMuteStream,
@@ -116,8 +115,6 @@ protected:
     void ShowAnalyzerConsole();
     void UpdateAudioFaderSlider();
     void UpdateRevSelection();
-    void Connect ( const QString& strSelectedAddress, const QString& strMixerBoardLabel );
-    void Disconnect();
     void ManageDragNDrop ( QDropEvent* Event, const bool bCheckAccept );
     void SetPingTime ( const int iPingTime, const int iOverallDelayMs, const CMultiColorLED::ELightColor eOverallDelayLEDColor );
 
@@ -148,6 +145,9 @@ protected:
     CAnalyzerConsole   AnalyzerConsole;
 
 public slots:
+    void OnConnect ( const QString& strServerName );
+    void OnConnectingFailed ( const QString& strErrorText );
+    void OnDisconnect();
     void OnConnectDisconBut();
     void OnTimerSigMet();
     void OnTimerBuffersLED();
@@ -254,7 +254,6 @@ public slots:
     }
 
     void OnConnectDlgAccepted();
-    void OnDisconnected() { Disconnect(); }
     void OnGUIDesignChanged();
     void OnMeterStyleChanged();
     void OnRecorderStateReceived ( ERecorderState eRecorderState );

--- a/src/global.h
+++ b/src/global.h
@@ -123,6 +123,11 @@ LED bar:      lbr
 // specify an invalid port to disable the server
 #define INVALID_PORT -1
 
+// when connecting via a directory (hole punching), wait this long after asking
+// the directory to poke its registered servers before connecting, so the
+// servers' replies have time to open their firewall for our socket
+#define HOLE_PUNCH_CONNECT_DELAY_MS 400
+
 // servers to check for new versions
 #define UPDATECHECK1_ADDRESS "updatecheck1.jamulus.app"
 #define UPDATECHECK2_ADDRESS "updatecheck2.jamulus.app"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,7 @@ int main ( int argc, char** argv )
     quint16      iQosNumber                  = DEFAULT_QOS_NUMBER;
     ELicenceType eLicenceType                = LT_NO_LICENCE;
     QString      strConnOnStartupAddress     = "";
+    QString      strConnectDirectory         = "";
     QString      strIniFileName              = "";
     QString      strLoggingFileName          = "";
     QString      strRecordingDirName         = "";
@@ -533,6 +534,16 @@ int main ( int argc, char** argv )
             qInfo() << qUtf8Printable ( QString ( "- connect on startup to address: %1" ).arg ( strConnOnStartupAddress ) );
             CommandLineOptions << "--connect";
             ClientOnlyOptions << "--connect";
+            continue;
+        }
+
+        // Directory to hole-punch through for connect on startup --------------
+        if ( GetStringArgument ( argc, argv, i, "--connectdirectory", "--connectdirectory", strArgument ) )
+        {
+            strConnectDirectory = NetworkUtil::FixAddress ( strArgument );
+            qInfo() << qUtf8Printable ( QString ( "- connect on startup via directory: %1" ).arg ( strConnectDirectory ) );
+            CommandLineOptions << "--connectdirectory";
+            ClientOnlyOptions << "--connectdirectory";
             continue;
         }
 
@@ -1013,7 +1024,7 @@ int main ( int argc, char** argv )
                 // Connect on startup if requested
                 if ( !strConnOnStartupAddress.isEmpty() )
                 {
-                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
+                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress, strConnectDirectory );
                 }
 
                 pApp->exec();
@@ -1027,7 +1038,7 @@ int main ( int argc, char** argv )
                 // Connect on startup if requested
                 if ( !strConnOnStartupAddress.isEmpty() )
                 {
-                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
+                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress, strConnectDirectory );
                 }
 
                 pApp->exec();
@@ -1193,6 +1204,7 @@ QString UsageArguments ( char** argv )
            "\n"
            "Client only:\n"
            "  -c, --connect           connect to given Server address on startup\n"
+           "      --connectdirectory  directory to hole-punch through for --connect (host:port)\n"
            "  -j, --nojackconnect     disable auto JACK connections\n"
            "  -M, --mutestream        prevent others on a server from hearing what I play\n"
            "      --mutemyown         prevent me from hearing what I play in the server mix (headless only)\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1005,25 +1005,30 @@ int main ( int argc, char** argv )
                 }
 
                 // GUI object
-                CClientDlg
-                    ClientDlg ( &Client, &Settings, strConnOnStartupAddress, bShowComplRegConnList, bShowAnalyzerConsole, bMuteStream, nullptr );
+                CClientDlg ClientDlg ( &Client, &Settings, bShowComplRegConnList, bShowAnalyzerConsole, bMuteStream, nullptr );
 
                 // show dialog
                 ClientDlg.show();
+
+                // Connect on startup if requested
+                if ( !strConnOnStartupAddress.isEmpty() )
+                {
+                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
+                }
 
                 pApp->exec();
             }
             else
 #    endif
             {
-                if ( !strConnOnStartupAddress.isEmpty() )
-                {
-                    Client.SetServerAddr ( strConnOnStartupAddress );
-                    Client.Start();
-                }
-
                 // only start application without using the GUI
                 qInfo() << qUtf8Printable ( GetVersionAndNameStr ( false ) );
+
+                // Connect on startup if requested
+                if ( !strConnOnStartupAddress.isEmpty() )
+                {
+                    Client.Connect ( strConnOnStartupAddress, strConnOnStartupAddress );
+                }
 
                 pApp->exec();
             }

--- a/src/util.h
+++ b/src/util.h
@@ -590,17 +590,6 @@ enum ERecorderState
     RS_RECORDING       = 3
 };
 
-// Client connection state -----------------------------------------------------
-enum EConnectionState
-{
-    // a connection is "requested" as soon as the client starts the audio
-    // stream towards the configured server and "established" once the server
-    // has assigned a channel ID to the client
-    CS_DISCONNECTED = 0, // no connection requested or established
-    CS_CONNECTING   = 1, // connection requested but not yet established
-    CS_CONNECTED    = 2  // connection established and current
-};
-
 // Channel sort type -----------------------------------------------------------
 enum EChSortType
 {

--- a/src/util.h
+++ b/src/util.h
@@ -590,6 +590,17 @@ enum ERecorderState
     RS_RECORDING       = 3
 };
 
+// Client connection state -----------------------------------------------------
+enum EConnectionState
+{
+    // a connection is "requested" as soon as the client starts the audio
+    // stream towards the configured server and "established" once the server
+    // has assigned a channel ID to the client
+    CS_DISCONNECTED = 0, // no connection requested or established
+    CS_CONNECTING   = 1, // connection requested but not yet established
+    CS_CONNECTED    = 2  // connection established and current
+};
+
 // Channel sort type -----------------------------------------------------------
 enum EChSortType
 {


### PR DESCRIPTION
**Short description of changes**

Adds an optional `--connectdirectory <host:port>` client option and gives `CClient::Connect` an optional directory argument. When a directory is supplied, the client first asks that directory for its server list — which makes the directory tell its registered servers to send an "empty message" toward the client's socket (the same directory-assisted UDP hole punch the GUI directory list relies on) — waits `HOLE_PUNCH_CONNECT_DELAY_MS`, then connects.

Today `-c` / `--connect` connects straight to the address and never contacts a directory, so a server behind a cloud firewall/NAT that the GUI reaches fine is silently unreachable via `-c`. The server address is connected to verbatim and need not appear in the directory's server list, so this also lets you reach a server that isn't in any *built-in* directory by naming the (possibly custom/private) directory it is registered with.

CHANGELOG: Client: Added `--connectdirectory` to hole-punch through a directory when connecting on startup with `--connect`

**Context: Fixes an issue?**

Relates to jamulussoftware/jamuluswebsite#1122, which documents this `-c` reachability limitation. This is the code side of that gap.

Stacked on #3805 — it uses the `CClient::Connect` refactor introduced there, so the diff currently includes #3805's commit; the single top commit is the change in this PR. Please review/merge #3805 first.

**Does this change need documentation? What needs to be documented and how?**

Yes — a short website entry for `--connectdirectory` next to the `-c` text (a companion to the `-c` note added in jamuluswebsite#1156). A draft on the website repo will follow.

**Status of this Pull Request**

Working implementation. Verified with a UDP capture: with `--connectdirectory` the client sends `CLM_REQ_SERVER_LIST` to the directory and connects ~400 ms later; without it there is no directory traffic and behaviour is unchanged. Clean SIGTERM shutdown, including when interrupted during the hole-punch delay.

**What is missing until this pull request can be merged?**

Depends on #3805 merging first. Otherwise ready for review.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above
