### PR TITLE
Comment accuracy: minimal wording fixes in src/

### DIFF
--- a/src/audiomixerboard.cpp
+++ b/src/audiomixerboard.cpp
@@ -1339,7 +1339,8 @@ void CAudioMixerBoard::ApplyNewConClientList ( CVector<CChannelInfo>& vecChanInf
         // get all channels which are in use/not in use.
         // We use the array index of vecChanInfo if the fader is in use,
         // else INVALID_INDEX to specify it is not in use
-        // so must use "int" for the array type.
+        // so the array type is "int", which also keeps the comparisons below
+        // free of signedness warnings.
         int iFaderNumber[MAX_NUM_CHANNELS];
 
         for ( size_t iChanID = 0; iChanID < MAX_NUM_CHANNELS; iChanID++ )

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -164,8 +164,8 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
             return false;
         }
 
-        // to get the number of input blocks we assume that the number of bytes for
-        // the sequence number is much smaller than the number of coded audio bytes
+        // to get the number of input blocks we assume that the total sequence number
+        // overhead, iNumBlocks * iNumBytesSeqNum, is smaller than iBlockSize
         const int iNumBlocks = /* floor */ ( iInSize / iBlockSize );
 
         // copy new data in internal buffer

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -191,8 +191,8 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
             }
 
             // The 1-byte sequence number wraps around at a count of 256. So, if a packet is delayed
-            // further than this we cannot detect it. But it does not matter since such a packet is
-            // more than 100 ms delayed so we have a bad network situation anyway. Therefore we
+            // further than half of this we cannot detect it. But it does not matter since such a packet is
+            // more than 170 ms delayed so we have a bad network situation anyway. Therefore we
             // assume that the sequence number difference between the received and local counter is
             // correct. The idea of the following code is that we always move our "buffer window" so
             // that the received packet fits into the buffer. By doing this we are robust against

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -716,9 +716,9 @@ int CChannel::GetUploadRateKbps()
 {
     const int iAudioSizeOut = iNetwFrameSizeFact * iAudioFrameSizeSamples;
 
-    // we assume that the UDP packet which is transported via IP has an
-    // additional header size of ("Network Music Performance (NMP) in narrow
-    // band networks; Carot, Kraemer, Schuller; 2006")
+    // we assume the PPPoE-over-ATM DSL access path described in ("Network Music
+    // Performance (NMP) in narrow band networks; Carot, Kraemer, Schuller; 2006"),
+    // whose additional header size is
     // 8 (UDP) + 20 (IP without optional fields) = 28 bytes
     // 2 (PPP) + 6 (PPPoE) + 18 (MAC)            = 26 bytes
     // 5 (RFC1483B) + 8 (AAL) + 10 (ATM)         = 23 bytes

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1009,7 +1009,7 @@ void CClient::OnClientIDReceived ( int iServerChanID )
     }
 
     // allocate and map client-side channel 0
-    int iChanID = FindClientChannel ( iServerChanID, true ); // should always return channel 0
+    int iChanID = FindClientChannel ( iServerChanID, true ); // returns channel 0 for an in-range iServerChanID
 
     // for headless mode we support to mute our own signal in the personal mix
     // (note that the check for headless is done in the main.cpp and must not

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -482,7 +482,7 @@ void CClient::SetDoAutoSockBufSize ( const bool bValue )
 //
 // When the first gain or pan change message is requested after an idle period (i.e. the timer is not
 // running), it will be sent immediately, and a timer started. The timer period is dependent on
