### PR TITLE
src/sound/README.md: start documenting the sound design

### DIFF
--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -48,4 +48,54 @@ This folder contains the related files for all sound APIs.
 
 ## Documentation of sound design
 
-**Fixme:** The sound design is not yet documented.
+This describes how the code behaves today. It covers the device lifecycle and the threading rules
+around the audio callback; the areas still missing are listed at the end.
+
+Each platform provides one `CSound` class deriving from `CSoundBase`, and exactly one of the
+subdirectories is compiled in: `asio/` (Windows), `coreaudio-mac/`, `coreaudio-ios/`, `oboe/`
+(Android) and `jack/` (where JACK is enabled).
+
+### Buffer size negotiation
+
+`Init ( iNewPrefMonoBufferSize )` returns the mono buffer size the device actually accepted,
+which may differ from the one requested. `CClient::Init()` uses that return value to find out
+which sizes a device supports, so it calls `Init()` four times per invocation: once for each of
+`FRAME_SIZE_FACTOR_PREFERRED`, `FRAME_SIZE_FACTOR_DEFAULT` and `FRAME_SIZE_FACTOR_SAFE` to fill
+`bFraSiFactPrefSupported`, `bFraSiFactDefSupported` and `bFraSiFactSafeSupported`, then once with
+the size selected in the settings. Those three flags drive the enabled state of the buffer delay
+radio buttons, and the settings dialog polls them once a second; no signal runs from the sound
+device to that dialog.
+
+A driver may also change the buffer size on its own. `kAsioBufferSizeChange` in the ASIO backend
+and JACK's buffer size callback both report that by calling
+`EmitReinitRequestSignal ( RS_ONLY_RESTART_AND_INIT )`, which reaches
+`CClient::OnSndCrdReinitRequest` and repeats the negotiation above.
+
+### Start, stop and the audio callback
+
+`Init()` is only ever entered with the device stopped. Callers that may be running stop it first
+and restart it afterwards, which is the `bWasRunning` pattern throughout `client.cpp`.
+
+The audio callback runs on a thread owned by the driver. Backends keep it away from a device that
+is being re-initialised in two ways, and the ASIO backend is the exception to both:
+
+| backend | audio callback | ignores the callback while stopped | takes `MutexAudioProcessCallback` |
+|---|---|---|---|
+| JACK | `process()` | yes, `IsRunning()` | yes |
+| CoreAudio (macOS) | `callbackIO()` | yes, `bRun` | yes |
+| CoreAudio (iOS) | `processBufferList()` | no | yes |
+| Oboe | `onAudioReady()` | yes, `!bRun` | yes |
+| ASIO | `bufferSwitch()` | no | no, it uses its own `ASIOMutex` |
+
+`CSoundBase::Stop()` clears `bRun` and then takes `MutexAudioProcessCallback` to wait for a
+callback that is already in flight. The ASIO backend never takes that mutex, so on Windows that
+wait returns immediately and `CSound::Stop()` waits on `ASIOMutex` instead.
+
+### Not yet documented
+
+- device enumeration, and what `SetDev()` does when a device cannot be used
+- input and output channel selection, and the input channel mixing in the callbacks
+- MIDI: device selection, controller mapping and `ParseMIDIMessage()`
+- latency reporting via `GetInOutLatencyMs()`
+- the sound card conversion buffer used when a device's buffer size is not a multiple of the
+  system frame size

--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -111,11 +111,11 @@ Inside the callback itself, backends differ again, and not just in which flag th
 
 | backend | audio callback | flag check | mutex behavior |
 |---|---|---|---|
-| Oboe | `onAudioReady()` | `!bRun`, first line, before any lock | skipped entirely once stopped |
-| JACK | `process()` | `IsRunning()`, after the lock | always taken; only the processing is skipped |
+| ASIO | `bufferSwitch()` | none | always taken (its own `ASIOMutex`); always processes |
 | CoreAudio (macOS) | `callbackIO()` | `bRun`, after the lock | always taken; only the processing is skipped |
 | CoreAudio (iOS) | `processBufferList()` | none | always taken; always processes |
-| ASIO | `bufferSwitch()` | none | always taken (its own `ASIOMutex`); always processes |
+| Oboe | `onAudioReady()` | `!bRun`, first line, before any lock | skipped entirely once stopped |
+| JACK | `process()` | `IsRunning()`, after the lock | always taken; only the processing is skipped |
 
 `IsRunning()`, `bRun` and `!bRun` all read the same flag (`IsRunning()` is `return bRun;`) —
 three spellings of one check. But only Oboe's placement actually avoids the mutex; JACK's and

