### PR TITLE
Improve focus handling and accessibility in Connect dialog

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -279,8 +279,6 @@ CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool 
     QObject::connect ( edtFilter, &QLineEdit::textEdited, this, &CConnectDlg::OnFilterTextEdited );
 
     // combo boxes
-    QObject::connect ( cbxServerAddr, &QComboBox::editTextChanged, this, &CConnectDlg::OnServerAddrEditTextChanged );
-
     QObject::connect ( cbxDirectory, static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ), this, &CConnectDlg::OnDirectoryChanged );
 
     // check boxes
@@ -662,13 +660,6 @@ void CConnectDlg::OnServerListItemDoubleClicked ( QTreeWidgetItem* Item, int )
     {
         OnConnectClicked();
     }
-}
-
-void CConnectDlg::OnServerAddrEditTextChanged ( const QString& )
-{
-    // in the server address combo box, a text was changed, remove selection
-    // in the server list (if any)
-    lvwServers->clearSelection();
 }
 
 void CConnectDlg::OnCustomDirectoriesChanged()

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -283,6 +283,9 @@ CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool 
     // combo boxes
     QObject::connect ( cbxDirectory, static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ), this, &CConnectDlg::OnDirectoryChanged );
 
+    // connect when pressing Enter in the Server Address box
+    QObject::connect ( cbxServerAddr->lineEdit(), &QLineEdit::returnPressed, this, &CConnectDlg::OnConnectClicked );
+
     // check boxes
     QObject::connect ( chbExpandAll, &QCheckBox::stateChanged, this, &CConnectDlg::OnExpandAllStateChanged );
 

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -207,6 +207,7 @@ CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool 
 
     // install event filter to catch FocusIn
     cbxServerAddr->installEventFilter ( this );
+    lvwServers->installEventFilter ( this );
 
     // set up list view for connected clients (note that the last column size
     // must not be specified since this column takes all the remaining space)
@@ -334,6 +335,7 @@ void CConnectDlg::RequestServerList()
 
     // clear server list view
     lvwServers->clear();
+    savedServer = nullptr;
 
     // update list combo box (disable events to avoid a signal)
     cbxDirectory->blockSignals ( true );
@@ -1194,8 +1196,26 @@ bool CConnectDlg::eventFilter ( QObject* obj, QEvent* event )
 {
     if ( obj == cbxServerAddr && event->type() == QEvent::FocusIn )
     {
+        // check for a selected server before clearing the selection in the list
+        QList<QTreeWidgetItem*> CurSelListItemList = lvwServers->selectedItems();
+
+        if ( CurSelListItemList.count() > 0 )
+        {
+            // there was a selected item - save it before deselecting
+            savedServer = GetParentListViewItem ( CurSelListItemList[0] );
+        }
         // remove selection in the server list (if any)
         lvwServers->clearSelection();
+    }
+
+    if ( obj == lvwServers && event->type() == QEvent::FocusIn )
+    {
+        if ( savedServer )
+        {
+            // re-select any previously-selected server on regaining focus
+            lvwServers->setCurrentItem ( savedServer );
+            savedServer = nullptr;
+        }
     }
 
     return QDialog::eventFilter ( obj, event );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -124,6 +124,7 @@ bool CMappedTreeWidgetItem::operator<( const QTreeWidgetItem& other ) const
 
 CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool bNewShowCompleteRegList, QWidget* parent ) :
     CBaseDlg ( parent, Qt::Dialog ),
+    savedServer ( nullptr ),
     pClient ( pNCliP ),
     pSettings ( pNSetP ),
     strSelectedAddress ( "" ),
@@ -334,8 +335,8 @@ void CConnectDlg::RequestServerList()
     strSelectedServerName = "";
 
     // clear server list view
-    lvwServers->clear();
     savedServer = nullptr;
+    lvwServers->clear();
 
     // update list combo box (disable events to avoid a signal)
     cbxDirectory->blockSignals ( true );
@@ -446,6 +447,7 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
     }
 
     // first clear list
+    savedServer = nullptr;
     lvwServers->clear();
 
     // add list item for each server in the server list

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -205,6 +205,9 @@ CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool 
     cbxServerAddr->setMaxCount ( MAX_NUM_SERVER_ADDR_ITEMS );
     cbxServerAddr->setInsertPolicy ( QComboBox::NoInsert );
 
+    // install event filter to catch FocusIn
+    cbxServerAddr->installEventFilter ( this );
+
     // set up list view for connected clients (note that the last column size
     // must not be specified since this column takes all the remaining space)
 #ifdef ANDROID
@@ -1194,4 +1197,15 @@ void CConnectDlg::OnCurrentServerItemChanged ( QTreeWidgetItem* current, QTreeWi
     }
     QAccessible::updateAccessibility ( new QAccessibleAnnouncementEvent ( lvwServers, announcement ) );
 #endif
+}
+
+bool CConnectDlg::eventFilter ( QObject* obj, QEvent* event )
+{
+    if ( obj == cbxServerAddr && event->type() == QEvent::FocusIn )
+    {
+        // remove selection in the server list (if any)
+        lvwServers->clearSelection();
+    }
+
+    return QDialog::eventFilter ( obj, event );
 }

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -127,7 +127,8 @@ protected:
     void                   EmitCLServerListPingMes ( const CHostAddress& haServerAddress, const bool bNeedVersion );
     void                   UpdateDirectoryComboBox();
 
-    bool eventFilter ( QObject* obj, QEvent* event );
+    bool                   eventFilter ( QObject* obj, QEvent* event ) override;
+    CMappedTreeWidgetItem* savedServer;
 
     CClient*         pClient;
     CClientSettings* pSettings;

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -127,6 +127,8 @@ protected:
     void                   EmitCLServerListPingMes ( const CHostAddress& haServerAddress, const bool bNeedVersion );
     void                   UpdateDirectoryComboBox();
 
+    bool eventFilter ( QObject* obj, QEvent* event );
+
     CClient*         pClient;
     CClientSettings* pSettings;
 

--- a/src/connectdlg.h
+++ b/src/connectdlg.h
@@ -147,7 +147,6 @@ protected:
 
 public slots:
     void OnServerListItemDoubleClicked ( QTreeWidgetItem* Item, int );
-    void OnServerAddrEditTextChanged ( const QString& );
     void OnDirectoryChanged ( int iTypeIdx );
     void OnFilterTextEdited ( const QString& ) { UpdateListFilter(); }
     void OnExpandAllStateChanged ( int value ) { ShowAllMusicians ( value == Qt::Checked ); }

--- a/src/connectdlgbase.ui
+++ b/src/connectdlgbase.ui
@@ -63,9 +63,6 @@
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
-     <property name="tabKeyNavigation">
-      <bool>true</bool>
-     </property>
      <column>
       <property name="text">
        <string>Server Name</string>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Deselects any selected server in the server list when the Server Address combo box gains focus. This ensures that clicking
Connect when the Server Address has focus will connect to the expected server, even if a server had previously been
selected in the server list.

In addition, corrects the consuming of Tab and shift-Tab within the server list, improving keyboard navigation for accessibility.

CHANGELOG: Client: Improve server list navigation in Connect Dialog.

**Context: Fixes an issue?**

Fixes #3857

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready to merge. Tested on Linux and Windows..

**What is missing until this pull request can be merged?**

Nothing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
