### PR TITLE
Fix headless builds on macOS and Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -909,7 +909,7 @@ int main ( int argc, char** argv )
     // For accessible support we need to add a plugin to qt. The plugin has to
     // be located in the install directory of the software by the installer.
     // Here, we set the path to our application path.
-    QDir ApplDir ( QApplication::applicationDirPath() );
+    QDir ApplDir ( QCoreApplication::applicationDirPath() );
     pApp->addLibraryPath ( QString ( ApplDir.absolutePath() ) );
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,8 @@
 #endif
 #if defined( Q_OS_MACOS )
 #    include "mac/activity.h"
+#endif
+#if defined( Q_OS_MACOS ) && !defined( HEADLESS )
 extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 #endif
 #include <memory>
@@ -82,7 +84,7 @@ extern void qt_set_sequence_auto_mnemonic ( bool bEnable );
 int main ( int argc, char** argv )
 {
 
-#if defined( Q_OS_MACOS )
+#if defined( Q_OS_MACOS ) && !defined( HEADLESS )
     // Mnemonic keys are default disabled in Qt for MacOS. The following function enables them.
     // Qt will not show these with underline characters in the GUI on MacOS. (#1873)
     qt_set_sequence_auto_mnemonic ( true );

--- a/src/sound/coreaudio-mac/sound.h
+++ b/src/sound/coreaudio-mac/sound.h
@@ -50,7 +50,6 @@
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreMIDI/CoreMIDI.h>
 #include <QMutex>
-#include <QMessageBox>
 #include "../soundbase.h"
 #include "../../global.h"
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Three one-line fixes so that `CONFIG+=headless` compiles (and links) on macOS and Windows, as it already does on Linux.

CHANGELOG: Build: Fixed headless builds (`CONFIG+=headless`) not compiling on macOS and Windows.

**Context: Fixes an issue?**

Fixes: #3825

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Working implementation, CI-verified..

**What is missing until this pull request can be merged?**

Nothing known.

- Verified in a fork with a headless client/server build-and-connect job on all three platforms:
    - [failing before](https://github.com/dtinth/jamulus/actions/runs/29933460318)
        - macOS: `fatal error: 'QMessageBox' file not found`, then `Undefined symbols … qt_set_sequence_auto_mnemonic(bool)`
        - Windows: `error C2027: use of undefined type 'QApplication'`
    - [green after](https://github.com/dtinth/jamulus/actions/runs/29989445107) with only these three commits.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->

AUTOBUILD: Please build all targets