--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -49,7 +49,9 @@ This folder contains the related files for all sound APIs.
 ## Documentation of sound design
 
 This describes how the code behaves today. It covers the device lifecycle and the threading rules
-around the audio callback; the areas still missing are listed at the end.
+around the audio callback; the areas still missing are listed at the end. Where today's behaviour
+only makes sense in light of how it arose, the origin is given as well, so that an accident of
+history is not read as a deliberate design.
 
 Each platform provides one `CSound` class deriving from `CSoundBase`, and exactly one of the five
 backend subdirectories is compiled in: `asio/` (Windows), `coreaudio-mac/`, `coreaudio-ios/`,
@@ -139,6 +141,25 @@ ASIO defines and owns its own `ASIOMutex` (in `asio/sound.h`) instead of using t
 `MutexAudioProcessCallback`. Its own `CSound::Stop()` calls `ASIOStop()` first, then
 `CSoundBase::Stop()` (whose wait on the unused `MutexAudioProcessCallback` returns immediately
 for this backend), then waits on `ASIOMutex` directly to confirm the callback thread is done.
+
+The two are not interchangeable, because `ASIOMutex` covers more ground. It is also held across
+the whole of `CSound::Init()` — spanning `ASIODisposeBuffers()`, `ASIOCreateBuffers()` and the
+`vecsMultChanAudioSndCrd` reallocation — whereas no other backend locks anything in its `Init()`.
+The waits differ too: `CSoundBase::Stop()` blocks unconditionally on its `QMutexLocker`, while
+ASIO's `Stop()` uses `tryLock ( 5000 )` and carries on regardless if the callback has not finished
+within five seconds. The two differences compound: because ASIO's stop can return while a callback
+is still in flight, the lock held across `Init()` is what actually keeps `ASIOCreateBuffers()` off
+a live `bufferSwitch()`.
+
+That there are two mutexes at all is chronological rather than a design decision. `ASIOMutex` was
+added with the ASIO backend itself in `5eb86941` (2008-07-12), when ASIO was the only backend and
+`CSoundBase` did not yet exist (`3fb2d9ca`, 2009-02-22); its drain-on-stop wait followed in
+`73f408e4` (2011-12-27). The shared `MutexAudioProcessCallback` arrived nine years after that, in
+`ecff80fc` (2020-08-26), to fix a crash when the JACK backend was reconfigured quickly; that commit
+touches `linux/sound.cpp` and `soundbase.{h,cpp}` and nothing else. It is a later, independent
+re-implementation of a guard ASIO already had, and it was never extended to ASIO. Collapsing the
+two into one would therefore not be a rename: it would have to preserve the coverage across
+`Init()` and settle which of the two wait policies applies.
 
 ### Not yet documented
 

--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -76,8 +76,10 @@ and JACK's buffer size callback both report that by calling
 `Init()` is only ever entered with the device stopped. Callers that may be running stop it first
 and restart it afterwards, which is the `bWasRunning` pattern throughout `client.cpp`.
 
-The audio callback runs on a thread owned by the driver. Backends keep it away from a device that
-is being re-initialised in two ways, and the ASIO backend is the exception to both:
+The audio callback runs on a thread owned by the driver. `CSoundBase` inherits `QThread`, but
+nothing here overrides `run()` or calls `start()`, so no such thread exists. Backends keep the
+callback away from a device that is being re-initialised in two ways, and the ASIO backend is the
+exception to both:
 
 | backend | audio callback | ignores the callback while stopped | takes `MutexAudioProcessCallback` |
 |---|---|---|---|

--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -51,9 +51,11 @@ This folder contains the related files for all sound APIs.
 This describes how the code behaves today. It covers the device lifecycle and the threading rules
 around the audio callback; the areas still missing are listed at the end.
 
-Each platform provides one `CSound` class deriving from `CSoundBase`, and exactly one of the
-subdirectories is compiled in: `asio/` (Windows), `coreaudio-mac/`, `coreaudio-ios/`, `oboe/`
-(Android) and `jack/` (where JACK is enabled).
+Each platform provides one `CSound` class deriving from `CSoundBase`, and exactly one of the five
+backend subdirectories is compiled in: `asio/` (Windows), `coreaudio-mac/`, `coreaudio-ios/`,
+`oboe/` (Android) and `jack/` (where JACK is enabled). A sixth subdirectory, `midi-win/`, holds the
+Windows MIDI implementation (`CMidi`) rather than a backend; the default Windows build compiles it
+alongside `asio/`, while a `CONFIG+=jackonwindows` build takes `jack/` and neither of the other two.
 
 ### Buffer size negotiation
 
