### PR TITLE
Eliminate Qt6 deprecation warnings for QLibraryInfo, QDomDocument and…

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -300,11 +300,23 @@ CChannelFader::CChannelFader ( QWidget* pNW ) :
 
     QObject::connect ( pPan, &QDial::valueChanged, this, &CChannelFader::OnPanValueChanged );
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( pcbMute, &QCheckBox::checkStateChanged, this, &CChannelFader::OnMuteStateChanged );
+#else
     QObject::connect ( pcbMute, &QCheckBox::stateChanged, this, &CChannelFader::OnMuteStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( pcbSolo, &QCheckBox::checkStateChanged, this, &CChannelFader::soloStateChanged );
+#else
     QObject::connect ( pcbSolo, &QCheckBox::stateChanged, this, &CChannelFader::soloStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( pcbGroup, &QCheckBox::checkStateChanged, this, &CChannelFader::OnGroupStateChanged );
+#else
     QObject::connect ( pcbGroup, &QCheckBox::stateChanged, this, &CChannelFader::OnGroupStateChanged );
+#endif
 }
 
 void CChannelFader::SetGUIDesign ( const EGUIDesign eNewDesign )
@@ -932,8 +944,13 @@ void CChannelFader::SetChannelInfos ( const CChannelInfo& cChanInfo )
 
         if ( eTTCountry != QLocale::AnyCountry )
         {
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+            strToolTip += QLocale::territoryToString ( eTTCountry );
+            strLocationAccessible += QLocale::territoryToString ( eTTCountry );
+#else
             strToolTip += QLocale::countryToString ( eTTCountry );
             strLocationAccessible += QLocale::countryToString ( eTTCountry );
+#endif
         }
     }
 

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -478,11 +478,23 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
     QObject::connect ( butConnect, &QPushButton::clicked, this, &CClientDlg::OnConnectDisconBut );
 
     // check boxes
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbSettings, &QCheckBox::checkStateChanged, this, &CClientDlg::OnSettingsStateChanged );
+#else
     QObject::connect ( chbSettings, &QCheckBox::stateChanged, this, &CClientDlg::OnSettingsStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbChat, &QCheckBox::checkStateChanged, this, &CClientDlg::OnChatStateChanged );
+#else
     QObject::connect ( chbChat, &QCheckBox::stateChanged, this, &CClientDlg::OnChatStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbLocalMute, &QCheckBox::checkStateChanged, this, &CClientDlg::OnLocalMuteStateChanged );
+#else
     QObject::connect ( chbLocalMute, &QCheckBox::stateChanged, this, &CClientDlg::OnLocalMuteStateChanged );
+#endif
 
     // timers
     QObject::connect ( &TimerSigMet, &QTimer::timeout, this, &CClientDlg::OnTimerSigMet );
@@ -1117,7 +1129,11 @@ void CClientDlg::OnTimerSigMet()
         msgbox.setDefaultButton ( QMessageBox::Ok );
         msgbox.setCheckBox ( chb );
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+        QObject::connect ( chb, &QCheckBox::checkStateChanged, this, &CClientDlg::OnFeedbackDetectionChanged );
+#else
         QObject::connect ( chb, &QCheckBox::stateChanged, this, &CClientDlg::OnFeedbackDetectionChanged );
+#endif
 
         msgbox.exec();
     }

--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -91,7 +91,11 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
                 { "name", chanInfo.strName },
                 { "skillLevel", SerializeSkillLevel ( chanInfo.eSkillLevel ) },
                 { "countryId", chanInfo.eCountry },
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+                { "country", QLocale::territoryToString ( chanInfo.eCountry ) },
+#else
                 { "country", QLocale::countryToString ( chanInfo.eCountry ) },
+#endif
                 { "city", chanInfo.strCity },
                 { "instrumentId", chanInfo.iInstrument },
                 { "instrument", CInstPictures::GetName ( chanInfo.iInstrument ) },
@@ -140,7 +144,11 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
                           { "address", serverInfo.HostAddr.toString() },
                           { "name", serverInfo.strName },
                           { "countryId", serverInfo.eCountry },
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+                          { "country", QLocale::territoryToString ( serverInfo.eCountry ) },
+#else
                           { "country", QLocale::countryToString ( serverInfo.eCountry ) },
+#endif
                           { "city", serverInfo.strCity },
                       };
                       arrServerInfo.append ( objServerInfo );
@@ -239,7 +247,11 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
             // TODO: We cannot include "id" here is pClient->ChannelInfo is a CChannelCoreInfo which lacks that field.
             { "name", pClient->ChannelInfo.strName },
             { "countryId", pClient->ChannelInfo.eCountry },
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+            { "country", QLocale::territoryToString ( pClient->ChannelInfo.eCountry ) },
+#else
             { "country", QLocale::countryToString ( pClient->ChannelInfo.eCountry ) },
