### PR TITLE
Correct calculation of blocks in an audio message

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -164,9 +164,8 @@ bool CNetBuf::Put ( const CVector<uint8_t>& vecbyData, int iInSize )
             return false;
         }
 
-        // to get the number of input blocks we assume that the number of bytes for
-        // the sequence number is much smaller than the number of coded audio bytes
-        const int iNumBlocks = /* floor */ ( iInSize / iBlockSize );
+        // the div for the number of blocks is exact, due to the check above
+        const int iNumBlocks = iInSize / ( iBlockSize + iNumBytesSeqNum );
 
         // copy new data in internal buffer
         for ( int iBlock = 0; iBlock < iNumBlocks; iBlock++ )


### PR DESCRIPTION


<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Corrects the calculation of `iNumBlocks` in `CNetBuf::Put` when sequence numbers are active.
This does not change functionality in practice, but fixes a theoretical inconsistency found by AI.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Relates to #3885 but only addresses the part related to buffer.cpp

**Does this change need documentation? What needs to be documented and how?**

No, fix only.

**Status of this Pull Request**

Tested and ready.

**What is missing until this pull request can be merged?**

Nothing.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
