### PR TITLE
[WIP] Use unused bytes in CNetworkTransportProps for EAudioQuality (backwards compatible)

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -444,6 +444,7 @@ void CChannel::OnNetTranspPropsReceived ( CNetworkTransportProps NetworkTranspor
             iNetwFrameSizeFact    = NetworkTransportProps.iBlockSizeFact;
             iNetwFrameSize        = static_cast<int> ( NetworkTransportProps.iBaseNetworkPacketSize );
             bUseSequenceNumber    = ( NetworkTransportProps.eFlags == NF_WITH_COUNTER );
+            iAudioCodingArg       = NetworkTransportProps.iAudioCodingArg;
 
             if ( bUseSequenceNumber )
             {
@@ -522,7 +523,7 @@ CNetworkTransportProps CChannel::GetNetworkTransportPropsFromCurrentSettings()
                                     SYSTEM_SAMPLE_RATE_HZ,
                                     eAudioCompressionType,
                                     eFlags,
-                                    0 );
+                                    iAudioCodingArg );
 }
 
 void CChannel::Disconnect()

--- a/src/channel.h
+++ b/src/channel.h
@@ -162,6 +162,8 @@ public:
 
     EAudComprType GetAudioCompressionType() { return eAudioCompressionType; }
     int           GetNumAudioChannels() const { return iNumAudioChannels; }
+    int           GetAudioCodingArg() const { return iAudioCodingArg; }
+    void          SetAudioCodingArg ( int iNAudioCodingArg ) { iAudioCodingArg = iNAudioCodingArg; }
 
     // network protocol interface
     void CreateJitBufMes ( const int iJitBufSize )
@@ -245,6 +247,7 @@ protected:
     int iNetwFrameSize;
     int iCeltNumCodedBytes;
     int iAudioFrameSizeSamples;
+    int iAudioCodingArg;
 
     EAudComprType eAudioCompressionType;
     int           iNumAudioChannels;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1441,6 +1441,8 @@ void CClient::Init()
         }
     }
 
+    Channel.SetAudioCodingArg ( eAudioQuality );
+
     // calculate stereo (two channels) buffer size
     iStereoBlockSizeSam = 2 * iMonoBlockSizeSam;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -183,6 +183,7 @@ CServer::CServer ( const int          iNewMaxNumChan,
     vecNumFrameSizeConvBlocks.Init ( iMaxNumChannels );
     vecUseDoubleSysFraSizeConvBuf.Init ( iMaxNumChannels );
     vecAudioComprType.Init ( iMaxNumChannels );
+    vecAudioCodingArg.Init ( iMaxNumChannels );
 
     for ( i = 0; i < iMaxNumChannels; i++ )
     {
@@ -844,6 +845,7 @@ void CServer::DecodeReceiveData ( const int iChanCnt, const int iNumClients )
     // get and store number of audio channels and compression type
     vecNumAudioChannels[iChanCnt] = vecChannels[iCurChanID].GetNumAudioChannels();
     vecAudioComprType[iChanCnt]   = vecChannels[iCurChanID].GetAudioCompressionType();
+    vecAudioCodingArg[iChanCnt]   = vecChannels[iCurChanID].GetAudioCodingArg();
 
     // get info about required frame size conversion properties
     vecUseDoubleSysFraSizeConvBuf[iChanCnt] = ( !bUseDoubleSystemFrameSize && ( vecAudioComprType[iChanCnt] == CT_OPUS ) );
@@ -974,7 +976,8 @@ void CServer::DecodeReceiveData ( const int iChanCnt, const int iNumClients )
             // sizeof ( int16_t ) is the size in bytes for the raw pcm audio data = 2
             // Sizes other than that are considered OPUS coded because those depend on hardcoded sizes in client.h
             const bool bIsRawAudio =
-                ( iCeltNumCodedBytes == static_cast<int> ( sizeof ( int16_t ) * iClientFrameSizeSamples * vecNumAudioChannels[iChanCnt] ) );
+                ( vecAudioCodingArg[iChanCnt] == AQ_RAW ||
+                  iCeltNumCodedBytes == static_cast<int> ( sizeof ( int16_t ) * iClientFrameSizeSamples * vecNumAudioChannels[iChanCnt] ) );
 
             const int iOffset = iB * SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt];
 
@@ -1263,7 +1266,8 @@ void CServer::MixEncodeTransmitData ( const int iChanCnt, const int iNumClients 
             DoubleFrameSizeConvBufOut[iCurChanID].GetAll ( vecsSendData, DOUBLE_SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt] );
         }
 
