### PR TITLE
Allow supplying ABI from command line override

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -247,7 +247,9 @@ win32 {
     LIBS += -framework AVFoundation \
         -framework AudioToolbox
 } else:android {
-    ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
+    isEmpty(ANDROID_ABIS) {
+        ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
+    }
     ANDROID_VERSION_NAME = $$VERSION
     ANDROID_VERSION_CODE = $$system(git log --oneline | wc -l)
     message("Setting ANDROID_VERSION_NAME=$${ANDROID_VERSION_NAME} ANDROID_VERSION_CODE=$${ANDROID_VERSION_CODE}")


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

When I'm doing a build locally, rather than have to build _all_ the android platforms, it's useful to be able to specify which ABI to target.  Currently, `Jamulus.pro` prevents this by directly setting the ABIs to build.

This small change first checks whether any target is set and only sets it to the default list if it's empty.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Useful enhancement to local build tooling.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Tested locally.

**What is missing until this pull request can be merged?**

Confirmation I'm not missing something.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

AUTOBUILD: Please build all targets
