### PR TITLE
Avoid windows ASIO4ALL hang by using QueuedConnection

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -182,7 +182,15 @@ CClient::CClient ( const quint16  iPortNumber,
     QObject::connect ( &ConnLessProtocol, &CProtocol::CLChannelLevelListReceived, this, &CClient::OnCLChannelLevelListReceived );
 
     // other
-    QObject::connect ( &Sound, &CSound::ReinitRequest, this, &CClient::OnSndCrdReinitRequest );
+    QObject::connect ( &Sound,
+                       &CSound::ReinitRequest,
+                       this,
+                       &CClient::OnSndCrdReinitRequest
+#if defined( Q_OS_WINDOWS )
+                       ,
+                       Qt::QueuedConnection // On Windows, use a queued connection to avoid an ASIO4ALL hang (#3867)
+#endif
+    );
 
     QObject::connect ( &Sound, &CSound::ControllerInFaderLevel, this, &CClient::OnControllerInFaderLevel );
 


### PR DESCRIPTION
**Short description of changes**

I believe this fixes the hang on ASIO4ALL device switches - I cannot reproduce the hang anymore.

The AI proposed guard and the narrowed lock (#3862) doesn't seem to be needed - but might be worth implementing as lower prio fix.

CHANGELOG: Bug: Fix hang on Windows while changing devices in ASIO4ALL

**Context: Fixes an issue?**

Found by AI debugging:
https://github.com/jamulussoftware/jamulus/issues/3779#issuecomment-5209182261

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready for testing and review by someone else.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review and 2nd testing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
