### PR TITLE
Remove "wc -l" from Jamulus.pro

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -251,7 +251,13 @@ win32 {
         ANDROID_ABIS = armeabi-v7a arm64-v8a x86 x86_64
     }
     ANDROID_VERSION_NAME = $$VERSION
-    ANDROID_VERSION_CODE = $$system(git log --oneline | wc -l)
+    # Used by Play Store
+    ANDROID_VERSION_CODE = 0
+    !contains(VERSION, .*dev.*) {
+        exists(".git/config") {
+            ANDROID_VERSION_CODE = $$size($$list($$system(git log --format=format:1,lines)))
+        }
+    }
     message("Setting ANDROID_VERSION_NAME=$${ANDROID_VERSION_NAME} ANDROID_VERSION_CODE=$${ANDROID_VERSION_CODE}")
 
     # liboboe requires C++17 for std::timed_mutex

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -255,7 +255,7 @@ win32 {
     ANDROID_VERSION_CODE = 0
     !contains(VERSION, .*dev.*) {
         exists(".git/config") {
-            ANDROID_VERSION_CODE = $$size($$list($$system(git log --format=format:1,lines)))
+            ANDROID_VERSION_CODE = $$system(git rev-list --count HEAD)
         }
     }
     message("Setting ANDROID_VERSION_NAME=$${ANDROID_VERSION_NAME} ANDROID_VERSION_CODE=$${ANDROID_VERSION_CODE}")


### PR DESCRIPTION
**Short description of changes**

Currently, to get a build number for android builds, Jamulus.pro runs `wc -l` -- this is unlikely to work on Windows and isn't necessary to achieve the result intended.  This patch amends Jamulus.pro to use built-ins to do the calculation.

It also amends the build number so it is _aways zero on dev builds_.  This is so that only tagged builds have the number of commits counted.  (We're unlikely to have more commits on a release branch than on main.)

CHANGELOG: SKIP

**Context: Fixes an issue?**

Makes Jamulus.pro more portable.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Tested locally, including on branch and tagged builds.

**What is missing until this pull request can be merged?**

Should be good, subject to review.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