@@ -66,10 +68,18 @@ the size selected in the settings. Those three flags drive the enabled state of 
 radio buttons, and the settings dialog polls them once a second; no signal runs from the sound
 device to that dialog.
 
-A driver may also change the buffer size on its own. `kAsioBufferSizeChange` in the ASIO backend
-and JACK's buffer size callback both report that by calling
+A driver can also change its buffer size on its own, outside any call from Jamulus. Reporting
+that back needs a native change-notification callback from the driver API, and only two of the
+five backends have one: ASIO's `kAsioBufferSizeChange` (`asioMessages()`, `asio/sound.cpp`) and
+JACK's buffer-size callback (`jack/sound.cpp`) both call
 `EmitReinitRequestSignal ( RS_ONLY_RESTART_AND_INIT )`, which reaches
-`CClient::OnSndCrdReinitRequest` and repeats the negotiation above.
+`CClient::OnSndCrdReinitRequest` and repeats the negotiation above. The other three backends
+can't do this the same way: the two CoreAudio backends only watch device-identity/route events
+(`kAudioDevicePropertyDeviceHasChanged`/`IsAlive`/default-device switches on macOS,
+`AVAudioSessionRouteChangeNotification` on iOS) and never register a buffer-size-specific
+listener, so a size change on its own is invisible to them. Oboe does detect it —
+`onAudioInput()` compares the delivered frame count against the requested size on every callback
+— but the mismatch is only logged (`qDebug()`), never renegotiated.
 
 ### Start, stop and the audio callback
 
@@ -77,23 +87,58 @@ and JACK's buffer size callback both report that by calling
 and restart it afterwards, which is the `bWasRunning` pattern throughout `client.cpp`.
 
 The audio callback runs on a thread owned by the driver. `CSoundBase` inherits `QThread`, but
-nothing here overrides `run()` or calls `start()`, so no such thread exists. Backends keep the
-callback away from a device that is being re-initialised in two ways, and the ASIO backend is the
-exception to both:
+nothing here overrides `run()` or calls `start()`, so no such thread exists — nor has it ever:
+neither appears anywhere in this file's tracked history, and no other `QThread`-specific method
+is used in the sound layer either. The inheritance predates the current driver-callback
+architecture and contributes nothing; changing it to `QObject` looks safe from this file alone,
+but that wasn't verified further here.
 
-| backend | audio callback | ignores the callback while stopped | takes `MutexAudioProcessCallback` |
+Every backend but ASIO also overrides `Stop()`, and every override but JACK's calls a
+driver-level stop function *before* touching `bRun` at all:
+
+| backend | own `Stop()` calls first |
+|---|---|
+| ASIO | (no override — `ASIOStop()` happens inside `CSound::Stop()` itself, see below) |
+| CoreAudio (macOS) | `AudioDeviceStop()` + `AudioDeviceDestroyIOProcID()` |
+| CoreAudio (iOS) | `AudioOutputUnitStop()` |
+| Oboe | `closeStreams()` |
+| JACK | nothing — goes straight to `CSoundBase::Stop()` |
+
+Inside the callback itself, backends differ again, and not just in which flag they read but in
+*when* they read it relative to the mutex:
+
+| backend | audio callback | flag check | mutex behavior |
 |---|---|---|---|
-| JACK | `process()` | yes, `IsRunning()` | yes |
-| CoreAudio (macOS) | `callbackIO()` | yes, `bRun` | yes |
-| CoreAudio (iOS) | `processBufferList()` | no | yes |
-| Oboe | `onAudioReady()` | yes, `!bRun` | yes |
-| ASIO | `bufferSwitch()` | no | no, it uses its own `ASIOMutex` |
+| Oboe | `onAudioReady()` | `!bRun`, first line, before any lock | skipped entirely once stopped |
+| JACK | `process()` | `IsRunning()`, after the lock | always taken; only the processing is skipped |
+| CoreAudio (macOS) | `callbackIO()` | `bRun`, after the lock | always taken; only the processing is skipped |
+| CoreAudio (iOS) | `processBufferList()` | none | always taken; always processes |
+| ASIO | `bufferSwitch()` | none | always taken (its own `ASIOMutex`); always processes |
 
