### PR TITLE
Fixes 3880: Bump Dependencies retrieved empty jom version

### DIFF
--- a/.github/workflows/bump-dependencies.yml
+++ b/.github/workflows/bump-dependencies.yml
@@ -61,8 +61,8 @@ jobs:
           - name: choco-jom
             # not Changelog-worthy
             get_upstream_version: |
-              curl -s -o /dev/null --location --range 0-5 --write-out '%{url_effective}' https://community.chocolatey.org/api/v2/package/jom/ |
-                grep -oP 'jom\.\K.*(?=\.nupkg)'
+              curl -sL "https://community.chocolatey.org/api/v2/FindPackagesById()?id='jom'" |
+                grep -oP '(?<=<d:Version>)[^<]+' | sort --version-sort | tail -n1
             local_version_regex: (.*JomVersion\s*=\s*"?)([0-9.]+)("?.*)
 
           - name: NSIS


### PR DESCRIPTION
**Short description of changes**

> [!Note]
> AI Authored change
> (ridiculous amount of effort but at least it knew where to look, which I didn't)
> Human tested

Bump Dependencies retrieved empty jom version.  This changes the method of version retrieval and successfully retrieves a version.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Fixes #3880

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Tested the old command against the new command:
```
$ echo "Old: {$(curl -s -o /dev/null --location --range 0-5 --write-out '%{url_effective}' https://community.chocolatey.org/api/v2/package/jom/ | grep -oP 'jom\.\K.*(?=\.nupkg)')}"
Old: {}
```
```
$ echo "New: {$(curl -sL "https://community.chocolatey.org/api/v2/FindPackagesById()?id='jom'" | grep -oP '(?<=<d:Version>)[^<]+' | sort --version-sort | tail -n1)}"
New: {1.1.2}
```

Merge to main on pljones/jamulus (failure is unrelated to this bug - it's expected behaviour on a non-jamulussoftware repo):
https://github.com/pljones/jamulus/actions/runs/31321765594/job/93265754130

**What is missing until this pull request can be merged?**

Review.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
