### PR TITLE
Docs: fix Fedora dependency list to build the GUI (qt5-qtmultimedia-devel)

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -34,7 +34,7 @@ On Debian 11+ you can install the dependencies by issuing the following command:
 - qt5-qtbase
 - jack-audio-connection-kit-devel
 - qt5-linguist
-- qt5-qtmultimedia
+- qt5-qtmultimedia-devel
 
 ### For all desktop distributions
 


### PR DESCRIPTION
MY LLM WROTE:

The Fedora list in COMPILING.md is missing the `-devel` package needed to build the default (GUI) client.

The non-headless build adds `QT += multimedia` and includes `<QSoundEffect>` (`src/util.cpp`). On Fedora the runtime `qt5-qtmultimedia` package contains neither that header nor the qmake module file `mkspecs/modules/qt_lib_multimedia.pri`, so `qmake` aborts before compiling:

```
Project ERROR: Unknown module(s) in QT: multimedia
```

Both ship in `qt5-qtmultimedia-devel`, which requires the runtime package, so this one-word change is sufficient. The headless server build removes gui/multimedia and is unaffected.

Reproducible on a clean image:

```
docker run --rm fedora:latest bash -c '
  dnf install -y gcc-c++ make git \
    qt5-qtdeclarative-devel jack-audio-connection-kit-dbus qt5-qtbase \
    jack-audio-connection-kit-devel qt5-linguist qt5-qtmultimedia-devel
  git clone --depth 1 https://github.com/jamulussoftware/jamulus
  cd jamulus && qmake-qt5 Jamulus.pro'
```

Fixes #3366.