-`CSoundBase::Stop()` clears `bRun` and then takes `MutexAudioProcessCallback` to wait for a
-callback that is already in flight. The ASIO backend is the exception: it defines and owns its
-own `ASIOMutex` (in `asio/sound.h`) instead of using the shared `MutexAudioProcessCallback`.
-So on Windows, `CSoundBase::Stop()`'s wait returns immediately, and the ASIO-specific
-`CSound::Stop()` waits on `ASIOMutex` instead.
+`IsRunning()`, `bRun` and `!bRun` all read the same flag (`IsRunning()` is `return bRun;`) —
+three spellings of one check. But only Oboe's placement actually avoids the mutex; JACK's and
+CoreAudio (macOS)'s checks run *after* the lock is already held, so they cost the same
+mutex-contention as not checking at all and only save the processing work itself.
+
+`CSoundBase::Stop()` clears `bRun` and then briefly takes `MutexAudioProcessCallback`, releasing
+it as soon as `Stop()` returns:
+```cpp
+void CSoundBase::Stop() {
+    bRun = false;
+    QMutexLocker locker ( &MutexAudioProcessCallback );
+}
+```
+CoreAudio (iOS) and ASIO have no flag check anywhere in their callback, so they depend entirely
+on their own driver-level stop call above (or, for ASIO, on `ASIOStop()` inside its own
+`CSound::Stop()`) actually preventing further callbacks — if the driver fires one more callback
+after that call returns, it runs to completion regardless of `bRun`. Whether `AudioOutputUnitStop`
+/ `ASIOStop` are synchronous enough to rule that out wasn't tested here; it would need real
+hardware.
+
+ASIO defines and owns its own `ASIOMutex` (in `asio/sound.h`) instead of using the shared
+`MutexAudioProcessCallback`. Its own `CSound::Stop()` calls `ASIOStop()` first, then
+`CSoundBase::Stop()` (whose wait on the unused `MutexAudioProcessCallback` returns immediately
+for this backend), then waits on `ASIOMutex` directly to confirm the callback thread is done.
 
 ### Not yet documented
 

--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -90,8 +90,10 @@ exception to both:
 | ASIO | `bufferSwitch()` | no | no, it uses its own `ASIOMutex` |
 
 `CSoundBase::Stop()` clears `bRun` and then takes `MutexAudioProcessCallback` to wait for a
-callback that is already in flight. The ASIO backend never takes that mutex, so on Windows that
-wait returns immediately and `CSound::Stop()` waits on `ASIOMutex` instead.
+callback that is already in flight. The ASIO backend is the exception: it defines and owns its
+own `ASIOMutex` (in `asio/sound.h`) instead of using the shared `MutexAudioProcessCallback`.
+So on Windows, `CSoundBase::Stop()`'s wait returns immediately, and the ASIO-specific
+`CSound::Stop()` waits on `ASIOMutex` instead.
 
 ### Not yet documented
 

--- a/src/sound/README.md
+++ b/src/sound/README.md
@@ -89,18 +89,19 @@ listener, so a size change on its own is invisible to them. Oboe does detect it 
 and restart it afterwards, which is the `bWasRunning` pattern throughout `client.cpp`.
 
 The audio callback runs on a thread owned by the driver. `CSoundBase` inherits `QThread`, but
-nothing here overrides `run()` or calls `start()`, so no such thread exists — nor has it ever:
-neither appears anywhere in this file's tracked history, and no other `QThread`-specific method
-is used in the sound layer either. The inheritance predates the current driver-callback
-architecture and contributes nothing; changing it to `QObject` looks safe from this file alone,
-but that wasn't verified further here.
+nothing overrides `run()` or calls `start()`, so no such thread is ever created.
 
-Every backend but ASIO also overrides `Stop()`, and every override but JACK's calls a
-driver-level stop function *before* touching `bRun` at all:
+Three separate mechanisms keep that callback off a device that is stopping or being
+re-initialised: the driver-level stop call in a backend's own `Stop()`, the `bRun` flag the
+callback may test, and a mutex the callback and `Stop()` share. All three are in use, but no two
+backends combine them the same way.
+
+All five backends override `Stop()`, and all but JACK's call a driver-level stop function before
+`CSoundBase::Stop()` clears `bRun`:
 
 | backend | own `Stop()` calls first |
 |---|---|
-| ASIO | (no override — `ASIOStop()` happens inside `CSound::Stop()` itself, see below) |
+| ASIO | `ASIOStop()` — then, after the base call, waits on `ASIOMutex`, see below |
 | CoreAudio (macOS) | `AudioDeviceStop()` + `AudioDeviceDestroyIOProcID()` |
 | CoreAudio (iOS) | `AudioOutputUnitStop()` |
 | Oboe | `closeStreams()` |
@@ -113,8 +114,8 @@ Inside the callback itself, backends differ again, and not just in which flag th
 |---|---|---|---|
 | ASIO | `bufferSwitch()` | none | always taken (its own `ASIOMutex`); always processes |
 | CoreAudio (macOS) | `callbackIO()` | `bRun`, after the lock | always taken; only the processing is skipped |
