### PR TITLE
Fix jamulus/pollServerList reporting success on invalid directory address

### DIFF
--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -201,8 +201,6 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
             response["error"] =
                 CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: directory is not a valid socket address" );
         }
-
-        response["result"] = "ok";
     } );
 
     /// @rpc_method jamulus/getMode

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -190,17 +190,16 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
         CHostAddress haDirectoryAddress;
 
         // Allow IPv4 only for communicating with Directories
-        if ( NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
-        {
-            // send the request for the server list
-            pClient->CreateCLReqServerListMes ( haDirectoryAddress );
-            response["result"] = "ok";
-        }
-        else
+        if ( !NetworkUtil::ParseNetworkAddress ( jsonDirectoryIp.toString(), haDirectoryAddress, false ) )
         {
             response["error"] =
                 CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: directory is not a valid socket address" );
+            return;
         }
+
+        // send the request for the server list
+        pClient->CreateCLReqServerListMes ( haDirectoryAddress );
+        response["result"] = "ok";
     } );
 
     /// @rpc_method jamulus/getMode


### PR DESCRIPTION
## Fixes #3818

The `jamulus/pollServerList` RPC handler set `response["error"]` when the directory address failed to parse, but then **unconditionally** set `response["result"] = "ok"` after the `if`/`else`. As a result, an invalid socket address was reported as success, with both `"error"` and `"result"` present in the response.

```cpp
if ( NetworkUtil::ParseNetworkAddress ( ..., false ) )
{
    pClient->CreateCLReqServerListMes ( haDirectoryAddress );
    response["result"] = "ok";
}
else
{
    response["error"] = CRpcServer::CreateJsonRpcError ( ... );
}

response["result"] = "ok";   // <-- always ran, clobbering the error case
```

### Fix
Remove the stray unconditional assignment. The success branch already sets `result = "ok"`, so the handler now reports `error` on failure and `result` on success — matching the error-path idiom used by every other handler in this file.

### Testing
- `clang-format-14` clean
- Headless build + server smoke test (clean startup, clean SIGTERM)