### PR TITLE
Fix MIDI pickup crossing detection never firing

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -95,7 +95,7 @@ static bool midiPickupShouldApply ( int midiValue, int currentValue, int toleran
     // Handles the case where rapid movement causes MIDI values to "skip over" the software value
     if ( recentMidiValues.size() >= 2 )
     {
-        int prevMidi = recentMidiValues.back();
+        int prevMidi = recentMidiValues[recentMidiValues.size() - 2];
         // Check if current and previous MIDI values bracket the software value
         if ( ( prevMidi <= currentValue && midiValue >= currentValue ) || ( prevMidi >= currentValue && midiValue <= currentValue ) )
             return true;
@@ -117,7 +117,11 @@ static bool midiPickupTryApply ( int midiValue, int currentValue, int tolerance,
         tempPickup.push_back ( midiValue );
 
         if ( !midiPickupShouldApply ( midiValue, currentValue, tolerance, tempPickup ) )
+        {
+            // keep this value: the next message needs it to detect a crossing
+            pickupBuffer = tempPickup;
             return true; // Still waiting for pickup
+        }
 
         // Picked up. Stop waiting
         waitingForPickup = false;

--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -118,7 +118,8 @@ static bool midiPickupTryApply ( int midiValue, int currentValue, int tolerance,
 
         if ( !midiPickupShouldApply ( midiValue, currentValue, tolerance, tempPickup ) )
         {
-            // keep this value: the next message needs it to detect a crossing
+            // still waiting: keep this value in the channel's recentFader/recentPan
+            // history so the next message can detect a crossing
             pickupBuffer = tempPickup;
             return true; // Still waiting for pickup
         }


### PR DESCRIPTION
> [!NOTE]
> 📡 **STAND BY FOR AN LLM-AUTHORED MESSAGE.**

Fixes: #3942

MIDI pickup mode has a second acceptance path beside the tolerance test, for when a fast fader move makes consecutive MIDI values skip straight over the software value:

```cpp
// If buffer has at least 2 values, check if we're crossing the current value
// Handles the case where rapid movement causes MIDI values to "skip over" the software value
if ( recentMidiValues.size() >= 2 )
{
    int prevMidi = recentMidiValues.back();
    ...
}
```

It has never run. There are two independent defects, and either one alone is enough to disable it.

**1. The history is never recorded while waiting.** `midiPickupTryApply` builds a temporary copy, tests it, and on failure returns early — jumping over the `// Update the pickup buffer` block at the end of the function. So while `waitingForPickup` is true, which is exactly the state the history exists to serve, `pickupBuffer` stays empty. The largest deque ever passed to `midiPickupShouldApply` is 1, so `size() >= 2` is never satisfied.

**2. `prevMidi` is not the previous value.** `recentMidiValues.back()` is the element `midiValue` was just `push_back`'d as, so `prevMidi == midiValue` and the bracket test reduces to `midiValue == currentValue` — already covered by the tolerance test three lines above. Sweeping `(prev, current, new)` over 0..100 outside tolerance, the current code detects **0 of 323400** genuine crossings.

The `size() >= 2` guard is itself the evidence of intent: you only need two elements if you mean to look past the last one.

## What it costs a user

`CSoundBase::ParseMIDIMessage` maps CC 0..127 onto fader 0..`AUD_MIX_FADER_MAX` (100), so one CC step is 0.79 fader units against a `MIDI_PICKUP_TOLERANCE` of 2. Slow moves are picked up by the tolerance test and the bug stays invisible. Fast moves are where it shows: sweeping a hardware fader past a software fader sitting at 50, the fader stays dead at several speeds until the user slows down and lands within ±2 units.

| CC step | before | fix 1 only | fix 2 only | this PR | client, before / this PR |
|---|---|---|---|---|---|
| 8 | picks up (9 msgs) | picks up (9) | picks up (9) | picks up (9) | 9 / 9 |
| 10 | **never picks up** | **never** | **never** | picks up (8) | never / 8 |
| 13 | picks up (6) | picks up (6) | picks up (6) | picks up (6) | 6 / 6 |
| 20 | **never picks up** | **never** | **never** | picks up (5) | never / 5 |
| 24 | **never picks up** | **never** | **never** | picks up (4) | never / 4 |
| 32 | picks up (3) | picks up (3) | picks up (3) | picks up (3) | 3 / 3 |

The two middle columns are the reason this PR changes two things rather than one: fixing either defect on its own changes nothing measurable.

Those six rows are a sample. Across the first 32 step sizes, fader parked at 50, **16 never pick up on `main` and 0 never pick up with this PR**, the smallest failing step being 10. Under that size the tolerance test absorbs the move: at one CC value per message, sweeping against every parked position 0..100 gives **0 of 101 positions that fail on either build**. So a controller emitting its full CC stream cannot expose this at any speed, and the shortest reproduction is to send CC in steps of 10 or more.

## Checks

Harness compiles the two patched functions verbatim out of `audiomixerboard.cpp` rather than a re-typed copy, so what is measured is what is shipped.

- All previously stuck sweep speeds now pick up.
- Both directions: the exhaustive two-sample crossing sweep run upward and then downward — 147440 crossings each way, disjoint sets — picks up **147440 of 147440** with both edits and **0 of 147440** with either edit alone.
- Regression on the property the feature exists for: pickup must never engage on the first message when the hardware fader is far from the software fader. Across all 12928 combinations of software position 0..100 and CC 0..127 outside tolerance, first-message jumps: **0**.
- `clang-format` 14.0.6 reports no change; compiles clean under `-Wall -Wextra`.

**Runtime, through the shipped client.** A JACK MIDI source — not physical hardware, but real MIDI arriving on the port `CSound::CreateMIDIPort` opens — feeds a GUI client with one channel fader parked at 50 and Pick-up Mode on, and the observable is the `CHANNEL_GAIN` message the client puts on the wire. Two control-change messages 298.12 ms apart carrying CC 51 and CC 76 — fader 40 and 59, bracketing the parked 50, both outside tolerance — produce no gain message and no fader movement on `main` at `72e856af`. The same two messages on that tree with this PR's two edits applied pick up and send the gain for 59. Sweeping that same span one CC step at a time on `main` instead picks up at 48, the tolerance edge, and tracks from there: 12 gain messages. The sweep table's last column is that same client — 12 runs, one per step and build, the controller stepping up from CC 0 one message every 30 ms — and every cell agrees with the harness. Reproducers, including one that needs no MIDI hardware at all: [this gist](https://gist.github.com/mcfnord/fdd88cdbe5265a9dbf4cf8e12841851d).

## What I did not do

One related thing I noticed and deliberately left alone: `g_midiPickupWaitingForPickup` is a single flag per channel shared by the fader *and* the pan, while the history deques and timestamps beside it in `MidiPickupState` are correctly per-control (`recentFader`/`recentPan`, `lastMidiTimeFader`/`lastMidiTimePan`). That means picking up the pan also clears the fader's waiting state, and either control's inactivity timeout re-arms both. It needs two flags rather than one, which is a different change from this one, so I have not folded it in. I can open it separately if you would like.

CHANGELOG: Bugfix: MIDI pickup mode now correctly detects a fader crossing the software value during fast moves.



