### PR TITLE
When server list received, only start pings if timer not running

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -560,10 +560,14 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
         }
     }
 
+    // only if the ping timer is not already running (avoids double ping):
     // immediately issue the ping measurements and start the ping timer since
     // the server list is filled now
-    OnTimerPing();
-    TimerPing.start ( PING_UPDATE_TIME_SERVER_LIST_MS );
+    if ( !TimerPing.isActive() )
+    {
+        OnTimerPing();
+        TimerPing.start ( PING_UPDATE_TIME_SERVER_LIST_MS );
+    }
 }
 
 void CConnectDlg::SetConnClientsList ( const CHostAddress& InetAddr, const CVector<CChannelInfo>& vecChanInfo )

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -318,6 +318,9 @@ void CConnectDlg::showEvent ( QShowEvent* )
 
 void CConnectDlg::RequestServerList()
 {
+    // ensure ping timer is stopped
+    TimerPing.stop();
+
     // reset flags
     bServerListReceived        = false;
     bReducedServerListReceived = false;


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

In `CConnectDlg::SetServerList()`, test whether `TimerPing` is already running before starting it and calling `OnTimerPing()`

This avoids a double ping on startup due to receiving the reduced server list and the normal server list in quick succession. It also appears to fix the longstanding behaviour of the first ping values displayed being wildly inaccurate.

CHANGELOG: Client: remove double ping from Connect Dialog, improving accuracy of initial ping times displayed.

**Context: Fixes an issue?**

I noticed while working on the TCP support, that when opening the connect dialog or changing directory, it would initially ping every server twice in succession. This turned out to be because of receiving the reduced and full server lists from the directory. They would both result in a call to `OnTimerPing()` and starting of `TImerPing`. This PR checks whether `TimerPing` is already running before doing so, thereby avoiding the double ping.

**Does this change need documentation? What needs to be documented and how?**

No, bugfix only.

**Status of this Pull Request**

Ready. Would also be worth backporting to 3.12.4

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