-| CoreAudio (iOS) | `processBufferList()` | none | always taken; always processes |
-| Oboe | `onAudioReady()` | `!bRun`, first line, before any lock | skipped entirely once stopped |
+| CoreAudio (iOS) | `recordingCallback()` | none | taken in `processBufferList()` only; output copy unlocked |
+| Oboe | `onAudioReady()` | `!bRun`, before any lock | skipped once stopped; only `onAudioOutput()` locks |
 | JACK | `process()` | `IsRunning()`, after the lock | always taken; only the processing is skipped |
 
 `IsRunning()`, `bRun` and `!bRun` all read the same flag (`IsRunning()` is `return bRun;`) —
@@ -130,12 +131,11 @@ void CSoundBase::Stop() {
     QMutexLocker locker ( &MutexAudioProcessCallback );
 }
 ```
-CoreAudio (iOS) and ASIO have no flag check anywhere in their callback, so they depend entirely
-on their own driver-level stop call above (or, for ASIO, on `ASIOStop()` inside its own
-`CSound::Stop()`) actually preventing further callbacks — if the driver fires one more callback
-after that call returns, it runs to completion regardless of `bRun`. Whether `AudioOutputUnitStop`
-/ `ASIOStop` are synchronous enough to rule that out wasn't tested here; it would need real
-hardware.
+CoreAudio (iOS) and ASIO have no flag check anywhere in their callback, so they depend entirely on
+their own driver-level stop call — `AudioOutputUnitStop()` and `ASIOStop()` — actually preventing
+further callbacks: if the driver fires one more after that call returns, it runs to completion
+regardless of `bRun`. Whether either is synchronous enough to rule that out wasn't tested here; it
+would need real hardware.
 
 ASIO defines and owns its own `ASIOMutex` (in `asio/sound.h`) instead of using the shared
 `MutexAudioProcessCallback`. Its own `CSound::Stop()` calls `ASIOStop()` first, then


### PR DESCRIPTION
MY LLM WROTE:

**Short description of changes**

`src/sound/README.md` ends with *"Fixme: The sound design is not yet documented."* This makes a start on that section.

It describes how the code behaves today, not why it was designed that way — intent is not something a reader of the source can verify, so none is asserted. It is also not the whole design, so the blanket Fixme is replaced by a list of the areas still missing rather than dropped.

What the new section covers:

- **Buffer size negotiation** — `Init()` returns the size the device actually accepted, which is how `CClient::Init()` discovers which sizes are supported, and why it calls `Init()` four times per invocation. Also that the three `bFraSiFact*Supported` flags drive the buffer delay radio buttons, and that the settings dialog polls them once a second rather than being signalled.
- **Driver-initiated size changes** — `kAsioBufferSizeChange` and JACK's buffer size callback both arrive through `EmitReinitRequestSignal ( RS_ONLY_RESTART_AND_INIT )`.
- **Start, stop and the audio callback** — that `Init()` is only ever entered with the device stopped, and a table of which backend ignores its audio callback while stopped and which takes `MutexAudioProcessCallback`. ASIO is the exception to both, which is why `CSoundBase::Stop()`'s wait for a callback in flight does nothing on Windows and `asio/CSound::Stop()` waits on `ASIOMutex` instead.
- **Not yet documented** — device enumeration and `SetDev()` failure handling, channel selection and mixing, MIDI, `GetInOutLatencyMs()`, and the sound card conversion buffer.

CHANGELOG: SKIP

**Context: Fixes an issue?**

No issue. The material comes out of #3869, where the buffer size display question ([issuecomment-5227331894](https://github.com/jamulussoftware/jamulus/issues/3869#issuecomment-5227331894)) turned into the lifecycle and callback rules written down here.

**Does this change need documentation? What needs to be documented and how?**

This is the documentation. Nothing is needed on the website: it is developer-facing detail about one source folder, which is what `src/sound/README.md` already exists to hold.

**Status of this Pull Request**

Working implementation. Every statement in it is checkable against the tree at the commit it was written on, and the table was read off all five backends rather than assumed.

**What is missing until this pull request can be merged?**

Review, and a decision on scope: whether a partial section plus an explicit "not yet documented" list is the right shape for that Fixme, or whether it should stay a placeholder until the whole design is covered.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above

No checks run on this one: `autobuild.yml` carries `paths-ignore: '**README.md'` and `coding-style-check.yml` only triggers on `**.cpp`/`**.h`, so the fourth box stays unticked rather than claiming a green run that never happened.