-// the current ping time to the remote server.
+// the current ping time to the remote server, which only a GUI client measures (see #3874).
 //
 // If a gain or pan change message is requested while the timer is still running, the new value is not sent,
 // but just stored in newGain or newPan within clientChannels[iId], and the minGainOrPanId and maxGainOrPanId

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1000,7 +1000,7 @@ void CClient::OnControllerInMuteMyself ( bool bMute )
 void CClient::OnClientIDReceived ( int iServerChanID )
 {
     // if we have just connected to a running server, iActiveChannels will be 0
-    // if iActiveChannels is not 0, the server must have been restarted on the fly
+    // if iActiveChannels is not 0, the server was restarted or our channel timed out
     // in that case, channels might have changed, so clear our list to get it afresh.
     if ( iActiveChannels != 0 )
     {

--- a/src/client.h
+++ b/src/client.h
@@ -335,7 +335,6 @@ public:
     void SetSettings ( CClientSettings* settings );
 
 protected:
-    // Signal handler must be declared before pSettings for correct init order
     CSignalHandler* pSignalHandler;
     // Pointer to settings for MIDI and other config
     CClientSettings* pSettings;

--- a/src/clientdlg.cpp
+++ b/src/clientdlg.cpp
@@ -575,8 +575,8 @@ CClientDlg::CClientDlg ( CClient*         pNCliP,
 
     QObject::connect ( &ConnectDlg, &CConnectDlg::ReqServerListQuery, this, &CClientDlg::OnReqServerListQuery );
 
-    // note that this connection must be a queued connection, otherwise the server list ping
-    // times are not accurate and the client list may not be retrieved for all servers listed
+    // note that this delivery must be queued, otherwise the server list ping times are not
+    // accurate and the client list may not be retrieved for all servers listed
     // (it seems the sendto() function needs to be called from different threads to fire the
     // packet immediately and do not collect packets before transmitting)
     QObject::connect ( &ConnectDlg, &CConnectDlg::CreateCLServerListPingMes, this, &CClientDlg::OnCreateCLServerListPingMes, Qt::QueuedConnection );

--- a/src/connectdlg.cpp
+++ b/src/connectdlg.cpp
@@ -164,8 +164,7 @@ CConnectDlg::CConnectDlg ( CClient* pNCliP, CClientSettings* pNSetP, const bool 
     cbxServerAddr->installEventFilter ( this );
     lvwServers->installEventFilter ( this );
 
-    // set up list view for connected clients (note that the last column size
-    // must not be specified since this column takes all the remaining space)
+    // set up list view for connected clients
 #ifdef ANDROID
     // for Android we need larger numbers because of the default font size
     lvwServers->setColumnWidth ( LVC_NAME, 200 );

--- a/src/global.h
+++ b/src/global.h
@@ -102,7 +102,7 @@ LED bar:      lbr
 
 // System block size, this is the block size on which the audio coder works.
 // All other block sizes must be a multiple of this size.
-// Note that the UpdateAutoSetting() function assumes a value of 128.
+// Note that the IIR_WEIGTH_* filter constants in buffer.h assume values of 64 and 128.
 #define SYSTEM_FRAME_SIZE_SAMPLES        64
 #define DOUBLE_SYSTEM_FRAME_SIZE_SAMPLES ( 2 * SYSTEM_FRAME_SIZE_SAMPLES )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -706,8 +706,8 @@ int main ( int argc, char** argv )
 #ifndef HEADLESS
         if ( bUseGUI )
         {
-            // by definition, when running with the GUI we always default to registering somewhere but
-            // until the settings are loaded we do not know where, so we cannot be prescriptive here
+            // when running with the GUI, until the settings are loaded we do not know whether or
+            // where this server will register, so we cannot be prescriptive here
 
             if ( !strServerListFileName.isEmpty() )
             {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -316,7 +316,7 @@ protected:
     int iOldRecID;
     int iOldRecCnt;
 
-    // these two objects must be sequred by a mutex
+    // these two objects must be secured by a mutex
     uint8_t                 iCounter;
     std::list<CSendMessage> SendMessQueue;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -662,7 +662,7 @@ void CServer::OnTimer()
     bool bUseMT               = false;
     int  iNumBlocks           = 0;     // init number of blocks for multithreading
     int  iMTBlockSize         = 0;     // init block size for multithreading
-    bChannelIsNowDisconnected = false; // note that the flag must be a member function since QtConcurrent::run can only take 5 params
+    bChannelIsNowDisconnected = false; // note that the flag is a member since DecodeReceiveData sets it and the check below reads it
 
     {
         // Make put and get calls thread safe.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -165,7 +165,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
         iServerFrameSizeSamples = SYSTEM_FRAME_SIZE_SAMPLES;
     }
 
-    // To avoid audio clitches, in the entire realtime timer audio processing
+    // To avoid audio glitches, in the entire realtime timer audio processing
     // routine including the ProcessData no memory must be allocated. Since we
     // do not know the required sizes for the vectors, we allocate memory for
     // the worst case here:

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -192,7 +192,7 @@ void CSocket::Init ( const quint16  iNewPortNumber,
         UdpSocket4 = socket ( AF_INET, SOCK_DGRAM, 0 );
         if ( UdpSocket4 == INVALID_SOCKET )
         {
-            // IPv4 requested but not available, throw error (should never happen, but check anyway)
+            // socket creation can fail (e.g. under file descriptor exhaustion), throw error
             throw CGenErr ( "IPv4 requested but not available on this system.", "Network Error" );
         }
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -151,9 +151,9 @@ signals:
     void ProtocolCLMessageReceived ( int iRecID, CVector<uint8_t> vecbyMesBodyData, CHostAddress HostAdr );
 };
 
-/* Socket which runs in a separate high priority thread --------------------- */
+/* Socket which runs in a separate thread requesting high priority ---------- */
 // The receive socket should be put in a high priority thread to ensure the GUI
-// does not effect the stability of the audio stream (e.g. if the GUI is on
+// does not affect the stability of the audio stream (e.g. if the GUI is on
 // high load because of a table update, the incoming network packets must still
 // be put in the jitter buffer with highest priority).
 class CHighPrioSocket : public QObject
@@ -240,7 +240,7 @@ protected:
 
     void Init()
     {
-        // Creation of the new socket thread which has to have the highest
+        // Creation of the new socket thread which requests the highest
         // possible thread priority to make sure the jitter buffer is reliably
         // filled with the network audio packets and does not get interrupted
         // by other GUI threads. The following code is based on:


### PR DESCRIPTION
**🤖 AI**

Fifteen comments in `src/` state something the code does not do, and three misspell a word. Each fix is the smallest wording change that makes the sentence true; the diff is comment-only (+25/−26, no code line changes), and each commit message carries the measurement or code reference behind its correction.

- `buffer.cpp` (`Put`) - the block-count divide is exact only while `iNumBlocks * iNumBytesSeqNum` stays below `iBlockSize`; the per-block size ratio is not the condition.
- `buffer.cpp` (sequence wrap) - the fold above limits detection to 128 counts, half the wrap distance, and 128 counts is at least 170 ms.
- `client.cpp` (`OnClientIDReceived`) - a 30 s traffic gap (`CON_TIME_OUT_SEC_MAX`) also produces non-zero `iActiveChannels`, from a server that never restarted.
- `client.cpp` (same function) - `FindClientChannel` returns `INVALID_INDEX` for an out-of-range ID, as `client.h` documents; channel 0 is the in-range result.
- `client.cpp` (gain/pan rate limiter) - only a GUI client measures the ping time the timer period depends on ([#3874](https://github.com/jamulussoftware/jamulus/issues/3874)).
- `server.cpp` (`OnTimer`) - the flag's `QtConcurrent::run` five-parameter rationale is stale: dispatch is `CThreadPool::enqueue`, which is variadic.
- `main.cpp` - a GUI server with a fresh ini writes `<directorytype>-1</directorytype>`, which is `AT_NONE`, so the "always default to registering somewhere" premise goes; the justification for not validating here stands without it.
- `connectdlg.cpp` - the width of every visible column is set, including the last, and `setStretchLastSection ( false )` six lines below is what stops the last column taking the remaining space.
- `global.h` - the 128 assumption belongs to the `IIR_WEIGTH_*` filter constants in `buffer.h`, which come in a 64 set and a 128 set, not to `UpdateAutoSetting()`.
- `client.h` - swapping the `pSignalHandler`/`pSettings` declarations and rebuilding gives byte-identical startup output, so the init-order comment goes.
- `socket.h` - `TimeCriticalPriority` is requested, not guaranteed: on unprivileged Linux the thread runs `SCHED_OTHER`, rt_priority 0 (the `IdlePriority` control does take effect, downward), while macOS grants sched_priority 47 against a main thread at 31.
- `socket.cpp` - a failed IPv4 `socket()` is reachable under descriptor exhaustion, so "should never happen" goes; "IPv4 not available" did not occur even inside an empty network namespace.
- `clientdlg.cpp` - the delivery is queued with or without the explicit `Qt::QueuedConnection`, because the emit always comes from a `QtConcurrent` worker thread; the requirement belongs to the delivery, not this flag.
- `audiomixerboard.cpp` - a `size_t` arm of the in-use array behaves identically (the `INVALID_INDEX` sentinel round-trips); what `int` buys is a comparison free of signedness warnings.
- `channel.cpp` (`GetUploadRateKbps`) - the 77-byte overhead is the PPPoE-over-ATM DSL access path of the cited paper; the comment now names the model it quotes.
- Spelling: `clitches` → `glitches` (`server.cpp`), `sequred` → `secured` (`protocol.h`), `effect` → `affect` (`socket.h`).

This replaces [#3866](https://github.com/jamulussoftware/jamulus/pull/3866) and applies the review feedback there: comments stay short, say what is rather than what is not, and carry no experimental data - the measurements live in the commit messages. `clang-format` 14 reports every touched file clean. Sites where the measurement points at the code rather than the comment are excluded and will be raised separately.

---

🤖 *This message was written by AI and reviewed by @mcfnord.*
