### PR TITLE
Add jamulusclient/setInputBoost JSON-RPC method

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -274,6 +274,23 @@ Results:
 | result | string | Always "ok". |
 
 
+### jamulusclient/setInputBoost
+
+Sets the input boost factor.
+
+Parameters:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| params.boost | int | boost factor, 1 (no boost) to 10. |
+
+Results:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| result | string | Always "ok". |
+
+
 ### jamulusclient/setMidiSettings
 
 Sets one or more MIDI controller settings.

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -511,6 +511,30 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
 
         response["result"] = "ok";
     } );
+
+    /// @rpc_method jamulusclient/setInputBoost
+    /// @brief Sets the input boost factor.
+    /// @param {int} params.boost - boost factor, 1 (no boost) to 10.
+    /// @result {string} result - Always "ok".
+    pRpcServer->HandleMethod ( "jamulusclient/setInputBoost", [=] ( const QJsonObject& params, QJsonObject& response ) {
+        auto boost = params["boost"];
+        if ( !boost.isDouble() )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: boost is not a number" );
+            return;
+        }
+
+        const int iBoost = boost.toInt();
+        if ( iBoost < 1 || iBoost > 10 )
+        {
+            response["error"] = CRpcServer::CreateJsonRpcError ( CRpcServer::iErrInvalidParams, "Invalid params: boost must be between 1 and 10" );
+            return;
+        }
+
+        pClient->SetInputBoost ( iBoost );
+
+        response["result"] = "ok";
+    } );
 }
 
 QJsonValue CClientRpc::SerializeSkillLevel ( ESkillLevel eSkillLevel )


### PR DESCRIPTION
MY LLM WROTE:

Adds `jamulusclient/setInputBoost` so headless clients can change the input boost factor at runtime, matching what the GUI's Advanced Settings combo box already does.

Requested by @pljones on #3841: *"add the JSONRPC to match the Client UI first, then this one. I'd rather not introduce a hole."* This is that first PR; #3841 (the ini-parse fix) follows it.

### What it does

`{"boost": <1-10>}` calls `CClient::SetInputBoost()` directly — the same call the GUI makes from `CClientSettingsDlg::OnInputBoostChanged` (`clientsettingsdlg.cpp:1385-1389`) on every combo-box change. The factor is 1-based, where `1` is the GUI's "None", matching `cbxInputBoost`'s population in `clientsettingsdlg.cpp:549-556`.

Validation mirrors the existing `setMuted` handler. `docs/JSON-RPC.md` is regenerated via `tools/generate_json_rpc_docs.py`.

### Testing

Built headless (`qmake CONFIG+=headless && make`), then ran a real headless client (`jackd -d dummy`, `-n --jsonrpcport ... --jsonrpcsecretfile ...`) and drove the method over the TCP JSON-RPC socket — not just a startup smoke test:

| Request | Response |
| --- | --- |
| `{"boost": 10}` | `{"result": "ok"}` |
| `{"boost": 1}` | `{"result": "ok"}` |
| `{"boost": 11}` | `{"error": {"code": -32602, "message": "Invalid params: boost must be between 1 and 10"}}` |
| `{"boost": 0}` | `{"error": {"code": -32602, "message": "Invalid params: boost must be between 1 and 10"}}` |
| `{"boost": "x"}` | `{"error": {"code": -32602, "message": "Invalid params: boost is not a number"}}` |
| `{}` | `{"error": {"code": -32602, "message": "Invalid params: boost is not a number"}}` |

Each response carries `result` or `error`, never both — checked explicitly, since that was the bug fixed in #3820.

### Note

There is no `getInputBoost`: `client.h:290` defines only the setter, so a consumer can set the boost but not read it back. Several other RPC settings have the same asymmetry, so I left it out of this PR rather than address it piecemeal — happy to follow up if you'd like it covered.
