### PR TITLE
Use mapped version for update notification check

### DIFF
--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -855,11 +855,18 @@ void CClientDlg::OnCLVersionAndOSReceived ( CHostAddress InetAddr, COSUtil::EOpS
     {
         // update check
 #if ( QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 ) ) && !defined( DISABLE_VERSION_CHECK )
-        if ( CompareVersionStrings ( strVersion, VERSION ) > 0 )
+        // Ignore non-release remote versions when deciding whether to notify.
+        if ( IsReleaseVersion ( strVersion ) )
         {
-            // show the label and hide it after one minute again
-            lblUpdateCheck->show();
-            QTimer::singleShot ( 60000, this, [this]() { lblUpdateCheck->hide(); } );
+            const QString mappedServerVersion  = MapVersionStrForCompare ( strVersion );
+            const QString mappedCurrentVersion = MapVersionStrForCompare ( VERSION );
+
+            if ( mappedServerVersion.compare ( mappedCurrentVersion ) > 0 )
+            {
+                // show the label and hide it after one minute again
+                lblUpdateCheck->show();
+                QTimer::singleShot ( 60000, this, [this]() { lblUpdateCheck->hide(); } );
+            }
         }
 #endif
     }

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -855,14 +855,7 @@ void CClientDlg::OnCLVersionAndOSReceived ( CHostAddress InetAddr, COSUtil::EOpS
     {
         // update check
 #if ( QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 ) ) && !defined( DISABLE_VERSION_CHECK )
-        int            mySuffixIndex;
-        QVersionNumber myVersion = QVersionNumber::fromString ( VERSION, &mySuffixIndex );
-
-        int            serverSuffixIndex;
-        QVersionNumber serverVersion = QVersionNumber::fromString ( strVersion, &serverSuffixIndex );
-
-        // only compare if the server version has no suffix (such as dev or beta)
-        if ( strVersion.size() == serverSuffixIndex && QVersionNumber::compare ( serverVersion, myVersion ) > 0 )
+        if ( CompareVersionStrings ( strVersion, VERSION ) > 0 )
         {
             // show the label and hide it after one minute again
             lblUpdateCheck->show();

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -855,10 +855,11 @@ void CClientDlg::OnCLVersionAndOSReceived ( CHostAddress InetAddr, COSUtil::EOpS
     {
         // update check
 #if ( QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 ) ) && !defined( DISABLE_VERSION_CHECK )
+        const QString mappedServerVersion = MapVersionStrForCompare ( strVersion );
+
         // Ignore non-release remote versions when deciding whether to notify.
-        if ( IsReleaseVersion ( strVersion ) )
+        if ( IsMappedReleaseVersion ( mappedServerVersion ) )
         {
-            const QString mappedServerVersion  = MapVersionStrForCompare ( strVersion );
             const QString mappedCurrentVersion = MapVersionStrForCompare ( VERSION );
 
             if ( mappedServerVersion.compare ( mappedCurrentVersion ) > 0 )

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -73,7 +73,7 @@ bool CMappedTreeWidgetItem::operator<( const QTreeWidgetItem& other ) const
     if ( !lhs.isValid() || !rhs.isValid() )
         return QTreeWidgetItem::operator<( other );
 
-    return CompareVersionStrings ( lhs.toString(), rhs.toString() ) < 0;
+    return lhs.toString() < rhs.toString();
 }
 
 CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool bNewShowCompleteRegList, QWidget* parent ) :
@@ -1031,8 +1031,8 @@ void CConnectDlg::SetServerVersionResult ( const CHostAddress& InetAddr, const Q
     {
         pCurListViewItem->setText ( LVC_VERSION, GetDisplayVersion ( strVersion ) );
 
-        // and store original version string for semver-aware sorting
-        pCurListViewItem->setData ( LVC_VERSION, Qt::UserRole, strVersion );
+        // and store sortable mapped version number
+        pCurListViewItem->setData ( LVC_VERSION, Qt::UserRole, MapVersionStrForCompare ( strVersion ) );
 
         if ( pCurListViewItem == lvwServers->currentItem() )
         {

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -53,52 +53,6 @@
 
 /* Implementation *************************************************************/
 
-// mapVersionStr - converts a version number to a sortable string
-static QString mapVersionStr ( const QString& versionStr )
-{
-    QString key;
-    QString x = ">"; // default suffix is later (git, dev, nightly, etc)
-
-    // Regex for SemVer: major.minor.patch-suffix
-    QRegularExpression      semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*):?(.*)$)" );
-    QRegularExpressionMatch match = semVerRegex.match ( versionStr );
-
-    if ( !match.hasMatch() )
-    {
-        return versionStr; // fallback: plain text
-    }
-
-    int     major  = match.captured ( 1 ).toInt();
-    int     minor  = match.captured ( 2 ).toInt();
-    int     patch  = match.captured ( 3 ).toInt();
-    QString suffix = match.captured ( 4 ); // may be empty
-    QString tstamp = match.captured ( 5 ); // may be empty
-
-    if ( suffix.isEmpty() )
-    {
-        x = "="; // bare version number
-    }
-    else if ( suffix.startsWith ( "rc" ) || suffix.startsWith ( "beta" ) || suffix.startsWith ( "alpha" ) )
-    {
-        x = "<"; // pre-release version
-    }
-
-    // construct a sortable key mmmnnnpppksuffix, where:
-    //    mmm = major
-    //    nnn = minor
-    //    ppp = patch
-    //    k = sort key to sort alpha, beta, rc before bare version number, and other suffixes after (<, =, >)
-    //    suffix = supplied suffix
-    key = QString ( "%1%2%3%4%5" )
-              .arg ( major, 3, 10, QLatin1Char ( '0' ) )
-              .arg ( minor, 3, 10, QLatin1Char ( '0' ) )
-              .arg ( patch, 3, 10, QLatin1Char ( '0' ) )
-              .arg ( x )
-              .arg ( tstamp.isEmpty() ? suffix : tstamp );
-
-    return key;
-}
-
 // Subclass of QTreeWidgetItem that allows LVC_VERSION to sort by the UserRole data value
 CMappedTreeWidgetItem::CMappedTreeWidgetItem ( QTreeWidget* owner ) : QTreeWidgetItem ( owner ), owner ( owner ) {}
 
@@ -119,7 +73,7 @@ bool CMappedTreeWidgetItem::operator<( const QTreeWidgetItem& other ) const
     if ( !lhs.isValid() || !rhs.isValid() )
         return QTreeWidgetItem::operator<( other );
 
-    return lhs.toString() < rhs.toString();
+    return CompareVersionStrings ( lhs.toString(), rhs.toString() ) < 0;
 }
 
 CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool bNewShowCompleteRegList, QWidget* parent ) :
@@ -1077,8 +1031,8 @@ void CConnectDlg::SetServerVersionResult ( const CHostAddress& InetAddr, const Q
     {
         pCurListViewItem->setText ( LVC_VERSION, GetDisplayVersion ( strVersion ) );
 
-        // and store sortable mapped version number
-        pCurListViewItem->setData ( LVC_VERSION, Qt::UserRole, mapVersionStr ( strVersion ) );
+        // and store original version string for semver-aware sorting
+        pCurListViewItem->setData ( LVC_VERSION, Qt::UserRole, strVersion );
 
         if ( pCurListViewItem == lvwServers->currentItem() )
         {

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -689,14 +689,7 @@ void CServerDlg::OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType
 {
     // update check
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 )
-    int            mySuffixIndex;
-    QVersionNumber myVersion = QVersionNumber::fromString ( VERSION, &mySuffixIndex );
-
-    int            serverSuffixIndex;
-    QVersionNumber serverVersion = QVersionNumber::fromString ( strVersion, &serverSuffixIndex );
-
-    // only compare if the server version has no suffix (such as dev or beta)
-    if ( strVersion.size() == serverSuffixIndex && QVersionNumber::compare ( serverVersion, myVersion ) > 0 )
+    if ( CompareVersionStrings ( strVersion, VERSION ) > 0 )
     {
         lblUpdateCheck->show();
     }

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -689,10 +689,11 @@ void CServerDlg::OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType
 {
     // update check
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 )
+    const QString mappedServerVersion = MapVersionStrForCompare ( strVersion );
+
     // Ignore non-release remote versions when deciding whether to notify.
-    if ( IsReleaseVersion ( strVersion ) )
+    if ( IsMappedReleaseVersion ( mappedServerVersion ) )
     {
-        const QString mappedServerVersion  = MapVersionStrForCompare ( strVersion );
         const QString mappedCurrentVersion = MapVersionStrForCompare ( VERSION );
 
         if ( mappedServerVersion.compare ( mappedCurrentVersion ) > 0 )

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -689,9 +689,16 @@ void CServerDlg::OnCLVersionAndOSReceived ( CHostAddress, COSUtil::EOpSystemType
 {
     // update check
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 6, 0 )
-    if ( CompareVersionStrings ( strVersion, VERSION ) > 0 )
+    // Ignore non-release remote versions when deciding whether to notify.
+    if ( IsReleaseVersion ( strVersion ) )
     {
-        lblUpdateCheck->show();
+        const QString mappedServerVersion  = MapVersionStrForCompare ( strVersion );
+        const QString mappedCurrentVersion = MapVersionStrForCompare ( VERSION );
+
+        if ( mappedServerVersion.compare ( mappedCurrentVersion ) > 0 )
+        {
+            lblUpdateCheck->show();
+        }
     }
 #endif
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -46,6 +46,54 @@
 
 #include "util.h"
 
+namespace
+{
+QString MapVersionStrForCompare ( const QString& versionStr )
+{
+    QString key;
+    QString x = ">"; // default suffix is later (git, dev, nightly, etc)
+
+    // Regex for SemVer: major.minor.patch-suffix
+    QRegularExpression      semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*):?(.*)$)" );
+    QRegularExpressionMatch match = semVerRegex.match ( versionStr );
+
+    if ( !match.hasMatch() )
+    {
+        return versionStr; // fallback: plain text
+    }
+
+    int     major  = match.captured ( 1 ).toInt();
+    int     minor  = match.captured ( 2 ).toInt();
+    int     patch  = match.captured ( 3 ).toInt();
+    QString suffix = match.captured ( 4 ); // may be empty
+    QString tstamp = match.captured ( 5 ); // may be empty
+
+    if ( suffix.isEmpty() )
+    {
+        x = "="; // bare version number
+    }
+    else if ( suffix.startsWith ( "rc" ) || suffix.startsWith ( "beta" ) || suffix.startsWith ( "alpha" ) )
+    {
+        x = "<"; // pre-release version
+    }
+
+    // construct a sortable key mmmnnnpppksuffix, where:
+    //    mmm = major
+    //    nnn = minor
+    //    ppp = patch
+    //    k = sort key to sort alpha, beta, rc before bare version number, and other suffixes after (<, =, >)
+    //    suffix = supplied suffix
+    key = QString ( "%1%2%3%4%5" )
+              .arg ( major, 3, 10, QLatin1Char ( '0' ) )
+              .arg ( minor, 3, 10, QLatin1Char ( '0' ) )
+              .arg ( patch, 3, 10, QLatin1Char ( '0' ) )
+              .arg ( x )
+              .arg ( tstamp.isEmpty() ? suffix : tstamp );
+
+    return key;
+}
+}
+
 /* Implementation *************************************************************/
 // Input level meter implementation --------------------------------------------
 void CStereoSignalLevelMeter::Update ( const CVector<short>& vecsAudio, const int iMonoBlockSizeSam, const bool bIsStereoIn )
@@ -1701,4 +1749,12 @@ QString TruncateString ( QString str, int position )
         position = tbfString.position();
     }
     return str.left ( position );
+}
+
+int CompareVersionStrings ( const QString& lhsVersion, const QString& rhsVersion )
+{
+    const QString lhsMapped = MapVersionStrForCompare ( lhsVersion );
+    const QString rhsMapped = MapVersionStrForCompare ( rhsVersion );
+
+    return lhsMapped.compare ( rhsMapped );
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,14 +48,28 @@
 
 namespace
 {
+const QRegularExpression& GetSemVerRegex()
+{
+    static const QRegularExpression semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*):?(.*)$)" );
+    return semVerRegex;
+}
+} // namespace
+
+// Only bare x.y.z versions should trigger update notifications.
+bool IsReleaseVersion ( const QString& version )
+{
+    const QRegularExpressionMatch match = GetSemVerRegex().match ( version );
+
+    return match.hasMatch() && match.captured ( 4 ).isEmpty() && match.captured ( 5 ).isEmpty();
+}
+
 QString MapVersionStrForCompare ( const QString& versionStr )
 {
     QString key;
     QString x = ">"; // default suffix is later (git, dev, nightly, etc)
 
     // Regex for SemVer: major.minor.patch-suffix
-    QRegularExpression      semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*):?(.*)$)" );
-    QRegularExpressionMatch match = semVerRegex.match ( versionStr );
+    QRegularExpressionMatch match = GetSemVerRegex().match ( versionStr );
 
     if ( !match.hasMatch() )
     {
@@ -91,7 +105,6 @@ QString MapVersionStrForCompare ( const QString& versionStr )
               .arg ( tstamp.isEmpty() ? suffix : tstamp );
 
     return key;
-}
 }
 
 /* Implementation *************************************************************/
@@ -1749,12 +1762,4 @@ QString TruncateString ( QString str, int position )
         position = tbfString.position();
     }
     return str.left ( position );
-}
-
-int CompareVersionStrings ( const QString& lhsVersion, const QString& rhsVersion )
-{
-    const QString lhsMapped = MapVersionStrForCompare ( lhsVersion );
-    const QString rhsMapped = MapVersionStrForCompare ( rhsVersion );
-
-    return lhsMapped.compare ( rhsMapped );
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,19 +48,26 @@
 
 namespace
 {
+// Capture layout:
+//   (1)=major, (2)=minor, (3)=patch,
+//   (4)=suffix (may include dev-<sha>), (5)=timestamp.
+// Examples:
+//   3.10.1 -> (3,10,1,"","")
+//   3.10.1dev-2f2d2a1:1756656363 -> (3,10,1,"dev-2f2d2a1","1756656363")
+//   3.10.1dev-2f2d2a1 -> (3,10,1,"dev-2f2d2a1","")
+//   3.10.2rc1 -> (3,10,2,"rc1","")
+//   v3.10.1 -> no match
 const QRegularExpression& GetSemVerRegex()
 {
-    static const QRegularExpression semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?(.*):?(.*)$)" );
+    static const QRegularExpression semVerRegex ( R"(^(\d+)\.(\d+)\.(\d+)-?([^:]*):?(.*)$)" );
     return semVerRegex;
 }
 } // namespace
 