-        if ( iCeltNumCodedBytes != static_cast<int> ( sizeof ( int16_t ) * iClientFrameSizeSamples * vecNumAudioChannels[iChanCnt] ) )
+        if ( vecAudioCodingArg[iChanCnt] != AQ_RAW &&
+             iCeltNumCodedBytes != static_cast<int> ( sizeof ( int16_t ) * iClientFrameSizeSamples * vecNumAudioChannels[iChanCnt] ) )
         {
             // OPUS encoding
             if ( CurOpusEncoder != nullptr )

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -966,6 +966,7 @@ void CServer::DecodeReceiveData ( const int iChanCnt, const int iNumClients )
                 pCurCodedData = nullptr;
             }
 
+            //### DEPRECATED: BEGIN ###//
             // Recognise a raw audio packet by its size:
             // The client doesn't pass a value for the selected audio quality implicitly.
             // Rather the server is passed the length of the data sent by the client in iClientFrameSizeSamples.
@@ -975,6 +976,9 @@ void CServer::DecodeReceiveData ( const int iChanCnt, const int iNumClients )
             // iNumAudioChannels is either 1 for mono or 2 for stereo and mono-in/stereo-out
             // sizeof ( int16_t ) is the size in bytes for the raw pcm audio data = 2
             // Sizes other than that are considered OPUS coded because those depend on hardcoded sizes in client.h
+            //### DEPRECATED: END ###//
+            // The client sent its audio quality setting. Check if raw audio was set
+            // for backwards compatibility the size check is left in, see above
             const bool bIsRawAudio =
                 ( vecAudioCodingArg[iChanCnt] == AQ_RAW ||
                   iCeltNumCodedBytes == static_cast<int> ( sizeof ( int16_t ) * iClientFrameSizeSamples * vecNumAudioChannels[iChanCnt] ) );
@@ -1252,6 +1256,9 @@ void CServer::MixEncodeTransmitData ( const int iChanCnt, const int iNumClients 
         }
     }
 
+    // Check if the client wants raw audio rather than guessing by packet sizes
+    const bool bWantsRawAudio = vecAudioCodingArg[iChanCnt] == AQ_RAW;
+
     // If the server frame size is smaller than the received OPUS frame size, we need a conversion
     // buffer which stores the large buffer.
     // Note that we have a shortcut here. If the conversion buffer is not needed, the boolean flag
@@ -1266,7 +1273,7 @@ void CServer::MixEncodeTransmitData ( const int iChanCnt, const int iNumClients 
             DoubleFrameSizeConvBufOut[iCurChanID].GetAll ( vecsSendData, DOUBLE_SYSTEM_FRAME_SIZE_SAMPLES * vecNumAudioChannels[iChanCnt] );
         }
 
-        if ( vecAudioCodingArg[iChanCnt] != AQ_RAW &&
+        if ( !bWantsRawAudio &&
              iCeltNumCodedBytes != static_cast<int> ( sizeof ( int16_t ) * iClientFrameSizeSamples * vecNumAudioChannels[iChanCnt] ) )
         {
             // OPUS encoding

--- a/src/server.h
+++ b/src/server.h
@@ -285,6 +285,7 @@ protected:
     CVector<int>              vecNumFrameSizeConvBlocks;
     CVector<int>              vecUseDoubleSysFraSizeConvBuf;
     CVector<EAudComprType>    vecAudioComprType;
+    CVector<int>              vecAudioCodingArg;
     CVector<CVector<int16_t>> vecvecsSendData;
     CVector<CVector<float>>   vecvecfIntermediateProcBuf;
     CVector<CVector<uint8_t>> vecvecbyCodedData;


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

#3894 surfaced 4 bytes being unused in `CNetworkTransportProps`, namely `iAudioCodingArg`.
This uses those bytes to save the selected audio quality in the client. For backwards compatibility we simply leave the old checks in place. This should be improved, hence a work in progress.

<!-- Explain what your PR does -->

CHANGELOG: Use iAudioCodingArg in CNetworkTransportProps for EAudioQuality

**Context: Fixes an issue?**

fixes #3896 

**Does this change need documentation? What needs to be documented and how?**

No, just a bug fix

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
Proof of concept (not to be merged soon);

**What is missing until this pull request can be merged?**

- [ ] dedicated enum containing all possible audio quality settings combinations (or something similiar for the client and server to share)

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