+#endif
             { "city", pClient->ChannelInfo.strCity },
             { "instrumentId", pClient->ChannelInfo.iInstrument },
             { "instrument", CInstPictures::GetName ( pClient->ChannelInfo.iInstrument ) },

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -676,7 +676,11 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
         if ( !CurFlagIcon.isNull() )
         {
             // create a combo box item with text and image
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+            pcbxCountry->addItem ( QIcon ( CurFlagIcon ), QLocale::territoryToString ( eCountry ), iCurCntry );
+#else
             pcbxCountry->addItem ( QIcon ( CurFlagIcon ), QLocale::countryToString ( eCountry ), iCurCntry );
+#endif
         }
     }
 
@@ -718,13 +722,29 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
     QObject::connect ( sldNetBufServer, &QSlider::valueChanged, this, &CClientSettingsDlg::OnNetBufServerValueChanged );
 
     // check boxes
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbAutoJitBuf, &QCheckBox::checkStateChanged, this, &CClientSettingsDlg::OnAutoJitBufStateChanged );
+#else
     QObject::connect ( chbAutoJitBuf, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnAutoJitBufStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbSmallNetworkBuffers, &QCheckBox::checkStateChanged, this, &CClientSettingsDlg::OnEnableOPUS64StateChanged );
+#else
     QObject::connect ( chbSmallNetworkBuffers, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnEnableOPUS64StateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbDetectFeedback, &QCheckBox::checkStateChanged, this, &CClientSettingsDlg::OnFeedbackDetectionChanged );
+#else
     QObject::connect ( chbDetectFeedback, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnFeedbackDetectionChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbAudioAlerts, &QCheckBox::checkStateChanged, this, &CClientSettingsDlg::OnAudioAlertsChanged );
+#else
     QObject::connect ( chbAudioAlerts, &QCheckBox::stateChanged, this, &CClientSettingsDlg::OnAudioAlertsChanged );
+#endif
 
     // line edits
     QObject::connect ( edtNewClientLevel, &QLineEdit::editingFinished, this, &CClientSettingsDlg::OnNewClientLevelEditingFinished );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -241,7 +241,11 @@ CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool 
     QObject::connect ( cbxServerAddr->lineEdit(), &QLineEdit::returnPressed, this, &CConnectDlg::OnConnectClicked );
 
     // check boxes
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbExpandAll, &QCheckBox::checkStateChanged, this, &CConnectDlg::OnExpandAllStateChanged );
+#else
     QObject::connect ( chbExpandAll, &QCheckBox::stateChanged, this, &CConnectDlg::OnExpandAllStateChanged );
+#endif
 
     // buttons
     QObject::connect ( butCancel, &QPushButton::clicked, this, &CConnectDlg::close );
