### PR TITLE
Ensure a server is always selected when list gains focus

### DIFF
--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -1175,6 +1175,11 @@ bool CConnectDlg::eventFilter ( QObject* obj, QEvent* event )
             lvwServers->setCurrentItem ( savedServer );
             savedServer = nullptr;
         }
+        else if ( lvwServers->topLevelItemCount() > 0 )
+        {
+            // no saved server: select first item in list for keyboard navigation
+            lvwServers->setCurrentItem ( lvwServers->topLevelItem ( 0 ) );
+        }
     }
 
     return QDialog::eventFilter ( obj, event );


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

This fixes keyboard navigation when the list only contains one server. When the server list gains focus,
if there was a saved server from previously being in focus, that saved server is restored. In this PR,
if there was no saved server, the first item in the list will be selected, so that keyboard navigation
will work properly.

No changelog entry needed, as this is just a bugfix for #3859

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes #3871

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready

**What is missing until this pull request can be merged?**

Nothing

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