-// Only bare x.y.z versions should trigger update notifications.
-bool IsReleaseVersion ( const QString& version )
+bool IsMappedReleaseVersion ( const QString& mappedVersion )
 {
-    const QRegularExpressionMatch match = GetSemVerRegex().match ( version );
-
-    return match.hasMatch() && match.captured ( 4 ).isEmpty() && match.captured ( 5 ).isEmpty();
+    // Mapped release keys are exactly "mmmnnnppp=" and contain no dot placeholders.
+    return ( mappedVersion.size() == 10 ) && ( mappedVersion.at ( 9 ) == QLatin1Char ( '=' ) ) && ( !mappedVersion.contains ( QLatin1Char ( '.' ) ) );
 }
 
 QString MapVersionStrForCompare ( const QString& versionStr )
@@ -68,19 +75,30 @@ QString MapVersionStrForCompare ( const QString& versionStr )
     QString key;
     QString x = ">"; // default suffix is later (git, dev, nightly, etc)
 
-    // Regex for SemVer: major.minor.patch-suffix
+    // Build a lexicographically sortable key from regex captures so ordering is:
+    // pre-release (alpha/beta/rc) < release (x.y.z) < post-release/dev/homebrew.
+    // If capture (5) timestamp exists, it is used as the tie-break payload.
     QRegularExpressionMatch match = GetSemVerRegex().match ( versionStr );
 
     if ( !match.hasMatch() )
     {
-        return versionStr; // fallback: plain text
+        return QString ( "..." ) + versionStr;
     }
 
