### PR TITLE
Guard GetValFromStream against out-of-bounds reads in release builds

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -2832,6 +2832,14 @@ uint32_t CProtocol::GetValFromStream ( const CVector<uint8_t>& vecIn, int& iPos,
     Q_ASSERT ( ( iNumOfBytes > 0 ) && ( iNumOfBytes <= 4 ) );
     Q_ASSERT ( vecIn.Size() >= iPos + iNumOfBytes );
 
+    // The asserts above are compiled out in release builds, so also guard at
+    // runtime: CVector uses unchecked operator[], and reading past the end of a
+    // truncated/malformed network message would be an out-of-bounds access.
+    if ( ( iNumOfBytes < 1 ) || ( iNumOfBytes > 4 ) || ( vecIn.Size() < iPos + iNumOfBytes ) )
+    {
+        return 0;
+    }
+
     uint32_t iRet = 0;
 
     for ( int i = 0; i < iNumOfBytes; i++ )


### PR DESCRIPTION
## Fixes #3819

`GetValFromStream` validates its arguments only with `Q_ASSERT`, which is compiled out in release builds — the configuration everyone actually ships. `CVector` derives from `std::vector` and uses its **unchecked** `operator[]`, so a truncated or malformed network message can drive `vecIn[iPos]` past the end of the buffer with no protection at all in release.

### Approach
Keep the asserts (developer errors still fail loudly in debug builds) and add a runtime guard that returns `0` when `iNumOfBytes` is outside 1..4 or when fewer than `iNumOfBytes` bytes remain:

```cpp
Q_ASSERT ( ( iNumOfBytes > 0 ) && ( iNumOfBytes <= 4 ) );
Q_ASSERT ( vecIn.Size() >= iPos + iNumOfBytes );

if ( ( iNumOfBytes < 1 ) || ( iNumOfBytes > 4 ) || ( vecIn.Size() < iPos + iNumOfBytes ) )
{
    return 0;
}
```

Returning 0 (rather than crashing) keeps the existing "malformed input is tolerated, not fatal" posture of the surrounding parser — the sibling `GetStringFromStream` already returns an error code on short input rather than aborting. This is the minimal, hot-path-safe change and touches no call sites.

Open question for maintainers, per the issue: if a hard failure / disconnect on malformed input is preferred over silently returning 0, that would be a larger change (the function has no error channel today, so it would need a signature change across ~50 call sites). Happy to go that direction if you'd rather.

### Testing
- `clang-format-14` clean
- Headless build + server smoke test (clean startup, clean SIGTERM)