### PR TITLE
Build opus with NEON intrinsics on ARM (Android ABIs included)

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -660,7 +660,8 @@ SOURCES_OPUS = libs/opus/celt/bands.c \
     libs/opus/src/opus_encoder.c \
     libs/opus/src/repacketizer.c
 
-SOURCES_OPUS_ARM = libs/opus/celt/arm/armcpu.c \
+# NEON intrinsic sources: self-contained, need no external library.
+SOURCES_OPUS_ARM_NEON = libs/opus/celt/arm/armcpu.c \
     libs/opus/celt/arm/arm_celt_map.c \
     libs/opus/silk/arm/arm_silk_map.c \
     libs/opus/silk/arm/biquad_alt_neon_intr.c \
@@ -668,9 +669,14 @@ SOURCES_OPUS_ARM = libs/opus/celt/arm/armcpu.c \
     libs/opus/silk/arm/NSQ_del_dec_neon_intr.c \
     libs/opus/silk/arm/NSQ_neon.c \
     libs/opus/celt/arm/celt_neon_intr.c \
-    libs/opus/celt/arm/pitch_neon_intr.c \
-    libs/opus/celt/arm/celt_fft_ne10.c \
+    libs/opus/celt/arm/pitch_neon_intr.c
+# NE10 sources: FFT/MDCT acceleration via the external Ne10 library, which
+# Jamulus does not bundle (they #include <NE10_dsp.h> unconditionally and are
+# gated on HAVE_ARM_NE10, which we never define). Kept listed for completeness
+# but never added to SOURCES.
+SOURCES_OPUS_ARM_NE10 = libs/opus/celt/arm/celt_fft_ne10.c \
     libs/opus/celt/arm/celt_mdct_ne10.c
+SOURCES_OPUS_ARM = $$SOURCES_OPUS_ARM_NEON $$SOURCES_OPUS_ARM_NE10
 
 SOURCES_OPUS_X86_SSE = libs/opus/celt/x86/x86cpu.c \
     libs/opus/celt/x86/x86_celt_map.c \
@@ -690,6 +696,18 @@ contains(QT_ARCH, armeabi-v7a) | contains(QT_ARCH, arm64-v8a) {
     SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM
     DEFINES_OPUS += OPUS_ARM_PRESUME_NEON=1 OPUS_ARM_PRESUME_NEON_INTR=1
     contains(QT_ARCH, arm64-v8a):DEFINES_OPUS += OPUS_ARM_PRESUME_AARCH64_NEON_INTR
+} else:contains(QT_ARCH, arm64) {
+    # arm64-v8a above is the Android ABI name; plain arm64 is what Qt reports
+    # for 64-bit ARM everywhere else (Apple Silicon macOS, iOS, Linux aarch64).
+    # NEON is part of the base AArch64 ISA, so the NEON intrinsics can be
+    # presumed present and compiled without special compiler flags (see the
+    # SOURCES_OPUS_ARCH handling below).
+    # OPUS_ARM_MAY_HAVE_NEON_INTR is required in addition to the PRESUME
+    # defines: opus gates the inclusion of its arm/*.h headers on it
+    # (see libs/opus/celt/pitch.h and libs/opus/celt/cpu_support.h).
+    HEADERS_OPUS += $$HEADERS_OPUS_ARM
+    SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM_NEON
+    DEFINES_OPUS += OPUS_ARM_MAY_HAVE_NEON_INTR=1 OPUS_ARM_PRESUME_NEON_INTR=1 OPUS_ARM_PRESUME_AARCH64_NEON_INTR=1
 } else:contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
     HEADERS_OPUS += $$HEADERS_OPUS_X86
     SOURCES_OPUS_ARCH += $$SOURCES_OPUS_X86_SSE $$SOURCES_OPUS_X86_SSE2 $$SOURCES_OPUS_X86_SSE4
@@ -1172,6 +1190,11 @@ contains(CONFIG, "opus_shared_lib") {
             sse4_cc.variable_out = OBJECTS
             QMAKE_EXTRA_COMPILERS += sse_cc sse2_cc sse4_cc
         }
