### PR TITLE
Document TARGET naming mechanisms in Jamulus.pro

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -6,6 +6,16 @@ lessThan(QT_MAJOR_VERSION, 5) | equals(QT_MAJOR_VERSION, 5) : lessThan(QT_MINOR_
     error(Jamulus requires at least Qt5.12. See https://github.com/jamulussoftware/jamulus/pull/3288)
 }
 
+# Target naming. The two Debian packages get their binary names by different means
+# (see linux/debian/rules): the desktop build passes CONFIG+=noupcasename, handled
+# here, while the headless build passes TARGET=jamulus-headless on the qmake command
+# line. TARGET selects the installed usr/bin/<TARGET> listed in debian/*.install and
+# is substituted into Exec= in the generated .desktop files, and it has to keep
+# matching the hardcoded ExecStart=/usr/bin/jamulus-headless in the headless unit.
+# Note the assignment below overrides any TARGET= given on the command line, so
+# adding noupcasename to the headless build would silently rename its binary to
+# "jamulus" and break that package.
+
 # use target name which does not use a capital letter at the beginning
 contains(CONFIG, "noupcasename") {
     message(The target name is jamulus instead of Jamulus.)


### PR DESCRIPTION
MY LLM WROTE:

Follow-up to @pljones' review comment on #3799 (https://github.com/jamulussoftware/jamulus/pull/3799#discussion_r3676752949):

> It might be worth documenting in the `Jamulus.pro` rather than surfacing it to the debian-specific README. Anyone maintaining `Jamulus.pro` would need to be aware of the intent.
>
> Probably a separate PR, though, at this point.

This is that separate PR. Comment only — no build behaviour changes.

### What it documents

The two Debian packages get their binary names by *different* mechanisms, and nothing in `Jamulus.pro` said so:

| package | qmake invocation | resulting `TARGET` |
|---|---|---|
| `jamulus` | `CONFIG+=noupcasename` (`linux/debian/rules:34`) | `jamulus` |
| `jamulus-headless` | `TARGET=jamulus-headless` on the command line (`linux/debian/rules:35`) | `jamulus-headless` |
| *(neither)* | plain `qmake` | `Jamulus` |

`TARGET` is consumed in three places, so a change here is not local:

- `usr/bin/<TARGET>` is what `debian/jamulus.install` and `debian/jamulus-headless.install` list;
- it is substituted into `Exec=` in the generated `.desktop` files (`linux/jamulus.desktop.in:13` is `Exec=$$TARGET`);
- it has to keep matching the hardcoded `ExecStart=/usr/bin/jamulus-headless` in `debian/jamulus-headless.service:21`.

### The part worth knowing

`TARGET = jamulus` inside the `noupcasename` block **silently overrides** a `TARGET=` passed on the qmake command line. So adding `noupcasename` to the headless build — which looks like a harmless tidy-up that unifies the two mechanisms — would rename that binary to `jamulus`, and the failure surfaces as a broken package, not a build error.

### How this was checked

Each row of the table above was produced by running `qmake` and reading `TARGET` out of the generated `Makefile.Release`, not by reading the `.pro` file. The `Exec=` claim was checked against the generated `.desktop` files (`Exec=jamulus` with `noupcasename`, `Exec=Jamulus` without). Environment: qmake 3.1 / Qt 5.15.13, Ubuntu, `QT_SELECT=qt5` as `linux/debian/rules:3` pins.

Not exercised: the macOS `server_bundle` append at `Jamulus.pro:191` (`TARGET = $${TARGET}Server`), and the precedence rule was confirmed on Qt5 only. Neither affects Debian packaging, but say the word if you want either measured before merge.
