### PR TITLE
docs(JSON-RPC): connection example calls a non-existent method

### DIFF
--- a/docs/JSON-RPC.md
+++ b/docs/JSON-RPC.md
@@ -41,7 +41,7 @@ This snippet uses [jayson](https://www.npmjs.com/package/jayson) to connect usin
 const jayson = require("jayson/promise");
 const client = new jayson.client.tcp({ host: "127.0.0.1", port: 22100 });
 
-client.request('jamulusserver/getServerInfo', {})
+client.request('jamulus/apiAuth', { secret: "...the secret from the file in --jsonrpcsecretfile..." })
 .then(console.log)
 .catch(console.error)
 ```

--- a/tools/generate_json_rpc_docs.py
+++ b/tools/generate_json_rpc_docs.py
@@ -270,7 +270,7 @@ This snippet uses [jayson](https://www.npmjs.com/package/jayson) to connect usin
 const jayson = require("jayson/promise");
 const client = new jayson.client.tcp({ host: "127.0.0.1", port: 22100 });
 
-client.request('jamulusserver/getServerInfo', {})
+client.request('jamulus/apiAuth', { secret: "...the secret from the file in --jsonrpcsecretfile..." })
 .then(console.log)
 .catch(console.error)
 ```


### PR DESCRIPTION
MY LLM WROTE:

The "Connect to a JSON-RPC server" jayson snippet calls `jamulusserver/getServerInfo`, which is not a method the server implements — a copy-paste of it returns `-32601 Method not found`. `git log -S getServerInfo` shows it entered the doc in #3101 and never existed in `src/`.

It's also the connection example, so it should show the one call every connection must make first: `jamulus/apiAuth`. Every other method returns `401 Unauthenticated: Please authenticate using jamulus/apiAuth first` until that runs (measured against a `--jsonrpcport` server on `main`: `getVersion`, `getMode`, and `getServerProfile` all 401 pre-auth; `getServerInfo` is -32601 even after auth).

Changing the request to `apiAuth` fixes both: it's a real method and it's the correct first step. Left as a single request so it doesn't depend on whether jayson reuses the socket across calls (auth is per-connection).