@@ -485,7 +489,11 @@ void CConnectDlg::SetServerList ( const CHostAddress& InetAddr, const CVector<CS
 
         if ( vecServerInfo[iIdx].eCountry != QLocale::AnyCountry )
         {
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+            QString strCountryToString = QLocale::territoryToString ( vecServerInfo[iIdx].eCountry );
+#else
             QString strCountryToString = QLocale::countryToString ( vecServerInfo[iIdx].eCountry );
+#endif
 
             // Qt countryToString does not use spaces in between country name
             // parts but they use upper case letters which we can detect and
@@ -564,7 +572,11 @@ void CConnectDlg::SetConnClientsList ( const CHostAddress& InetAddr, const CVect
 
             if ( vecChanInfo[i].eCountry != QLocale::AnyCountry )
             {
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+                pNewChildListViewItem->setData ( LVC_NAME, Qt::UserRole, QLocale::territoryToString ( vecChanInfo[i].eCountry ) );
+#else
                 pNewChildListViewItem->setData ( LVC_NAME, Qt::UserRole, QLocale::countryToString ( vecChanInfo[i].eCountry ) );
+#endif
                 // try to load the country flag icon
                 QPixmap CountryFlagPixmap ( CLocale::GetCountryFlagIconsResourceReference ( vecChanInfo[i].eCountry ) );
 

--- a/src/serverdlg.cpp
+++ b/src/serverdlg.cpp
@@ -350,7 +350,11 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
         // store the country enum index together with the string (this is
         // important since we sort the combo box items later on)
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+        cbxLocationCountry->addItem ( QLocale::territoryToString ( static_cast<QLocale::Country> ( iCurCntry ) ), iCurCntry );
+#else
         cbxLocationCountry->addItem ( QLocale::countryToString ( static_cast<QLocale::Country> ( iCurCntry ) ), iCurCntry );
+#endif
     }
 
     // sort country combo box items in alphabetical order
@@ -433,11 +437,23 @@ CServerDlg::CServerDlg ( CServer* pNServP, CServerSettings* pNSetP, const bool b
 
     // Connections -------------------------------------------------------------
     // check boxes
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbJamRecorder, &QCheckBox::checkStateChanged, this, &CServerDlg::OnEnableRecorderStateChanged );
+#else
     QObject::connect ( chbJamRecorder, &QCheckBox::stateChanged, this, &CServerDlg::OnEnableRecorderStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbStartOnOSStart, &QCheckBox::checkStateChanged, this, &CServerDlg::OnStartOnOSStartStateChanged );
+#else
     QObject::connect ( chbStartOnOSStart, &QCheckBox::stateChanged, this, &CServerDlg::OnStartOnOSStartStateChanged );
+#endif
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbDelayPanning, &QCheckBox::checkStateChanged, this, &CServerDlg::OnEnableDelayPanningStateChanged );
+#else
     QObject::connect ( chbDelayPanning, &QCheckBox::stateChanged, this, &CServerDlg::OnEnableDelayPanningStateChanged );
+#endif
 
     // line edits
     QObject::connect ( edtServerName, &QLineEdit::editingFinished, this, &CServerDlg::OnServerNameEditingFinished );

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -212,7 +212,11 @@ CServerListManager::CServerListManager ( CServer*       pServer,
      *
      * If we are a directory, we assume that we are a permanent server.
      */
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    CServerListEntry ThisServerListEntry ( haServerAddr, ServerPublicIP, "", QLocale::system().territory(), "", iNumChannels, bIsDirectory );
+#else
     CServerListEntry ThisServerListEntry ( haServerAddr, ServerPublicIP, "", QLocale::system().country(), "", iNumChannels, bIsDirectory );
+#endif
 
     // parse the server info string according to definition:
     // [this server name];[this server city];[this server country as QLocale ID] (; ... ignored)
@@ -253,7 +257,11 @@ CServerListManager::CServerListManager ( CServer*       pServer,
                                         .arg ( ThisServerListEntry.strName )
                                         .arg ( ThisServerListEntry.strCity )
                                         .arg ( slServInfoSeparateParams[2] )
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+                                        .arg ( QLocale::territoryToString ( ThisServerListEntry.eCountry ) ) );
+#else
                                         .arg ( QLocale::countryToString ( ThisServerListEntry.eCountry ) ) );
+#endif
     }
 
     // per definition, the very first entry is this server and this entry will

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -567,7 +567,7 @@ void CServerListManager::OnTimerPollList()
 
     locker.unlock();
 
-    foreach ( const CHostAddress HostAddr, vecRemovedHostAddr )
+    for ( const CHostAddress& HostAddr : vecRemovedHostAddr )
     {
         qInfo() << qUtf8Printable ( QString ( "Expired entry for %1" ).arg ( HostAddr.toString() ) );
     }

--- a/src/serverrpc.cpp
+++ b/src/serverrpc.cpp
@@ -201,7 +201,11 @@ CServerRpc::CServerRpc ( CServer* pServer, CRpcServer* pRpcServer, QObject* pare
                 { "channels", pServer->GetClientNumAudioChannels ( i ) },
                 { "instrumentCode", vecChanInfo[i].iInstrument },
                 { "city", vecChanInfo[i].strCity },
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+                { "countryName", QLocale::territoryToString ( vecChanInfo[i].eCountry ) },
+#else
                 { "countryName", QLocale::countryToString ( vecChanInfo[i].eCountry ) },
+#endif
                 { "skillLevelCode", vecChanInfo[i].eSkillLevel },
             };
             clients.append ( client );

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -77,7 +77,11 @@ void CSettings::ReadFromFile ( const QString& strCurFileName, QDomDocument& XMLD
 
     if ( file.open ( QIODevice::ReadOnly ) )
     {
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 1, 0 )
+        XMLDocument.setContent ( QTextStream ( &file ).readAll().toUtf8(), QDomDocument::ParseOption::Default );
+#else
         XMLDocument.setContent ( QTextStream ( &file ).readAll(), false );
+#endif
         file.close();
     }
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -482,7 +482,11 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
     else
     {
         // if no country is given, use the one from the operating system
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+        pClient->ChannelInfo.eCountry = QLocale::system().territory();
+#else
         pClient->ChannelInfo.eCountry = QLocale::system().country();
+#endif
     }
 
     // city

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1631,7 +1631,11 @@ void CLocale::LoadTranslation ( const QString strLanguage, QCoreApplication* pAp
     }
 
     // allows the Qt messages to be translated in the application
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
+    if ( myqtTranslator.load ( QLocale ( strLanguage ), "qt", "_", QLibraryInfo::path ( QLibraryInfo::TranslationsPath ) ) )
+#else
     if ( myqtTranslator.load ( QLocale ( strLanguage ), "qt", "_", QLibraryInfo::location ( QLibraryInfo::TranslationsPath ) ) )
+#endif
     {
         pApp->installTranslator ( &myqtTranslator );
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -728,7 +728,11 @@ CLicenceDlg::CLicenceDlg ( QWidget* parent ) : CBaseDlg ( parent )
     butAccept->setEnabled ( false );
     butAccept->setDefault ( true );
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    QObject::connect ( chbAgree, &QCheckBox::checkStateChanged, this, &CLicenceDlg::OnAgreeStateChanged );
+#else
     QObject::connect ( chbAgree, &QCheckBox::stateChanged, this, &CLicenceDlg::OnAgreeStateChanged );
+#endif
 
     QObject::connect ( butAccept, &QPushButton::clicked, this, &CLicenceDlg::accept );
 


### PR DESCRIPTION
… Q_FOREACH

- Use QLibraryInfo::path() instead of location() on Qt6
- Use the QDomDocument::setContent() overload taking ParseOptions on Qt6
- Replace Q_FOREACH with range-based for over CVector

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
