### PR TITLE
Harden panning via bound check

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -337,7 +337,8 @@ void CChannel::SetPan ( const int iChanID, const float fNewPan )
     // set value (make sure channel ID is in range)
     if ( ( iChanID >= 0 ) && ( iChanID < MAX_NUM_CHANNELS ) )
     {
-        vecfPannings[iChanID] = fNewPan;
+        // pan range is 0..1; guard to avoid wrong values from the network
+        vecfPannings[iChanID] = std::min ( 1.0f, std::max ( fNewPan, 0.0f ) );
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Bounds pan values to always be in range. In theory, the network values could have been any value. Thus bounding those is needed.

CHANGELOG: Bug: Ensure correct bounds for panning

**Context: Fixes an issue?**

No. Found by @mcfnord via AI review.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Ready for review (fast review!)
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

Review.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
