### PR TITLE
Guard auto-vectorization flag for GCC only

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1175,8 +1175,13 @@ contains(CONFIG, "opus_shared_lib") {
     }
 }
 
-# Always enable auto vectorization
-QMAKE_CXXFLAGS+=-ftree-vectorize
+# GCC enables -ftree-vectorize at -O3, and also at -O2 from GCC 12 on. Setting it
+# explicitly keeps vectorization on for GCC builds that would not enable it by
+# default. Clang already vectorizes and MSVC would warn on the flag, so scope it
+# to GCC mkspecs (linux-g++, win32-g++, ...). (#3863)
+*-g++* {
+    QMAKE_CXXFLAGS += -ftree-vectorize
+}
 
 # disable version check if requested (#370)
 contains(CONFIG, "disable_version_check") {

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1175,10 +1175,12 @@ contains(CONFIG, "opus_shared_lib") {
     }
 }
 
-# GCC enables -ftree-vectorize at -O3, and also at -O2 from GCC 12 on. Setting it
-# explicitly keeps vectorization on for GCC builds that would not enable it by
-# default. Clang already vectorizes and MSVC would warn on the flag, so scope it
-# to GCC mkspecs (linux-g++, win32-g++, ...). (#3863)
+# Scope -ftree-vectorize to GCC mkspecs (linux-g++, win32-g++, ...). Clang already
+# auto-vectorizes and MSVC warns on the unknown flag (#3863). On every current GCC
+# the explicit flag turns vectorization on at the 'cheap' cost model: on GCC <= 11
+# it raises -O2 from scalar, and on GCC 12+ it lifts the -O2 default from
+# 'very-cheap' to 'cheap'. That vectorizes the audio mixing loops with no
+# -ffast-math needed.
 *-g++* {
     QMAKE_CXXFLAGS += -ftree-vectorize
 }

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1175,12 +1175,9 @@ contains(CONFIG, "opus_shared_lib") {
     }
 }
 
-# Scope -ftree-vectorize to GCC mkspecs (linux-g++, win32-g++, ...). Clang already
-# auto-vectorizes and MSVC warns on the unknown flag (#3863). On every current GCC
-# the explicit flag turns vectorization on at the 'cheap' cost model: on GCC <= 11
-# it raises -O2 from scalar, and on GCC 12+ it lifts the -O2 default from
-# 'very-cheap' to 'cheap'. That vectorizes the audio mixing loops with no
-# -ffast-math needed.
+# Scope -ftree-vectorize to GCC mkspecs (#3863): Clang already auto-vectorizes
+# and MSVC warns on the flag. At -O2 the flag raises GCC's cost model to `cheap`,
+# which vectorizes the mixer loops on every current GCC (11 through 14).
 *-g++* {
     QMAKE_CXXFLAGS += -ftree-vectorize
 }


### PR DESCRIPTION
Closes #3863

## Short description of changes

Wrap the `-ftree-vectorize` flag in a `*-g++*` qmake scope so it only reaches GCC compilers.

## Context: Fixes an issue?

Fixes #3863

## What does this change do?

- MSVC no longer gets the D9002 warning for the unknown `-ftree-vectorize` flag
- Clang builds are unchanged (it already auto-vectorizes at `-O2`)
- GCC builds continue to receive the `-ftree-vectorize` flag where it's needed

## Checklist

- I've verified that this Pull Request follows the general code principles
- I tested my code and it does what I want
- My code follows the style guide
- I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- I've filled all the content above