### PR TITLE
Build: Enable dependabot for git submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "Build"
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "Build"


### PR DESCRIPTION
MY LLM WROTE:

**Short description of changes**

Enables Dependabot for git submodules by adding a `gitsubmodule` package-ecosystem entry to `.github/dependabot.yml`. This makes Dependabot check the one submodule we have — `libs/oboe` (google/oboe) — for updates weekly and open a PR when a newer commit is available, exactly as it already does for GitHub Actions.

CHANGELOG: Build: Enable dependabot for git submodule updates

**Context: Fixes an issue?**

Related: #2346 (checklist item "Submodules (liboboe)").

This is one PR in the "set of PRs" requested in #2346. It deliberately covers **only** the submodule item, which Dependabot handles natively and safely. The remaining unchecked items in #2346 — Android SDK/NDK/command-line-tools and the pylint pin — are *not* included here on purpose: those are compatibility- and policy-coupled version jumps (NDK r21d, `android-30`/build-tools 30.0.2, and a deliberate `pylint < 3.0` ceiling) that would break the build or the style check if bumped mechanically, and are already being handled deliberately elsewhere (#3392, #3261, #2767, #3056). Automating them the way aqt/Qt/NSIS are automated would just produce failing PRs. Happy to discuss those separately if useful.

**Does this change need documentation?**

No.

**Status of this Pull Request**

Ready for review.

**What is missing until this pull request can be merged?**

- [ ] Review
- [ ] After merge, confirm on the Dependabot page that the submodule ecosystem is picked up and no errors are shown.