+    } else:contains(QT_ARCH, arm64) {
+        # Unlike the x86 SSE files above, the AArch64 NEON intrinsics need no
+        # special compiler flags (NEON is part of the base AArch64 ISA), so
+        # they can be compiled like any other source file.
+        SOURCES += $$SOURCES_OPUS_ARCH
     }
 }
 

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -660,8 +660,7 @@ SOURCES_OPUS = libs/opus/celt/bands.c \
     libs/opus/src/opus_encoder.c \
     libs/opus/src/repacketizer.c
 
-# NEON intrinsic sources: self-contained, need no external library.
-SOURCES_OPUS_ARM_NEON = libs/opus/celt/arm/armcpu.c \
+SOURCES_OPUS_ARM = libs/opus/celt/arm/armcpu.c \
     libs/opus/celt/arm/arm_celt_map.c \
     libs/opus/silk/arm/arm_silk_map.c \
     libs/opus/silk/arm/biquad_alt_neon_intr.c \
@@ -670,13 +669,6 @@ SOURCES_OPUS_ARM_NEON = libs/opus/celt/arm/armcpu.c \
     libs/opus/silk/arm/NSQ_neon.c \
     libs/opus/celt/arm/celt_neon_intr.c \
     libs/opus/celt/arm/pitch_neon_intr.c
-# NE10 sources: FFT/MDCT acceleration via the external Ne10 library, which
-# Jamulus does not bundle (they #include <NE10_dsp.h> unconditionally and are
-# gated on HAVE_ARM_NE10, which we never define). Kept listed for completeness
-# but never added to SOURCES.
-SOURCES_OPUS_ARM_NE10 = libs/opus/celt/arm/celt_fft_ne10.c \
-    libs/opus/celt/arm/celt_mdct_ne10.c
-SOURCES_OPUS_ARM = $$SOURCES_OPUS_ARM_NEON $$SOURCES_OPUS_ARM_NE10
 
 SOURCES_OPUS_X86_SSE = libs/opus/celt/x86/x86cpu.c \
     libs/opus/celt/x86/x86_celt_map.c \
@@ -691,23 +683,16 @@ SOURCES_OPUS_X86_SSE4 = libs/opus/celt/x86/celt_lpc_sse4_1.c \
      libs/opus/silk/x86/VAD_sse4_1.c \
      libs/opus/silk/x86/VQ_WMat_EC_sse4_1.c
 
-contains(QT_ARCH, armeabi-v7a) | contains(QT_ARCH, arm64-v8a) {
-    HEADERS_OPUS += $$HEADERS_OPUS_ARM
-    SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM
-    DEFINES_OPUS += OPUS_ARM_PRESUME_NEON=1 OPUS_ARM_PRESUME_NEON_INTR=1
-    contains(QT_ARCH, arm64-v8a):DEFINES_OPUS += OPUS_ARM_PRESUME_AARCH64_NEON_INTR
-} else:contains(QT_ARCH, arm64) {
-    # arm64-v8a above is the Android ABI name; plain arm64 is what Qt reports
-    # for 64-bit ARM everywhere else (Apple Silicon macOS, iOS, Linux aarch64).
-    # NEON is part of the base AArch64 ISA, so the NEON intrinsics can be
-    # presumed present and compiled without special compiler flags (see the
-    # SOURCES_OPUS_ARCH handling below).
-    # OPUS_ARM_MAY_HAVE_NEON_INTR is required in addition to the PRESUME
-    # defines: opus gates the inclusion of its arm/*.h headers on it
+contains(QT_ARCH, armeabi-v7a) | contains(QT_ARCH, arm64-v8a) | contains(QT_ARCH, arm64) {
+    # armeabi-v7a and arm64-v8a are the Android ABI names; plain arm64 is what Qt
+    # reports for 64-bit ARM everywhere else (Apple Silicon macOS, iOS, Linux aarch64).
+    # OPUS_ARM_MAY_HAVE_NEON_INTR is required in addition to the PRESUME defines:
+    # opus gates the inclusion of its arm/*.h headers on it
     # (see libs/opus/celt/pitch.h and libs/opus/celt/cpu_support.h).
     HEADERS_OPUS += $$HEADERS_OPUS_ARM
-    SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM_NEON
-    DEFINES_OPUS += OPUS_ARM_MAY_HAVE_NEON_INTR=1 OPUS_ARM_PRESUME_NEON_INTR=1 OPUS_ARM_PRESUME_AARCH64_NEON_INTR=1
+    SOURCES_OPUS_ARCH += $$SOURCES_OPUS_ARM
+    DEFINES_OPUS += OPUS_ARM_MAY_HAVE_NEON_INTR=1 OPUS_ARM_PRESUME_NEON=1 OPUS_ARM_PRESUME_NEON_INTR=1
+    contains(QT_ARCH, arm64-v8a) | contains(QT_ARCH, arm64):DEFINES_OPUS += OPUS_ARM_PRESUME_AARCH64_NEON_INTR
 } else:contains(QT_ARCH, x86) | contains(QT_ARCH, x86_64) {
     HEADERS_OPUS += $$HEADERS_OPUS_X86
     SOURCES_OPUS_ARCH += $$SOURCES_OPUS_X86_SSE $$SOURCES_OPUS_X86_SSE2 $$SOURCES_OPUS_X86_SSE4
@@ -1190,10 +1175,11 @@ contains(CONFIG, "opus_shared_lib") {
             sse4_cc.variable_out = OBJECTS
             QMAKE_EXTRA_COMPILERS += sse_cc sse2_cc sse4_cc
         }
-    } else:contains(QT_ARCH, arm64) {
-        # Unlike the x86 SSE files above, the AArch64 NEON intrinsics need no
-        # special compiler flags (NEON is part of the base AArch64 ISA), so
-        # they can be compiled like any other source file.
+    } else:contains(QT_ARCH, armeabi-v7a) | contains(QT_ARCH, arm64-v8a) | contains(QT_ARCH, arm64) {
+        # Unlike the x86 SSE files above, the NEON intrinsics need no special
+        # compiler flags: NEON is part of the base AArch64 ISA, and the NDK's
+        # clang enables it by default for armv7a-linux-androideabi. So they
+        # can be compiled like any other source file.
         SOURCES += $$SOURCES_OPUS_ARCH
     }
 }