-    int     major  = match.captured ( 1 ).toInt();
-    int     minor  = match.captured ( 2 ).toInt();
-    int     patch  = match.captured ( 3 ).toInt();
-    QString suffix = match.captured ( 4 ); // may be empty
-    QString tstamp = match.captured ( 5 ); // may be empty
+    bool majorOk = false;
+    bool minorOk = false;
+    bool patchOk = false;
+    int  major   = match.captured ( 1 ).toInt ( &majorOk );
+    int  minor   = match.captured ( 2 ).toInt ( &minorOk );
+    int  patch   = match.captured ( 3 ).toInt ( &patchOk );
+
+    if ( !majorOk || !minorOk || !patchOk )
+    {
+        return QString ( "..." ) + versionStr;
+    }
+
+    QString suffix = match.captured ( 4 ); // suffix, if present
+    QString tstamp = match.captured ( 5 ); // timestamp, if present
 
     if ( suffix.isEmpty() )
     {
@@ -97,12 +115,11 @@ QString MapVersionStrForCompare ( const QString& versionStr )
     //    ppp = patch
     //    k = sort key to sort alpha, beta, rc before bare version number, and other suffixes after (<, =, >)
     //    suffix = supplied suffix
-    key = QString ( "%1%2%3%4%5" )
-              .arg ( major, 3, 10, QLatin1Char ( '0' ) )
-              .arg ( minor, 3, 10, QLatin1Char ( '0' ) )
-              .arg ( patch, 3, 10, QLatin1Char ( '0' ) )
-              .arg ( x )
-              .arg ( tstamp.isEmpty() ? suffix : tstamp );
+    const QString majorPart = QString ( "%1" ).arg ( major, 3, 10, QLatin1Char ( '0' ) );
+    const QString minorPart = QString ( "%1" ).arg ( minor, 3, 10, QLatin1Char ( '0' ) );
+    const QString patchPart = QString ( "%1" ).arg ( patch, 3, 10, QLatin1Char ( '0' ) );
+
+    key = QString ( "%1%2%3%4%5" ).arg ( majorPart ).arg ( minorPart ).arg ( patchPart ).arg ( x ).arg ( tstamp.isEmpty() ? suffix : tstamp );
 
     return key;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -138,7 +138,7 @@ inline int CalcBitRateBitsPerSecFromCodedBytes ( const int iCeltNumCodedBytes, c
 
 QString GetVersionAndNameStr ( const bool bDisplayInGui = true );
 QString MakeClientNameTitle ( QString win, QString client );
-bool    IsReleaseVersion ( const QString& version );
+bool    IsMappedReleaseVersion ( const QString& mappedVersion );
 QString MapVersionStrForCompare ( const QString& versionStr );
 QString TruncateString ( QString str, int position );
 

--- a/src/util.h
+++ b/src/util.h
@@ -138,8 +138,9 @@ inline int CalcBitRateBitsPerSecFromCodedBytes ( const int iCeltNumCodedBytes, c
 
 QString GetVersionAndNameStr ( const bool bDisplayInGui = true );
 QString MakeClientNameTitle ( QString win, QString client );
+bool    IsReleaseVersion ( const QString& version );
+QString MapVersionStrForCompare ( const QString& versionStr );
 QString TruncateString ( QString str, int position );
-int     CompareVersionStrings ( const QString& lhsVersion, const QString& rhsVersion );
 
 /******************************************************************************\
 * CVector Base Class                                                           *

--- a/src/util.h
+++ b/src/util.h
@@ -139,6 +139,7 @@ inline int CalcBitRateBitsPerSecFromCodedBytes ( const int iCeltNumCodedBytes, c
 QString GetVersionAndNameStr ( const bool bDisplayInGui = true );
 QString MakeClientNameTitle ( QString win, QString client );
 QString TruncateString ( QString str, int position );
+int     CompareVersionStrings ( const QString& lhsVersion, const QString& rhsVersion );
 
 /******************************************************************************\
 * CVector Base Class                                                           *


### PR DESCRIPTION
**Short description of changes**

When the Connect Dialog was updated to sort on server version number, we had to add a clever algorithm to allow it to get the version numbers in "Jamulus Version" order, which is somewhat non-standard.

Previously, there was an explicit guard in the update check to avoid a local version with a non-standard version running the version check, because the version check logic used couldn't handle it.

So this change:
- puts the new custom version comparator into common code
- updates the Connect Dialog to use it
- updates Client and Server version checks to use it
- removes the guard in Client and Server version checks

CHANGELOG: Use mapped version for update notification check

**Context: Fixes an issue?**

Fixes: #3669

Demo:

Current "latest" is release 3.12.3.  With our current versioning scheme, that means `main` and `release/3_12` have `3.12.3dev` as the version, going to 4.0.0 or 3.12.4 as appropriate.  Say we _had_ cut a pre-release for 3.12.3, though - 3.12.3beta1:
```
$ ./Jamulus --version
 *** Jamulus, Version 3.12.3beta1
```
Given 3.12.3 is on the update servers, I'd expect my old beta to get a notification...
<img width="380" height="163" alt="image" src="https://github.com/user-attachments/assets/b9dd6c50-d6cd-4762-978d-1e49823894e6" />
No update notification.


**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Tested as follows:
> <span>1</span>. Install a release version of the client or server with a version number less than current, run the GUI

(Test omitted -- this isn't being applied to old builds, only future builds.  Examples below use old build numbers just to use existing update check servers.)


1. Prove no regression
   > <span>3</span>. Install a development version of the next release (3.x.xdev...), run the GUI
   - Set ChangeLog and Jamulus.pro to 3.12.1dev (i.e. prior to current release)
   - Run GUI Client with `--showallservers`
     * [x] Verify Update Notification shown (as current)
     * [ ] Verify Connect Dialog sort order for server version is correct
   - Run GUI Server
     * [x] Verify Update Notification shown (as current)

   Client
   > <img width="406" height="210" alt="image" src="https://github.com/user-attachments/assets/c509c0b0-819e-43e0-9cd7-2de3c9be3c45" />
   
   Server
   > <img width="470" height="123" alt="image" src="https://github.com/user-attachments/assets/1c581e81-ca2f-4979-b28d-734c0a2b8889" />


2. Prove fix works
   > <span>5</span>. Install a tagged pre-release version of the next release (tag in "alpha*", "beta*" and "rc*"), run the GUI
   - Set ChangeLog and Jamulus.pro to 3.12.1alpha (i.e. prior to current release but )
   - Run GUI Client with `--showallservers`
     * [x] Verify Update Notification shown (as current)
     * [x] Verify Connect Dialog sort order for server version is correct
   - Run GUI Server
     * [ ] Verify Update Notification shown (as current)

   Client
   <img width="414" height="123" alt="image" src="https://github.com/user-attachments/assets/d51c331d-287c-4967-a0d9-a076d1298604" />
   > <img width="767" height="78" alt="image" src="https://github.com/user-attachments/assets/6dfeecd7-f9ef-46f6-9edf-0dc02516cdf4" />
   > <img width="768" height="87" alt="image" src="https://github.com/user-attachments/assets/7a65f75d-31f0-4bac-afda-fa207db8fa68" />
   
   Server

**What is missing until this pull request can be merged?**

There's a couple of tests I skipped but I think it's pretty sound.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
