### PR TITLE
Fix autobuild.yml to build merges and PRs on release/* branches

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -24,13 +24,14 @@ on:
         description: 'Build all targets (instead of just the main platforms)'
   push:
     tags:
-      - "r*"
+      - 'r*'
     branches:
       # For developers: Branches starting with autobuild will be built and evaluated on each push.
-      - "autobuild**"
+      - 'autobuild**'
       # CodeQL requires every branch from on.pull_request to be part of on.push as well in order to run comparisons.
       # We also need main here to trigger builds on PR merge to main and manual pushes (e.g. as part of the release process):
-      - "main"
+      - 'main'
+      - 'release/**'
     paths-ignore:
       - '**README.md'
       - 'docs/**'
@@ -43,7 +44,8 @@ on:
       - '.github/pull_request_template.md'
   pull_request:
     branches:
-      - main
+      - 'main'
+      - 'release/**'
     paths-ignore:
       - '**README.md'
       - 'docs/**'


### PR DESCRIPTION
**Short description of changes**

1. Adds `release/**` pattern to `on.push.branches` and `on.pull_request.branches`.
2. Makes the quoting consistent

CHANGELOG: SKIP

**Context: Fixes an issue?**

Direct merges to release/* or PRs to release/* would not have triggered the autobuild workflow as expected.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

I got Github CoPilot in VSCode to review it for me (it also did the quote fixes).

(Github CoPilot in VSCode GPT-5.3-Codex, 14.6 credits...)

**What is missing until this pull request can be merged?**

Human review.

I have no idea whether this needs backporting or whether it'll just work, either.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->