### PR DESCRIPTION
**🤖 AI:** Fixes #2806.

`Jamulus.pro`'s opus ARM block matched only the Android ABI names (`armeabi-v7a`, `arm64-v8a`), so every other 64-bit ARM build (Apple Silicon macOS, iOS, Linux aarch64, which Qt reports as `QT_ARCH=arm64`) compiled opus as plain C. The block was also inert where it did match: `SOURCES += $$SOURCES_OPUS_ARCH` existed only in the x86 branch, and `OPUS_ARM_MAY_HAVE_NEON_INTR`, which gates opus's `arm/*.h` headers, was never defined. On main no target compiles a single `libs/opus/*/arm/` file.

**What this PR does**

- One ARM case for all three values of `QT_ARCH`: same headers, the 9 NEON intrinsic sources, `OPUS_ARM_MAY_HAVE_NEON_INTR=1 OPUS_ARM_PRESUME_NEON=1 OPUS_ARM_PRESUME_NEON_INTR=1`, plus `OPUS_ARM_PRESUME_AARCH64_NEON_INTR` for the 64-bit ones.
- A consumption branch that compiles those sources for the ARM cases. No special compiler flags: NEON is part of the base AArch64 ISA, and the NDK's clang enables it by default for `armv7a-linux-androideabi`.
- `celt_fft_ne10.c` and `celt_mdct_ne10.c` removed from the source list. They `#include <NE10_dsp.h>` unconditionally, Jamulus does not bundle Ne10, and no target has ever compiled them.

The Android ABIs therefore compile the NEON sources for the first time; x86 builds are untouched.

**Testing**

- `qmake`-resolved `Makefile.Release` per `QT_ARCH`: x86_64 identical before and after; `arm64`, `arm64-v8a`, `armeabi-v7a` each list the 9 ARM sources and the defines above; main lists 0 ARM sources for the Android ABIs.
- Native Raspberry Pi 4 build (aarch64, gcc 14, `CONFIG+=headless`): links, 9 `_neon` symbols in the binary, 0 undefined.
- NDK r21d clang with Qt 5.15.2's `android-clang` flags (`-target <abi>30 -Oz -fPIC`): all 138 opus sources compile for `armv7a-linux-androideabi30` and `aarch64-linux-android30`, 0 failures, and every `_neon` symbol the objects reference is defined in the set.
- CPU effect on a Pi 4 server was measured earlier in this thread as noise-level at both complexity settings; this is a build-correctness fix, not a performance claim.

---

🤖 *This message was written by AI and reviewed by @mcfnord.*