### PR TITLE
On android, release and debug outputs overwrite - avoid

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -262,8 +262,16 @@ win32 {
     # enabled only for debugging on android devices
     DEFINES += ANDROIDDEBUG
 
-    target.path = /tmp/your_executable # path on device
-    INSTALLS += target
+    CONFIG(debug, debug|release) {
+        DESTDIR = $$OUT_PWD/debug
+    } else {
+        DESTDIR = $$OUT_PWD/release
+    }
+
+    CONFIG -= android_install
+    android_lib.files = $$DESTDIR/libJamulus_$${QT_ARCH}.so
+    android_lib.path = /libs/$$ANDROID_TARGET_ARCH
+    INSTALLS += android_lib
 
     HEADERS += src/sound/oboe/sound.h
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Currently, when running `qmake` for an android build, the command completes with
```
WARNING: Targets of builds 'ReleaseArm64-v8a' and 'DebugArm64-v8a' conflict: libJamulus_arm64-v8a.so.
```
because both targets write the same pre-packaging file in the project root (rather than under the Release or Debug ABI directory).  For example: https://github.com/jamulussoftware/jamulus/actions/runs/31731502137/job/94565506319

This change splits the DESTDIR for debug and release runs so there is no conflict and makes the other necessary changes to get the build to assemble the final target.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Build conflict on android.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Could do with someone who knows the intent of `debug_and_release` confirming this is a sensible fix.  It appears to work.

**What is missing until this pull request can be merged?**

Needs a second opinion on the approach.

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
