### PR TITLE
Backport #3810: bounds check iChanID before array access (release/3_12)

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1349,9 +1349,12 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
 
         for ( size_t iFader = 0; iFader < iNumConnectedClients; iFader++ )
         {
-            // ideally "iChanID" in CChannelInfo would be size_t if it can never be INVALID_INDEX
-            // as assumed here
-            iFaderNumber[vecChanInfo[iFader].iChanID] = static_cast<int> ( iFader );
+            const int iChanID = vecChanInfo[iFader].iChanID;
+
+            if ( MathUtils::InRange<int> ( iChanID, 0, MAX_NUM_CHANNELS ) )
+            {
+                iFaderNumber[iChanID] = static_cast<int> ( iFader );
+            }
         }
 
         // Hide all unused faders and initialize used ones

--- a/src/util.h
+++ b/src/util.h
@@ -1223,6 +1223,13 @@ public:
             return powf ( 10.0f, ( fInValueRange0_1 - 1.0f ) * AUD_MIX_FADER_RANGE_DB / 20.0f );
         }
     }
+
+    // Returns true if value is in [lower, upper) (inclusive lower, exclusive upper).
+    template<typename T>
+    static inline bool InRange ( T value, T lower /* inclusive */, T upper /* exclusive */ )
+    {
+        return value >= lower && value < upper;
+    }
 };
 
 /******************************************************************************\

--- a/src/util.h
+++ b/src/util.h
@@ -1222,6 +1222,13 @@ public:
             return powf ( 10.0f, ( fInValueRange0_1 - 1.0f ) * AUD_MIX_FADER_RANGE_DB / 20.0f );
         }
     }
+
+    // Returns true if value is in [lower, upper) (inclusive lower, exclusive upper).
+    template<typename T>
+    static inline bool InRange ( T value, T lower /* inclusive */, T upper /* exclusive */ )
+    {
+        return value >= lower && value < upper;
+    }
 };
 
 /******************************************************************************\


### PR DESCRIPTION
**🤖 AI:** Backports #3810's `iChanID` bounds check to `release/3_12` as a piecemeal patch: one commit, two files, +13/-3. [`MathUtils::InRange`](https://github.com/mcfnord/jamulus/blob/014f1ef09f2785083a192abeaf334a6b6ff4bea2/src/util.h#L1229) is added to `util.h` with #3812's half-open interval, and [the `ApplyNewConClientList` call site](https://github.com/mcfnord/jamulus/blob/014f1ef09f2785083a192abeaf334a6b6ff4bea2/src/audiomixerboard.cpp#L1354) is switched to use it. Both regions are byte-identical to [`main`](https://github.com/jamulussoftware/jamulus/blob/4a43f6f6bd49a37b79817a64450346724cba5752/src/audiomixerboard.cpp#L1354) at `4a43f6f6`.

Not cherry-picked, [at pljones's request](https://github.com/jamulussoftware/jamulus/pull/3840#discussion_r3936157588): the commits that carried `InRange` to `main` also carry an unrelated server chat-handling refactor that `release/3_12` does not have, so only the amended lines are backported. Base is `release/3_12` at `e6a87df6`.

Fixes the same issue as #3810, for `release/3_12`.

---

🤖 *This message was written by AI and reviewed by @mcfnord.*
