### PR TITLE
Distclean improvements

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -1199,3 +1199,27 @@ CLANG_FORMAT_SOURCES = $$find(CLANG_FORMAT_SOURCES, ^\(android|ios|mac|linux|src
 CLANG_FORMAT_SOURCES ~= s!^\(libs/.*/|src/res/qrc_resources\.cpp\)\S*$!!g
 clang_format.commands = 'clang-format -i $$CLANG_FORMAT_SOURCES'
 QMAKE_EXTRA_TARGETS += clang_format
+
+# QMAKE_DISTCLEAN only removes files. Use a custom target to remove
+# generated directory trees. Deliberately do not remove user-installed
+# dependencies such as libs/ASIOSDK2.
+android {
+    for (abi, ANDROID_ABIS) {
+        DISTCLEAN_DIRS += debug-$${abi} release-$${abi}
+    }
+    DISTCLEAN_DIRS += .qm
+} else {
+    DISTCLEAN_DIRS += debug release .qm
+}
+
+win32 {
+    for(dir, DISTCLEAN_DIRS) {
+        distclean_dirs.commands += if exist $$replace(dir, /, \\) rmdir /s /q $$replace(dir, /, \\) $$escape_expand(\\n\\t)
+    }
+} else {
+    # Works for Linux, macOS, iOS, and Android using standard Unix rm
+    distclean_dirs.commands += rm -rf $$DISTCLEAN_DIRS
+}
+
+QMAKE_EXTRA_TARGETS += distclean_dirs
+DISTCLEAN_DEPS += distclean_dirs

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -289,6 +289,7 @@ win32 {
     HEADERS += $$OBOE_HEADERS
     SOURCES += $$OBOE_SOURCES
     DISTFILES += $$DISTFILES_OBOE
+    QMAKE_DISTCLEAN += android-$${TARGET}-deployment-settings.json
 } else:unix {
     # we want to compile with C++11
     CONFIG += c++11


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Adds to Jamulus.pro rules to delete generated directories when doing a `make distclean`

The object is to return the tree to the state it would be after `git clone` by removing anything generated,
but not touching anything manually added such as `libs/ASIOSDK2` or local files.

CHANGELOG: Build: improve make distclean to remove leftover files and directories.

**Context: Fixes an issue?**

Fixes #3878

**Does this change need documentation? What needs to be documented and how?**

No

**Status of this Pull Request**

Ready. Tested on Linux, Mac and Windows

**What is missing until this pull request can be merged?**

- [ ] Testing in Android build environment.
- [ ] Testing in iOS build environment.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
AUTOBUILD: Please build all targets
