### PR TITLE
macOS: separate input and output audio device selection

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -746,7 +746,14 @@ void CClient::SetAudioChannels ( const EAudChanConf eNAudChanConf )
     }
 }
 
-QString CClient::SetSndCrdDev ( const QString strNewDev )
+QString CClient::SetSndCrdDev ( const QString strNewDev ) { return ChangeSndCrdDev ( strNewDev, QString(), false ); }
+
+QString CClient::SetSndCrdInOutDev ( const QString& strNewInDev, const QString& strNewOutDev )
+{
+    return ChangeSndCrdDev ( strNewInDev, strNewOutDev, true );
+}
+
+QString CClient::ChangeSndCrdDev ( const QString& strNewDev, const QString& strNewOutDev, const bool bSeparateInOutDev )
 {
     QString strError = "";
 
@@ -762,7 +769,8 @@ QString CClient::SetSndCrdDev ( const QString strNewDev )
     // on error condition. Catch it here as exceptions must not escape from a Qt slot.
     try
     {
-        strError = Sound.SetDev ( strNewDev );
+        // for a separate selection the first parameter is the input device name
+        strError = bSeparateInOutDev ? Sound.SetInOutDev ( strNewDev, strNewOutDev ) : Sound.SetDev ( strNewDev );
 
         // init again because the sound card actual buffer size might
         // be changed on new device

--- a/src/client.h
+++ b/src/client.h
@@ -244,6 +244,14 @@ public:
     QString GetSndCrdDev() { return Sound.GetDev(); }
     void    OpenSndCrdDriverSetup() { Sound.OpenDriverSetup(); }
 
+    // separate input/output device selection (only supported by some sound APIs)
+    bool        GetSndCrdInOutDevSelectionSeparate() { return Sound.IsInOutDevSelectionSeparate(); }
+    QStringList GetSndCrdInputDevNames() { return Sound.GetInputDevNames(); }
+    QStringList GetSndCrdOutputDevNames() { return Sound.GetOutputDevNames(); }
+    QString     GetSndCrdInputDev() { return Sound.GetInputDev(); }
+    QString     GetSndCrdOutputDev() { return Sound.GetOutputDev(); }
+    QString     SetSndCrdInOutDev ( const QString& strNewInDev, const QString& strNewOutDev );
+
     // sound card channel selection
     int     GetSndCrdNumInputChannels() { return Sound.GetNumInputChannels(); }
     QString GetSndCrdInputChannelName ( const int iDiD ) { return Sound.GetInputChannelName ( iDiD ); }
@@ -363,7 +371,9 @@ protected:
     void Start();
     void Stop();
 
-    void Init();
+    void    Init();
+    QString ChangeSndCrdDev ( const QString& strNewDev, const QString& strNewOutDev, const bool bSeparateInOutDev );
+
     void ProcessSndCrdAudioData ( CVector<short>& vecsStereoSndCrd );
     void ProcessAudioDataIntern ( CVector<short>& vecsStereoSndCrd );
 

--- a/src/clientsettingsdlg.cpp
+++ b/src/clientsettingsdlg.cpp
@@ -142,18 +142,24 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
 
 #if !defined( WITH_JACK )
     // sound card device
-    lblSoundcardDevice->setWhatsThis ( "<b>" + tr ( "Audio Device" ) + ":</b> " +
-                                       tr ( "Under the Windows operating system the ASIO driver (sound card) can be "
-                                            "selected using %1. If the selected ASIO driver is not valid an error "
-                                            "message is shown and the previous valid driver is selected. "
-                                            "Under macOS the input and output hardware can be selected." )
-                                           .arg ( APP_NAME ) +
-                                       "<br>" +
-                                       tr ( "If the driver is selected during an active connection, the connection "
-                                            "is stopped, the driver is changed and the connection is started again "
-                                            "automatically." ) );
+    const QString strAudioDevice = "<b>" + tr ( "Audio Device" ) + ":</b> " +
+                                   tr ( "Under the Windows operating system the ASIO driver (sound card) can be "
+                                        "selected using %1. If the selected ASIO driver is not valid an error "
+                                        "message is shown and the previous valid driver is selected. "
+                                        "Under macOS the input and output hardware can be selected." )
+                                       .arg ( APP_NAME ) +
+                                   "<br>" +
+                                   tr ( "If the driver is selected during an active connection, the connection "
+                                        "is stopped, the driver is changed and the connection is started again "
+                                        "automatically." );
+
+    lblSoundcardDevice->setWhatsThis ( strAudioDevice );
+    lblInputDevice->setWhatsThis ( strAudioDevice );
+    lblOutputDevice->setWhatsThis ( strAudioDevice );
 
     cbxSoundcard->setAccessibleName ( tr ( "Sound card device selector combo box" ) );
+    cbxInputDevice->setAccessibleName ( tr ( "Audio input device selector combo box" ) );
+    cbxOutputDevice->setAccessibleName ( tr ( "Audio output device selector combo box" ) );
 
 #    if defined( _WIN32 )
     // set Windows specific tool tip
@@ -735,6 +741,16 @@ CClientSettingsDlg::CClientSettingsDlg ( CClient* pNCliP, CClientSettings* pNSet
                        this,
                        &CClientSettingsDlg::OnSoundcardActivated );
 
+    QObject::connect ( cbxInputDevice,
+                       static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
+                       this,
+                       &CClientSettingsDlg::OnInputDeviceActivated );
+
+    QObject::connect ( cbxOutputDevice,
+                       static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
+                       this,
+                       &CClientSettingsDlg::OnOutputDeviceActivated );
+
     QObject::connect ( cbxLInChan,
                        static_cast<void ( QComboBox::* ) ( int )> ( &QComboBox::activated ),
                        this,
@@ -1126,18 +1142,44 @@ void CClientSettingsDlg::UpdateSoundCardFrame()
     }
 }
 
+void CClientSettingsDlg::UpdateSoundDeviceSelection()
+{
+    // Sound APIs which handle the input and the output device independently of
+    // each other (i.e. CoreAudio on macOS) get one combo box per direction. All
+    // other APIs get the single combo box containing the available devices.
+    const bool bSeparateInOutDev = pClient->GetSndCrdInOutDevSelectionSeparate();
+
+    lblSoundcardDevice->setVisible ( !bSeparateInOutDev );
+    cbxSoundcard->setVisible ( !bSeparateInOutDev );
+    lblInputDevice->setVisible ( bSeparateInOutDev );
+    cbxInputDevice->setVisible ( bSeparateInOutDev );
+    lblOutputDevice->setVisible ( bSeparateInOutDev );
+    cbxOutputDevice->setVisible ( bSeparateInOutDev );
+
+    if ( bSeparateInOutDev )
+    {
+        // update combo boxes containing the available input and output devices
+        cbxInputDevice->clear();
+        cbxInputDevice->addItems ( pClient->GetSndCrdInputDevNames() );
+        cbxInputDevice->setCurrentText ( pClient->GetSndCrdInputDev() );
+
+        cbxOutputDevice->clear();
+        cbxOutputDevice->addItems ( pClient->GetSndCrdOutputDevNames() );
+        cbxOutputDevice->setCurrentText ( pClient->GetSndCrdOutputDev() );
+    }
+    else
+    {
+        // update combo box containing all available sound cards in the system
+        cbxSoundcard->clear();
+        cbxSoundcard->addItems ( pClient->GetSndCrdDevNames() );
+        cbxSoundcard->setCurrentText ( pClient->GetSndCrdDev() );
+    }
+}
+
 void CClientSettingsDlg::UpdateSoundDeviceChannelSelectionFrame()
 {
-    // update combo box containing all available sound cards in the system
-    QStringList slSndCrdDevNames = pClient->GetSndCrdDevNames();
-    cbxSoundcard->clear();
-
-    foreach ( QString strDevName, slSndCrdDevNames )
-    {
-        cbxSoundcard->addItem ( strDevName );
-    }
-
-    cbxSoundcard->setCurrentText ( pClient->GetSndCrdDev() );
+    // update the sound device selection combo box(es)
+    UpdateSoundDeviceSelection();
 
     // update input/output channel selection
 #if defined( _WIN32 ) || defined( __APPLE__ ) || defined( __MACOSX )
@@ -1217,6 +1259,26 @@ void CClientSettingsDlg::OnNetBufServerValueChanged ( int value )
 void CClientSettingsDlg::OnSoundcardActivated ( int iSndDevIdx )
 {
     pClient->SetSndCrdDev ( cbxSoundcard->itemText ( iSndDevIdx ) );
+
+    UpdateSoundDeviceChannelSelectionFrame();
+    UpdateDisplay();
+}
+
+void CClientSettingsDlg::OnInputDeviceActivated ( int iSndDevIdx )
+{
+    // The device of the other direction is taken from its combo box and not from
+    // the sound API: if no device could be initialized at all, the sound API has
+    // no current device and we would compose an unusable device name from it.
+    pClient->SetSndCrdInOutDev ( cbxInputDevice->itemText ( iSndDevIdx ), cbxOutputDevice->currentText() );
+
+    UpdateSoundDeviceChannelSelectionFrame();
+    UpdateDisplay();
+}
+
+void CClientSettingsDlg::OnOutputDeviceActivated ( int iSndDevIdx )
+{
+    // the device of the other direction is taken from its combo box, see above
+    pClient->SetSndCrdInOutDev ( cbxInputDevice->currentText(), cbxOutputDevice->itemText ( iSndDevIdx ) );
 
     UpdateSoundDeviceChannelSelectionFrame();
     UpdateDisplay();

--- a/src/clientsettingsdlg.h
+++ b/src/clientsettingsdlg.h
@@ -80,6 +80,7 @@ public:
 
     void UpdateUploadRate();
     void UpdateDisplay();
+    void UpdateSoundDeviceSelection();
     void UpdateSoundDeviceChannelSelectionFrame();
 
     void SetEnableFeedbackDetection ( bool enable );
@@ -111,6 +112,8 @@ public slots:
     void OnInputBoostChanged();
     void OnSndCrdBufferDelayButtonGroupClicked ( QAbstractButton* button );
     void OnSoundcardActivated ( int iSndDevIdx );
+    void OnInputDeviceActivated ( int iSndDevIdx );
+    void OnOutputDeviceActivated ( int iSndDevIdx );
     void OnLInChanActivated ( int iChanIdx );
     void OnRInChanActivated ( int iChanIdx );
     void OnLOutChanActivated ( int iChanIdx );

--- a/src/clientsettingsdlgbase.ui
+++ b/src/clientsettingsdlgbase.ui
@@ -397,6 +397,58 @@
             </widget>
            </item>
            <item>
+            <widget class="QLabel" name="lblInputDevice">
+             <property name="text">
+              <string>Input Device</string>
+             </property>
+             <property name="buddy">
+              <cstring>cbxInputDevice</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="cbxInputDevice">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="lblOutputDevice">
+             <property name="text">
+              <string>Output Device</string>
+             </property>
+             <property name="buddy">
+              <cstring>cbxOutputDevice</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="cbxOutputDevice">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -2267,6 +2319,8 @@
   <tabstop>spnMixerRows</tabstop>
   <tabstop>chbAudioAlerts</tabstop>
   <tabstop>cbxSoundcard</tabstop>
+  <tabstop>cbxInputDevice</tabstop>
+  <tabstop>cbxOutputDevice</tabstop>
   <tabstop>butDriverSetup</tabstop>
   <tabstop>cbxLInChan</tabstop>
   <tabstop>cbxRInChan</tabstop>

--- a/src/global.h
+++ b/src/global.h
@@ -205,8 +205,11 @@ LED bar:      lbr
 // maximum number of fader groups (must be consistent to audiomixerboard implementation)
 #define MAX_NUM_FADER_GROUPS 8
 
-// maximum number of recognized sound cards installed in the system
-#define MAX_NUMBER_SOUND_CARDS 129 // e.g. 16 inputs, 8 outputs + default entry (MacOS)
+// maximum number of recognized sound cards installed in the system, i.e. the
+// number of available ASIO drivers on Windows. On macOS the input and the
+// output devices are enumerated separately, so the limit applies to each
+// direction on its own (including the system default entry)
+#define MAX_NUMBER_SOUND_CARDS 129
 
 // define the maximum number of audio channel for input/output we can store
 // channel infos for (and therefore this is the maximum number of entries in

--- a/src/sound/coreaudio-mac/sound.cpp
+++ b/src/sound/coreaudio-mac/sound.cpp
@@ -46,6 +46,20 @@
 
 #include "sound.h"
 
+/* Definitions ****************************************************************/
+// Names of the entries which follow the device selected as system default. Note
+// that these names are stored in the settings file and are therefore not
+// translated. The combined name of the "both directions are system default"
+// case is the one which was used when input and output were selected together
+// so that settings written by previous versions are still valid.
+static const QString strSystemDefaultInDevName    = "System Default In Device";
+static const QString strSystemDefaultOutDevName   = "System Default Out Device";
+static const QString strSystemDefaultInOutDevName = "System Default In/Out Devices";
+
+// separators used for combining the input and output device name
+static const QString strDevNameInPrefix  = "in: ";
+static const QString strDevNameOutPrefix = "/out: ";
+
 /* Implementation *************************************************************/
 CSound::CSound ( void ( *fpNewProcessCallback ) ( CVector<short>& psData, void* arg ), void* arg, const bool, const QString& ) :
     CSoundBase ( "CoreAudio", fpNewProcessCallback, arg ),
@@ -68,8 +82,7 @@ CSound::CSound ( void ( *fpNewProcessCallback ) ( CVector<short>& psData, void* 
     // initial query for available input/output sound devices in the system
     GetAvailableInOutDevices();
 
-    // init device index as not initialized (invalid)
-    lCurDev                    = INVALID_INDEX;
+    // init device IDs as not initialized (invalid)
     CurrentAudioInputDeviceID  = 0;
     CurrentAudioOutputDeviceID = 0;
     iNumInChan                 = 0;
@@ -119,14 +132,16 @@ void CSound::GetAvailableInOutDevices()
     // calculate device count based on size of returned data array
     const UInt32 iDeviceCount = iPropertySize / sizeof ( AudioDeviceID );
 
-    // always add system default devices for input and output as first entry
-    lNumDevs                 = 0;
-    strDriverNames[lNumDevs] = "System Default In/Out Devices";
+    // always add the system default device as first entry of each list
+    lNumInDevs                        = 0;
+    lNumOutDevs                       = 0;
+    strInputDeviceNames[lNumInDevs]   = strSystemDefaultInDevName;
+    strOutputDeviceNames[lNumOutDevs] = strSystemDefaultOutDevName;
 
     iPropertySize               = sizeof ( AudioDeviceID );
     stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
 
-    if ( AudioObjectGetPropertyData ( kAudioObjectSystemObject, &stPropertyAddress, 0, NULL, &iPropertySize, &audioInputDevice[lNumDevs] ) )
+    if ( AudioObjectGetPropertyData ( kAudioObjectSystemObject, &stPropertyAddress, 0, NULL, &iPropertySize, &audioInputDevice[lNumInDevs] ) )
     {
         throw CGenErr ( tr ( "No sound card is available in your system. "
                              "CoreAudio input AudioHardwareGetProperty call failed." ) );
@@ -135,49 +150,149 @@ void CSound::GetAvailableInOutDevices()
     iPropertySize               = sizeof ( AudioDeviceID );
     stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
 
-    if ( AudioObjectGetPropertyData ( kAudioObjectSystemObject, &stPropertyAddress, 0, NULL, &iPropertySize, &audioOutputDevice[lNumDevs] ) )
+    if ( AudioObjectGetPropertyData ( kAudioObjectSystemObject, &stPropertyAddress, 0, NULL, &iPropertySize, &audioOutputDevice[lNumOutDevs] ) )
     {
         throw CGenErr ( tr ( "No sound card is available in the system. "
                              "CoreAudio output AudioHardwareGetProperty call failed." ) );
     }
 
-    lNumDevs++; // next device
+    lNumInDevs++;  // next input device
+    lNumOutDevs++; // next output device
 
-    // add detected devices
-    //
-    // we add combined entries for input and output for each device so that we
-    // do not need two combo boxes in the GUI for input and output (therefore
-    // all possible combinations are required which can be a large number)
+    // add the detected devices to the input and/or the output list (a device
+    // which offers both directions shows up in both lists)
     for ( UInt32 i = 0; i < iDeviceCount; i++ )
     {
-        for ( UInt32 j = 0; j < iDeviceCount; j++ )
+        QString strDeviceName;
+        bool    bIsInput;
+        bool    bIsOutput;
+
+        GetAudioDeviceInfos ( vAudioDevices[i], strDeviceName, bIsInput, bIsOutput );
+
+        if ( bIsInput && ( lNumInDevs < MAX_NUMBER_SOUND_CARDS ) )
         {
-            // get device infos for both current devices
-            QString strDeviceName_i;
-            QString strDeviceName_j;
-            bool    bIsInput_i;
-            bool    bIsInput_j;
-            bool    bIsOutput_i;
-            bool    bIsOutput_j;
+            strInputDeviceNames[lNumInDevs] = strDeviceName;
+            audioInputDevice[lNumInDevs]    = vAudioDevices[i];
 
-            GetAudioDeviceInfos ( vAudioDevices[i], strDeviceName_i, bIsInput_i, bIsOutput_i );
+            lNumInDevs++; // next input device
+        }
 
-            GetAudioDeviceInfos ( vAudioDevices[j], strDeviceName_j, bIsInput_j, bIsOutput_j );
+        if ( bIsOutput && ( lNumOutDevs < MAX_NUMBER_SOUND_CARDS ) )
+        {
+            strOutputDeviceNames[lNumOutDevs] = strDeviceName;
+            audioOutputDevice[lNumOutDevs]    = vAudioDevices[i];
 
-            // check if i device is input and j device is output and that we are
-            // in range
-            if ( bIsInput_i && bIsOutput_j && ( lNumDevs < MAX_NUMBER_SOUND_CARDS ) )
-            {
-                strDriverNames[lNumDevs] = "in: " + strDeviceName_i + "/out: " + strDeviceName_j;
-
-                // store audio device IDs
-                audioInputDevice[lNumDevs]  = vAudioDevices[i];
-                audioOutputDevice[lNumDevs] = vAudioDevices[j];
-
-                lNumDevs++; // next device
-            }
+            lNumOutDevs++; // next output device
         }
     }
+}
+
+QStringList CSound::GetInputDevNames()
+{
+    QMutexLocker locker ( &Mutex );
+
+    // note that the device list is refreshed whenever a driver is loaded
+    QStringList slDevNames;
+
+    for ( int iDev = 0; iDev < lNumInDevs; iDev++ )
+    {
+        slDevNames << strInputDeviceNames[iDev];
+    }
+
+    return slDevNames;
+}
+
+QStringList CSound::GetOutputDevNames()
+{
+    QMutexLocker locker ( &Mutex );
+
+    // note that the device list is refreshed whenever a driver is loaded
+    QStringList slDevNames;
+
+    for ( int iDev = 0; iDev < lNumOutDevs; iDev++ )
+    {
+        slDevNames << strOutputDeviceNames[iDev];
+    }
+
+    return slDevNames;
+}
+
+QString CSound::GetInputDev()
+{
+    QMutexLocker locker ( &Mutex );
+
+    return strCurInDevName;
+}
+
+QString CSound::GetOutputDev()
+{
+    QMutexLocker locker ( &Mutex );
+
+    return strCurOutDevName;
+}
+
+QString CSound::SetInOutDev ( const QString& strInDevName, const QString& strOutDevName )
+{
+    // the base class handles the device change based on the combined name
+    return SetDev ( ComposeDevName ( strInDevName, strOutDevName ) );
+}
+
+QString CSound::ComposeDevName ( const QString& strInDevName, const QString& strOutDevName )
+{
+    // if both directions use the system default device, use the legacy name of
+    // the combined entry so that the settings stay compatible
+    if ( ( strInDevName.compare ( strSystemDefaultInDevName ) == 0 ) && ( strOutDevName.compare ( strSystemDefaultOutDevName ) == 0 ) )
+    {
+        return strSystemDefaultInOutDevName;
+    }
+
+    return strDevNameInPrefix + strInDevName + strDevNameOutPrefix + strOutDevName;
+}
+
+int CSound::FindDevIdx ( const QString strDevNames[], const long lNumDevices, const QString& strDevName ) const
+{
+    for ( int i = 0; i < lNumDevices; i++ )
+    {
+        if ( strDevNames[i].compare ( strDevName ) == 0 )
+        {
+            return i;
+        }
+    }
+
+    return INVALID_INDEX;
+}
+
+bool CSound::SplitAndResolveDevName ( const QString& strDevName, int& iInDevIdx, int& iOutDevIdx ) const
+{
+    iInDevIdx  = INVALID_INDEX;
+    iOutDevIdx = INVALID_INDEX;
+
+    if ( strDevName.compare ( strSystemDefaultInOutDevName ) == 0 )
+    {
+        // legacy name of the combined system default entry
+        iInDevIdx  = FindDevIdx ( strInputDeviceNames, lNumInDevs, strSystemDefaultInDevName );
+        iOutDevIdx = FindDevIdx ( strOutputDeviceNames, lNumOutDevs, strSystemDefaultOutDevName );
+    }
+    else if ( strDevName.startsWith ( strDevNameInPrefix ) )
+    {
+        const int iInPrefixLen  = static_cast<int> ( strDevNameInPrefix.length() );
+        const int iOutPrefixLen = static_cast<int> ( strDevNameOutPrefix.length() );
+
+        // a device name may itself contain the separator, therefore try all
+        // occurrences until both parts resolve to an available device
+        int iSepPos = static_cast<int> ( strDevName.indexOf ( strDevNameOutPrefix, iInPrefixLen ) );
+
+        while ( ( iSepPos >= 0 ) && ( ( iInDevIdx == INVALID_INDEX ) || ( iOutDevIdx == INVALID_INDEX ) ) )
+        {
+            iInDevIdx = FindDevIdx ( strInputDeviceNames, lNumInDevs, strDevName.mid ( iInPrefixLen, iSepPos - iInPrefixLen ) );
+
+            iOutDevIdx = FindDevIdx ( strOutputDeviceNames, lNumOutDevs, strDevName.mid ( iSepPos + iOutPrefixLen ) );
+
+            iSepPos = static_cast<int> ( strDevName.indexOf ( strDevNameOutPrefix, iSepPos + 1 ) );
+        }
+    }
+
+    return ( iInDevIdx != INVALID_INDEX ) && ( iOutDevIdx != INVALID_INDEX );
 }
 
 void CSound::GetAudioDeviceInfos ( const AudioDeviceID DeviceID, QString& strDeviceName, bool& bIsInput, bool& bIsOutput )
@@ -279,117 +394,178 @@ int CSound::CountChannels ( AudioDeviceID devID, bool isInput )
 
 QString CSound::LoadAndInitializeDriver ( QString strDriverName, bool )
 {
-    // secure lNumDevs/strDriverNames access
+    // secure device list access
     QMutexLocker locker ( &Mutex );
 
-    // reload the driver list of available sound devices
+    // reload the list of available sound devices
     GetAvailableInOutDevices();
 
-    // find driver index from given driver name
-    int iDriverIdx = INVALID_INDEX; // initialize with an invalid index
+    // find the input and output device index from the given combined name
+    int iInDevIdx;
+    int iOutDevIdx;
 
-    for ( int i = 0; i < MAX_NUMBER_SOUND_CARDS; i++ )
-    {
-        if ( strDriverName.compare ( strDriverNames[i] ) == 0 )
-        {
-            iDriverIdx = i;
-        }
-    }
-
-    // if the selected driver was not found, return an error message
-    if ( iDriverIdx == INVALID_INDEX )
+    // if one of the selected devices was not found, return an error message
+    if ( !SplitAndResolveDevName ( strDriverName, iInDevIdx, iOutDevIdx ) )
     {
         return tr ( "The currently selected audio device is no longer present. Please check your audio device." );
     }
 
-    // check device capabilities if it fulfills our requirements
-    const QString strStat = CheckDeviceCapabilities ( iDriverIdx );
+    // check device capabilities if they fulfill our requirements
+    QString strStat = CheckInputDeviceCapabilities ( iInDevIdx );
 
-    // check if device is capable and if not the same device is used
-    if ( strStat.isEmpty() && ( strCurDevName.compare ( strDriverNames[iDriverIdx] ) != 0 ) )
+    if ( strStat.isEmpty() )
     {
-        AudioObjectPropertyAddress stPropertyAddress;
+        strStat = CheckOutputDeviceCapabilities ( iOutDevIdx );
+    }
 
-        // unregister callbacks if previous device was valid
-        if ( lCurDev != INVALID_INDEX )
-        {
-            stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
-            stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
-
-            // unregister callback functions for device property changes
-            stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-
-            AudioObjectRemovePropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-            stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
-
-            AudioObjectRemovePropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-            stPropertyAddress.mSelector = kAudioDevicePropertyDeviceHasChanged;
-
-            AudioObjectRemovePropertyListener ( audioOutputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-            AudioObjectRemovePropertyListener ( audioInputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-            stPropertyAddress.mSelector = kAudioDevicePropertyDeviceIsAlive;
-
-            AudioObjectRemovePropertyListener ( audioOutputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-            AudioObjectRemovePropertyListener ( audioInputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-        }
-
-        // store ID of selected driver if initialization was successful
-        lCurDev                    = iDriverIdx;
-        CurrentAudioInputDeviceID  = audioInputDevice[iDriverIdx];
-        CurrentAudioOutputDeviceID = audioOutputDevice[iDriverIdx];
-
-        // register callbacks
-        stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
-        stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
-
-        // setup callbacks for device property changes
-        stPropertyAddress.mSelector = kAudioDevicePropertyDeviceHasChanged;
-
-        AudioObjectAddPropertyListener ( audioInputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-        AudioObjectAddPropertyListener ( audioOutputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-        stPropertyAddress.mSelector = kAudioDevicePropertyDeviceIsAlive;
-
-        AudioObjectAddPropertyListener ( audioInputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-        AudioObjectAddPropertyListener ( audioOutputDevice[lCurDev], &stPropertyAddress, deviceNotification, this );
-
-        stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-
-        AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-        stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
-
-        AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-        // the device has changed, per definition we reset the channel
-        // mapping to the defaults (first two available channels)
-        SetLeftInputChannel ( 0 );
-        SetRightInputChannel ( 1 );
-        SetLeftOutputChannel ( 0 );
-        SetRightOutputChannel ( 1 );
-
-        // store the current name of the driver
-        strCurDevName = strDriverNames[iDriverIdx];
+    if ( strStat.isEmpty() )
+    {
+        ApplyDeviceSelection ( iInDevIdx, iOutDevIdx );
     }
 
     return strStat;
 }
 
-QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
+QVector<CDriverInitError> CSound::LoadAndInitializeFirstValidDriver ( const bool )
+{
+    // secure device list access
+    QMutexLocker locker ( &Mutex );
+
+    // reload the list of available sound devices
+    GetAvailableInOutDevices();
+
+    // since the input and the output device are independent of each other, we
+    // can search for a usable device per direction instead of trying all
+    // possible combinations
+    QVector<CDriverInitError> vErrorList;
+
+    int iValidInDevIdx  = INVALID_INDEX;
+    int iValidOutDevIdx = INVALID_INDEX;
+
+    for ( int iInDevIdx = 0; ( iInDevIdx < lNumInDevs ) && ( iValidInDevIdx == INVALID_INDEX ); iInDevIdx++ )
+    {
+        const QString strCurError = CheckInputDeviceCapabilities ( iInDevIdx );
+
+        if ( strCurError.isEmpty() )
+        {
+            iValidInDevIdx = iInDevIdx;
+        }
+        else
+        {
+            vErrorList.append ( CDriverInitError ( strInputDeviceNames[iInDevIdx], strCurError ) );
+        }
+    }
+
+    for ( int iOutDevIdx = 0; ( iOutDevIdx < lNumOutDevs ) && ( iValidOutDevIdx == INVALID_INDEX ); iOutDevIdx++ )
+    {
+        const QString strCurError = CheckOutputDeviceCapabilities ( iOutDevIdx );
+
+        if ( strCurError.isEmpty() )
+        {
+            iValidOutDevIdx = iOutDevIdx;
+        }
+        else
+        {
+            vErrorList.append ( CDriverInitError ( strOutputDeviceNames[iOutDevIdx], strCurError ) );
+        }
+    }
+
+    if ( ( iValidInDevIdx != INVALID_INDEX ) && ( iValidOutDevIdx != INVALID_INDEX ) )
+    {
+        ApplyDeviceSelection ( iValidInDevIdx, iValidOutDevIdx );
+
+        // empty error list shows that init was successful
+        vErrorList.clear();
+    }
+
+    return vErrorList;
+}
+
+void CSound::ApplyDeviceSelection ( const int iInDevIdx, const int iOutDevIdx )
+{
+    const QString strNewDevName = ComposeDevName ( strInputDeviceNames[iInDevIdx], strOutputDeviceNames[iOutDevIdx] );
+
+    // nothing to do if the selected devices are already in use
+    if ( strCurDevName.compare ( strNewDevName ) == 0 )
+    {
+        return;
+    }
+
+    AudioObjectPropertyAddress stPropertyAddress;
+
+    stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
+    stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
+
+    // unregister the callback functions if devices were already selected (a
+    // device ID of zero means that no device was registered so far)
+    if ( CurrentAudioInputDeviceID != 0 )
+    {
+        stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+
+        AudioObjectRemovePropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
+
+        stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
+
+        AudioObjectRemovePropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
+
+        stPropertyAddress.mSelector = kAudioDevicePropertyDeviceHasChanged;
+
+        AudioObjectRemovePropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+        AudioObjectRemovePropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+        stPropertyAddress.mSelector = kAudioDevicePropertyDeviceIsAlive;
+
+        AudioObjectRemovePropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+        AudioObjectRemovePropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
+    }
+
+    // store the selected devices
+    CurrentAudioInputDeviceID  = audioInputDevice[iInDevIdx];
+    CurrentAudioOutputDeviceID = audioOutputDevice[iOutDevIdx];
+    strCurInDevName            = strInputDeviceNames[iInDevIdx];
+    strCurOutDevName           = strOutputDeviceNames[iOutDevIdx];
+    strCurDevName              = strNewDevName;
+
+    // setup callbacks for device property changes
+    stPropertyAddress.mSelector = kAudioDevicePropertyDeviceHasChanged;
+
+    AudioObjectAddPropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+    AudioObjectAddPropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+    stPropertyAddress.mSelector = kAudioDevicePropertyDeviceIsAlive;
+
+    AudioObjectAddPropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+    AudioObjectAddPropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
+
+    stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+
+    AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
+
+    stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
+
+    AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
+
+    // the device has changed, per definition we reset the channel
+    // mapping to the defaults (first two available channels)
+    SetLeftInputChannel ( 0 );
+    SetRightInputChannel ( 1 );
+    SetLeftOutputChannel ( 0 );
+    SetRightOutputChannel ( 1 );
+}
+
+QString CSound::CheckInputDeviceCapabilities ( const int iInDevIdx )
 {
     UInt32                      iPropertySize;
     AudioStreamBasicDescription CurDevStreamFormat;
     Float64                     inputSampleRate   = 0;
-    Float64                     outputSampleRate  = 0;
     const Float64               fSystemSampleRate = static_cast<Float64> ( SYSTEM_SAMPLE_RATE_HZ );
     AudioObjectPropertyAddress  stPropertyAddress;
+
+    const AudioDeviceID InputDeviceID = audioInputDevice[iInDevIdx];
 
     stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
     stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
@@ -398,7 +574,7 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
     stPropertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
     iPropertySize               = sizeof ( Float64 );
 
-    if ( AudioObjectGetPropertyData ( audioInputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize, &inputSampleRate ) )
+    if ( AudioObjectGetPropertyData ( InputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize, &inputSampleRate ) )
     {
         return QString ( tr ( "The audio input device is no longer available. Please check if your input device is connected correctly." ) );
     }
@@ -406,31 +582,9 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
     if ( inputSampleRate != fSystemSampleRate )
     {
         // try to change the sample rate
-        if ( AudioObjectSetPropertyData ( audioInputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, sizeof ( Float64 ), &fSystemSampleRate ) !=
-             noErr )
+        if ( AudioObjectSetPropertyData ( InputDeviceID, &stPropertyAddress, 0, NULL, sizeof ( Float64 ), &fSystemSampleRate ) != noErr )
         {
             return QString ( tr ( "The sample rate on the current input device isn't %1 Hz and is therefore incompatible. "
-                                  "Please select another device or try setting the sample rate to %1 Hz "
-                                  "manually via Audio-MIDI-Setup (in Applications->Utilities)." ) )
-                .arg ( SYSTEM_SAMPLE_RATE_HZ );
-        }
-    }
-
-    // check output device sample rate
-    iPropertySize = sizeof ( Float64 );
-
-    if ( AudioObjectGetPropertyData ( audioOutputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize, &outputSampleRate ) )
-    {
-        return QString ( tr ( "The audio output device is no longer available. Please check if your output device is connected correctly." ) );
-    }
-
-    if ( outputSampleRate != fSystemSampleRate )
-    {
-        // try to change the sample rate
-        if ( AudioObjectSetPropertyData ( audioOutputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, sizeof ( Float64 ), &fSystemSampleRate ) !=
-             noErr )
-        {
-            return QString ( tr ( "The sample rate on the current output device isn't %1 Hz and is therefore incompatible. "
                                   "Please select another device or try setting the sample rate to %1 Hz "
                                   "manually via Audio-MIDI-Setup (in Applications->Utilities)." ) )
                 .arg ( SYSTEM_SAMPLE_RATE_HZ );
@@ -442,32 +596,18 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
     stPropertyAddress.mSelector = kAudioDevicePropertyStreams;
     stPropertyAddress.mScope    = kAudioObjectPropertyScopeInput;
 
-    AudioObjectGetPropertyDataSize ( audioInputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize );
+    AudioObjectGetPropertyDataSize ( InputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize );
 
     CVector<AudioStreamID> vInputStreamIDList ( iPropertySize );
 
-    AudioObjectGetPropertyData ( audioInputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize, &vInputStreamIDList[0] );
+    AudioObjectGetPropertyData ( InputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize, &vInputStreamIDList[0] );
 
     const AudioStreamID inputStreamID = vInputStreamIDList[0];
-
-    // get the stream ID of the output device (at least one stream must always exist)
-    iPropertySize               = 0;
-    stPropertyAddress.mSelector = kAudioDevicePropertyStreams;
-    stPropertyAddress.mScope    = kAudioObjectPropertyScopeOutput;
-
-    AudioObjectGetPropertyDataSize ( audioOutputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize );
-
-    CVector<AudioStreamID> vOutputStreamIDList ( iPropertySize );
-
-    AudioObjectGetPropertyData ( audioOutputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize, &vOutputStreamIDList[0] );
-
-    const AudioStreamID outputStreamID = vOutputStreamIDList[0];
 
     // According to the AudioHardware documentation: "If the format is a linear PCM
     // format, the data will always be presented as 32 bit, native endian floating
     // point. All conversions to and from the true physical format of the hardware
     // is handled by the devices driver.".
-    // check the input
     iPropertySize               = sizeof ( AudioStreamBasicDescription );
     stPropertyAddress.mSelector = kAudioStreamPropertyVirtualFormat;
     stPropertyAddress.mScope    = kAudioObjectPropertyScopeGlobal;
@@ -482,30 +622,13 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
                               "compatible with this software. Please select another device." ) );
     }
 
-    // check the output
-    AudioObjectGetPropertyData ( outputStreamID, &stPropertyAddress, 0, NULL, &iPropertySize, &CurDevStreamFormat );
+    // store the number of input channels for this device
+    iNumInChan = CountChannels ( InputDeviceID, true );
 
-    if ( ( CurDevStreamFormat.mFormatID != kAudioFormatLinearPCM ) || ( CurDevStreamFormat.mFramesPerPacket != 1 ) ||
-         ( CurDevStreamFormat.mBitsPerChannel != 32 ) || ( !( CurDevStreamFormat.mFormatFlags & kAudioFormatFlagIsFloat ) ) ||
-         ( !( CurDevStreamFormat.mFormatFlags & kAudioFormatFlagIsPacked ) ) )
-    {
-        return QString ( tr ( "The stream format on the current output device isn't "
-                              "compatible with %1. Please select another device." ) )
-            .arg ( APP_NAME );
-    }
-
-    // store the input and out number of channels for this device
-    iNumInChan  = CountChannels ( audioInputDevice[iDriverIdx], true );
-    iNumOutChan = CountChannels ( audioOutputDevice[iDriverIdx], false );
-
-    // clip the number of input/output channels to our allowed maximum
+    // clip the number of input channels to our allowed maximum
     if ( iNumInChan > MAX_NUM_IN_OUT_CHANNELS )
     {
         iNumInChan = MAX_NUM_IN_OUT_CHANNELS;
-    }
-    if ( iNumOutChan > MAX_NUM_IN_OUT_CHANNELS )
-    {
-        iNumOutChan = MAX_NUM_IN_OUT_CHANNELS;
     }
 
     // get the channel names of the input device
@@ -518,7 +641,7 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
         stPropertyAddress.mScope    = kAudioObjectPropertyScopeInput;
         iPropertySize               = sizeof ( CFStringRef );
 
-        AudioObjectGetPropertyData ( audioInputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize, &sPropertyStringValue );
+        AudioObjectGetPropertyData ( InputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize, &sPropertyStringValue );
 
         // convert string
         const bool bConvOK = ConvertCFStringToQString ( sPropertyStringValue, sChannelNamesInput[iCurInCH] );
@@ -532,33 +655,6 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
         else
         {
             sChannelNamesInput[iCurInCH].prepend ( QString ( "%1: " ).arg ( iCurInCH + 1 ) );
-        }
-    }
-
-    // get the channel names of the output device
-    for ( int iCurOutCH = 0; iCurOutCH < iNumOutChan; iCurOutCH++ )
-    {
-        CFStringRef sPropertyStringValue = NULL;
-
-        stPropertyAddress.mSelector = kAudioObjectPropertyElementName;
-        stPropertyAddress.mElement  = iCurOutCH + 1;
-        stPropertyAddress.mScope    = kAudioObjectPropertyScopeOutput;
-        iPropertySize               = sizeof ( CFStringRef );
-
-        AudioObjectGetPropertyData ( audioOutputDevice[iDriverIdx], &stPropertyAddress, 0, NULL, &iPropertySize, &sPropertyStringValue );
-
-        // convert string
-        const bool bConvOK = ConvertCFStringToQString ( sPropertyStringValue, sChannelNamesOutput[iCurOutCH] );
-
-        // add the "[n]:" at the beginning as is in the Audio-Midi-Setup
-        if ( !bConvOK || ( iPropertySize == 0 ) )
-        {
-            // use a default name in case there was an error or the name is empty
-            sChannelNamesOutput[iCurOutCH] = QString ( "%1: Channel %1" ).arg ( iCurOutCH + 1 );
-        }
-        else
-        {
-            sChannelNamesOutput[iCurOutCH].prepend ( QString ( "%1: " ).arg ( iCurOutCH + 1 ) );
         }
     }
 
@@ -585,6 +681,109 @@ QString CSound::CheckDeviceCapabilities ( const int iDriverIdx )
     {
         // regular case: no mixing input channels used
         iNumInChanPlusAddChan = iNumInChan;
+    }
+
+    // everything is ok, return empty string for "no error" case
+    return "";
+}
+
+QString CSound::CheckOutputDeviceCapabilities ( const int iOutDevIdx )
+{
+    UInt32                      iPropertySize;
+    AudioStreamBasicDescription CurDevStreamFormat;
+    Float64                     outputSampleRate  = 0;
+    const Float64               fSystemSampleRate = static_cast<Float64> ( SYSTEM_SAMPLE_RATE_HZ );
+    AudioObjectPropertyAddress  stPropertyAddress;
+
+    const AudioDeviceID OutputDeviceID = audioOutputDevice[iOutDevIdx];
+
+    stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
+    stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
+
+    // check output device sample rate
+    stPropertyAddress.mSelector = kAudioDevicePropertyNominalSampleRate;
+    iPropertySize               = sizeof ( Float64 );
+
+    if ( AudioObjectGetPropertyData ( OutputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize, &outputSampleRate ) )
+    {
+        return QString ( tr ( "The audio output device is no longer available. Please check if your output device is connected correctly." ) );
+    }
+
+    if ( outputSampleRate != fSystemSampleRate )
+    {
+        // try to change the sample rate
+        if ( AudioObjectSetPropertyData ( OutputDeviceID, &stPropertyAddress, 0, NULL, sizeof ( Float64 ), &fSystemSampleRate ) != noErr )
+        {
+            return QString ( tr ( "The sample rate on the current output device isn't %1 Hz and is therefore incompatible. "
+                                  "Please select another device or try setting the sample rate to %1 Hz "
+                                  "manually via Audio-MIDI-Setup (in Applications->Utilities)." ) )
+                .arg ( SYSTEM_SAMPLE_RATE_HZ );
+        }
+    }
+
+    // get the stream ID of the output device (at least one stream must always exist)
+    iPropertySize               = 0;
+    stPropertyAddress.mSelector = kAudioDevicePropertyStreams;
+    stPropertyAddress.mScope    = kAudioObjectPropertyScopeOutput;
+
+    AudioObjectGetPropertyDataSize ( OutputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize );
+
+    CVector<AudioStreamID> vOutputStreamIDList ( iPropertySize );
+
+    AudioObjectGetPropertyData ( OutputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize, &vOutputStreamIDList[0] );
+
+    const AudioStreamID outputStreamID = vOutputStreamIDList[0];
+
+    // check the stream format (see the comment in CheckInputDeviceCapabilities())
+    iPropertySize               = sizeof ( AudioStreamBasicDescription );
+    stPropertyAddress.mSelector = kAudioStreamPropertyVirtualFormat;
+    stPropertyAddress.mScope    = kAudioObjectPropertyScopeGlobal;
+
+    AudioObjectGetPropertyData ( outputStreamID, &stPropertyAddress, 0, NULL, &iPropertySize, &CurDevStreamFormat );
+
+    if ( ( CurDevStreamFormat.mFormatID != kAudioFormatLinearPCM ) || ( CurDevStreamFormat.mFramesPerPacket != 1 ) ||
+         ( CurDevStreamFormat.mBitsPerChannel != 32 ) || ( !( CurDevStreamFormat.mFormatFlags & kAudioFormatFlagIsFloat ) ) ||
+         ( !( CurDevStreamFormat.mFormatFlags & kAudioFormatFlagIsPacked ) ) )
+    {
+        return QString ( tr ( "The stream format on the current output device isn't "
+                              "compatible with %1. Please select another device." ) )
+            .arg ( APP_NAME );
+    }
+
+    // store the number of output channels for this device
+    iNumOutChan = CountChannels ( OutputDeviceID, false );
+
+    // clip the number of output channels to our allowed maximum
+    if ( iNumOutChan > MAX_NUM_IN_OUT_CHANNELS )
+    {
+        iNumOutChan = MAX_NUM_IN_OUT_CHANNELS;
+    }
+
+    // get the channel names of the output device
+    for ( int iCurOutCH = 0; iCurOutCH < iNumOutChan; iCurOutCH++ )
+    {
+        CFStringRef sPropertyStringValue = NULL;
+
+        stPropertyAddress.mSelector = kAudioObjectPropertyElementName;
+        stPropertyAddress.mElement  = iCurOutCH + 1;
+        stPropertyAddress.mScope    = kAudioObjectPropertyScopeOutput;
+        iPropertySize               = sizeof ( CFStringRef );
+
+        AudioObjectGetPropertyData ( OutputDeviceID, &stPropertyAddress, 0, NULL, &iPropertySize, &sPropertyStringValue );
+
+        // convert string
+        const bool bConvOK = ConvertCFStringToQString ( sPropertyStringValue, sChannelNamesOutput[iCurOutCH] );
+
+        // add the "[n]:" at the beginning as is in the Audio-Midi-Setup
+        if ( !bConvOK || ( iPropertySize == 0 ) )
+        {
+            // use a default name in case there was an error or the name is empty
+            sChannelNamesOutput[iCurOutCH] = QString ( "%1: Channel %1" ).arg ( iCurOutCH + 1 );
+        }
+        else
+        {
+            sChannelNamesOutput[iCurOutCH].prepend ( QString ( "%1: " ).arg ( iCurOutCH + 1 ) );
+        }
     }
 
     // everything is ok, return empty string for "no error" case
@@ -710,13 +909,13 @@ void CSound::SetRightOutputChannel ( const int iNewChan )
 void CSound::Start()
 {
     // register the callback function for input and output
-    AudioDeviceCreateIOProcID ( audioInputDevice[lCurDev], callbackIO, this, &audioInputProcID );
+    AudioDeviceCreateIOProcID ( CurrentAudioInputDeviceID, callbackIO, this, &audioInputProcID );
 
-    AudioDeviceCreateIOProcID ( audioOutputDevice[lCurDev], callbackIO, this, &audioOutputProcID );
+    AudioDeviceCreateIOProcID ( CurrentAudioOutputDeviceID, callbackIO, this, &audioOutputProcID );
 
     // start the audio stream
-    AudioDeviceStart ( audioInputDevice[lCurDev], audioInputProcID );
-    AudioDeviceStart ( audioOutputDevice[lCurDev], audioOutputProcID );
+    AudioDeviceStart ( CurrentAudioInputDeviceID, audioInputProcID );
+    AudioDeviceStart ( CurrentAudioOutputDeviceID, audioOutputProcID );
 
     // call base class
     CSoundBase::Start();
@@ -725,12 +924,12 @@ void CSound::Start()
 void CSound::Stop()
 {
     // stop the audio stream
-    AudioDeviceStop ( audioInputDevice[lCurDev], audioInputProcID );
-    AudioDeviceStop ( audioOutputDevice[lCurDev], audioOutputProcID );
+    AudioDeviceStop ( CurrentAudioInputDeviceID, audioInputProcID );
+    AudioDeviceStop ( CurrentAudioOutputDeviceID, audioOutputProcID );
 
     // unregister the callback function for input and output
-    AudioDeviceDestroyIOProcID ( audioInputDevice[lCurDev], audioInputProcID );
-    AudioDeviceDestroyIOProcID ( audioOutputDevice[lCurDev], audioOutputProcID );
+    AudioDeviceDestroyIOProcID ( CurrentAudioInputDeviceID, audioInputProcID );
+    AudioDeviceDestroyIOProcID ( CurrentAudioOutputDeviceID, audioOutputProcID );
 
     // call base class
     CSoundBase::Stop();
@@ -906,13 +1105,13 @@ int CSound::Init ( const int iNewPrefMonoBufferSize )
                                        "select different input/output devices in your system settings." );
 
     // try to set input buffer size
-    iActualMonoBufferSize = SetBufferSize ( audioInputDevice[lCurDev], true, iNewPrefMonoBufferSize );
+    iActualMonoBufferSize = SetBufferSize ( CurrentAudioInputDeviceID, true, iNewPrefMonoBufferSize );
 
     if ( iActualMonoBufferSize != static_cast<UInt32> ( iNewPrefMonoBufferSize ) )
     {
         // try to set the input buffer size to the output so that we
         // have a matching pair
-        if ( SetBufferSize ( audioOutputDevice[lCurDev], false, iActualMonoBufferSize ) != iActualMonoBufferSize )
+        if ( SetBufferSize ( CurrentAudioOutputDeviceID, false, iActualMonoBufferSize ) != iActualMonoBufferSize )
         {
             throw CGenErr ( strErrBufSize );
         }
@@ -920,7 +1119,7 @@ int CSound::Init ( const int iNewPrefMonoBufferSize )
     else
     {
         // try to set output buffer size
-        if ( SetBufferSize ( audioOutputDevice[lCurDev], false, iNewPrefMonoBufferSize ) != static_cast<UInt32> ( iNewPrefMonoBufferSize ) )
+        if ( SetBufferSize ( CurrentAudioOutputDeviceID, false, iNewPrefMonoBufferSize ) != static_cast<UInt32> ( iNewPrefMonoBufferSize ) )
         {
             throw CGenErr ( strErrBufSize );
         }

--- a/src/sound/coreaudio-mac/sound.cpp
+++ b/src/sound/coreaudio-mac/sound.cpp
@@ -512,10 +512,16 @@ void CSound::ApplyDeviceSelection ( const int iInDevIdx, const int iOutDevIdx )
     const AudioDeviceID OldAudioInputDeviceID  = CurrentAudioInputDeviceID;
     const AudioDeviceID OldAudioOutputDeviceID = CurrentAudioOutputDeviceID;
 
-    const bool bInDevChanged  = ( strCurInDevName.compare ( strInputDeviceNames[iInDevIdx] ) != 0 );
-    const bool bOutDevChanged = ( strCurOutDevName.compare ( strOutputDeviceNames[iOutDevIdx] ) != 0 );
+    // compare the device IDs and not the device names: the device behind an
+    // entry can change while its name stays the same, i.e. for the system
+    // default entry when the driver is reloaded after the default device was
+    // changed in macOS
+    const bool bInDevChanged  = ( NewAudioInputDeviceID != OldAudioInputDeviceID );
+    const bool bOutDevChanged = ( NewAudioOutputDeviceID != OldAudioOutputDeviceID );
 
-    // store the names of the selected devices
+    // store the names of the selected devices in any case since the same device
+    // may now be addressed by another entry (i.e. by its name instead of by the
+    // system default entry)
     strCurInDevName  = strInputDeviceNames[iInDevIdx];
     strCurOutDevName = strOutputDeviceNames[iOutDevIdx];
     strCurDevName    = ComposeDevName ( strCurInDevName, strCurOutDevName );

--- a/src/sound/coreaudio-mac/sound.cpp
+++ b/src/sound/coreaudio-mac/sound.cpp
@@ -481,80 +481,113 @@ QVector<CDriverInitError> CSound::LoadAndInitializeFirstValidDriver ( const bool
     return vErrorList;
 }
 
-void CSound::ApplyDeviceSelection ( const int iInDevIdx, const int iOutDevIdx )
+void CSound::SetDeviceNotifications ( const AudioDeviceID DeviceID, const bool bEnable )
 {
-    const QString strNewDevName = ComposeDevName ( strInputDeviceNames[iInDevIdx], strOutputDeviceNames[iOutDevIdx] );
-
-    // nothing to do if the selected devices are already in use
-    if ( strCurDevName.compare ( strNewDevName ) == 0 )
-    {
-        return;
-    }
-
     AudioObjectPropertyAddress stPropertyAddress;
 
     stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
     stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
 
-    // unregister the callback functions if devices were already selected (a
-    // device ID of zero means that no device was registered so far)
-    if ( CurrentAudioInputDeviceID != 0 )
+    const AudioObjectPropertySelector aSelectors[] = { kAudioDevicePropertyDeviceHasChanged, kAudioDevicePropertyDeviceIsAlive };
+
+    for ( const AudioObjectPropertySelector eSelector : aSelectors )
     {
+        stPropertyAddress.mSelector = eSelector;
+
+        if ( bEnable )
+        {
+            AudioObjectAddPropertyListener ( DeviceID, &stPropertyAddress, deviceNotification, this );
+        }
+        else
+        {
+            AudioObjectRemovePropertyListener ( DeviceID, &stPropertyAddress, deviceNotification, this );
+        }
+    }
+}
+
+void CSound::ApplyDeviceSelection ( const int iInDevIdx, const int iOutDevIdx )
+{
+    const AudioDeviceID NewAudioInputDeviceID  = audioInputDevice[iInDevIdx];
+    const AudioDeviceID NewAudioOutputDeviceID = audioOutputDevice[iOutDevIdx];
+    const AudioDeviceID OldAudioInputDeviceID  = CurrentAudioInputDeviceID;
+    const AudioDeviceID OldAudioOutputDeviceID = CurrentAudioOutputDeviceID;
+
+    const bool bInDevChanged  = ( strCurInDevName.compare ( strInputDeviceNames[iInDevIdx] ) != 0 );
+    const bool bOutDevChanged = ( strCurOutDevName.compare ( strOutputDeviceNames[iOutDevIdx] ) != 0 );
+
+    // store the names of the selected devices
+    strCurInDevName  = strInputDeviceNames[iInDevIdx];
+    strCurOutDevName = strOutputDeviceNames[iOutDevIdx];
+    strCurDevName    = ComposeDevName ( strCurInDevName, strCurOutDevName );
+
+    if ( !bInDevChanged && !bOutDevChanged )
+    {
+        // nothing else to do since the notifications are already registered
+        return;
+    }
+
+    // the system default device notifications only have to be registered once
+    const bool bRegisterSystemNotifications = ( OldAudioInputDeviceID == 0 ) && ( OldAudioOutputDeviceID == 0 );
+
+    // store IDs of the selected devices
+    CurrentAudioInputDeviceID  = NewAudioInputDeviceID;
+    CurrentAudioOutputDeviceID = NewAudioOutputDeviceID;
+
+    // One device can serve both directions, in which case CoreAudio keeps one
+    // single registration for it. The notifications are therefore managed per
+    // device ID: they are only removed from a device which is no longer used by
+    // either direction and only added to a device which was not in use before.
+    if ( ( OldAudioInputDeviceID != 0 ) && ( OldAudioInputDeviceID != NewAudioInputDeviceID ) && ( OldAudioInputDeviceID != NewAudioOutputDeviceID ) )
+    {
+        SetDeviceNotifications ( OldAudioInputDeviceID, false );
+    }
+
+    if ( ( OldAudioOutputDeviceID != 0 ) && ( OldAudioOutputDeviceID != OldAudioInputDeviceID ) &&
+         ( OldAudioOutputDeviceID != NewAudioInputDeviceID ) && ( OldAudioOutputDeviceID != NewAudioOutputDeviceID ) )
+    {
+        SetDeviceNotifications ( OldAudioOutputDeviceID, false );
+    }
+
+    if ( ( NewAudioInputDeviceID != OldAudioInputDeviceID ) && ( NewAudioInputDeviceID != OldAudioOutputDeviceID ) )
+    {
+        SetDeviceNotifications ( NewAudioInputDeviceID, true );
+    }
+
+    if ( ( NewAudioOutputDeviceID != NewAudioInputDeviceID ) && ( NewAudioOutputDeviceID != OldAudioInputDeviceID ) &&
+         ( NewAudioOutputDeviceID != OldAudioOutputDeviceID ) )
+    {
+        SetDeviceNotifications ( NewAudioOutputDeviceID, true );
+    }
+
+    if ( bRegisterSystemNotifications )
+    {
+        AudioObjectPropertyAddress stPropertyAddress;
+
+        stPropertyAddress.mElement = kAudioObjectPropertyElementMaster;
+        stPropertyAddress.mScope   = kAudioObjectPropertyScopeGlobal;
+
         stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
 
-        AudioObjectRemovePropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
+        AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
 
         stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
 
-        AudioObjectRemovePropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-        stPropertyAddress.mSelector = kAudioDevicePropertyDeviceHasChanged;
-
-        AudioObjectRemovePropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-        AudioObjectRemovePropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-        stPropertyAddress.mSelector = kAudioDevicePropertyDeviceIsAlive;
-
-        AudioObjectRemovePropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-        AudioObjectRemovePropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
+        AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
     }
 
-    // store the selected devices
-    CurrentAudioInputDeviceID  = audioInputDevice[iInDevIdx];
-    CurrentAudioOutputDeviceID = audioOutputDevice[iOutDevIdx];
-    strCurInDevName            = strInputDeviceNames[iInDevIdx];
-    strCurOutDevName           = strOutputDeviceNames[iOutDevIdx];
-    strCurDevName              = strNewDevName;
+    // a device has changed, per definition we reset the channel mapping of that
+    // direction to the defaults (first two available channels)
+    if ( bInDevChanged )
+    {
+        SetLeftInputChannel ( 0 );
+        SetRightInputChannel ( 1 );
+    }
 
-    // setup callbacks for device property changes
-    stPropertyAddress.mSelector = kAudioDevicePropertyDeviceHasChanged;
-
-    AudioObjectAddPropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-    AudioObjectAddPropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-    stPropertyAddress.mSelector = kAudioDevicePropertyDeviceIsAlive;
-
-    AudioObjectAddPropertyListener ( CurrentAudioInputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-    AudioObjectAddPropertyListener ( CurrentAudioOutputDeviceID, &stPropertyAddress, deviceNotification, this );
-
-    stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-
-    AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-    stPropertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
-
-    AudioObjectAddPropertyListener ( kAudioObjectSystemObject, &stPropertyAddress, deviceNotification, this );
-
-    // the device has changed, per definition we reset the channel
-    // mapping to the defaults (first two available channels)
-    SetLeftInputChannel ( 0 );
-    SetRightInputChannel ( 1 );
-    SetLeftOutputChannel ( 0 );
-    SetRightOutputChannel ( 1 );
+    if ( bOutDevChanged )
+    {
+        SetLeftOutputChannel ( 0 );
+        SetRightOutputChannel ( 1 );
+    }
 }
 
 QString CSound::CheckInputDeviceCapabilities ( const int iInDevIdx )

--- a/src/sound/coreaudio-mac/sound.h
+++ b/src/sound/coreaudio-mac/sound.h
@@ -82,6 +82,15 @@ public:
     virtual int     GetLeftOutputChannel() override { return iSelOutputLeftChannel; }
     virtual int     GetRightOutputChannel() override { return iSelOutputRightChannel; }
 
+    // CoreAudio manages the input and the output device separately, therefore we
+    // offer one device list per direction instead of all possible combinations
+    virtual bool        IsInOutDevSelectionSeparate() const override { return true; }
+    virtual QStringList GetInputDevNames() override;
+    virtual QStringList GetOutputDevNames() override;
+    virtual QString     GetInputDev() override;
+    virtual QString     GetOutputDev() override;
+    virtual QString     SetInOutDev ( const QString& strInDevName, const QString& strOutDevName ) override;
+
     // MIDI functions
     virtual void        EnableMIDI ( const bool bEnable ) override;
     virtual bool        IsMIDIEnabled() const override;
@@ -94,7 +103,6 @@ public:
     int            iCoreAudioBufferSizeStereo;
     AudioDeviceID  CurrentAudioInputDeviceID;
     AudioDeviceID  CurrentAudioOutputDeviceID;
-    long           lCurDev;
     int            iNumInChan;
     int            iNumInChanPlusAddChan; // includes additional "added" channels
     int            iNumOutChan;
@@ -118,11 +126,20 @@ public:
     CVector<int>   vecNumOutBufChan;
 
 protected:
-    virtual QString LoadAndInitializeDriver ( QString strDriverName, bool ) override;
+    virtual QString                   LoadAndInitializeDriver ( QString strDriverName, bool ) override;
+    virtual QVector<CDriverInitError> LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup = false ) override;
 
-    QString CheckDeviceCapabilities ( const int iDriverIdx );
+    QString CheckInputDeviceCapabilities ( const int iInDevIdx );
+    QString CheckOutputDeviceCapabilities ( const int iOutDevIdx );
+    void    ApplyDeviceSelection ( const int iInDevIdx, const int iOutDevIdx );
     void    UpdateChSelection();
     void    GetAvailableInOutDevices();
+
+    // the input and the output device are selected separately but are stored in
+    // one single combined device name, see ComposeDevName()/SplitAndResolveDevName()
+    static QString ComposeDevName ( const QString& strInDevName, const QString& strOutDevName );
+    bool           SplitAndResolveDevName ( const QString& strDevName, int& iInDevIdx, int& iOutDevIdx ) const;
+    int            FindDevIdx ( const QString strDevNames[], const long lNumDevices, const QString& strDevName ) const;
 
     int CountChannels ( AudioDeviceID devID, bool isInput );
 
@@ -148,8 +165,20 @@ protected:
 
     static void callbackMIDI ( const MIDIPacketList* pktlist, void* refCon, void* );
 
-    AudioDeviceID       audioInputDevice[MAX_NUMBER_SOUND_CARDS];
-    AudioDeviceID       audioOutputDevice[MAX_NUMBER_SOUND_CARDS];
+    // available input and output devices (each list starts with the entry which
+    // follows the device selected as system default)
+    long          lNumInDevs;
+    long          lNumOutDevs;
+    QString       strInputDeviceNames[MAX_NUMBER_SOUND_CARDS];
+    QString       strOutputDeviceNames[MAX_NUMBER_SOUND_CARDS];
+    AudioDeviceID audioInputDevice[MAX_NUMBER_SOUND_CARDS];
+    AudioDeviceID audioOutputDevice[MAX_NUMBER_SOUND_CARDS];
+
+    // names of the currently selected devices (the combined name is stored in
+    // strCurDevName of the base class)
+    QString strCurInDevName;
+    QString strCurOutDevName;
+
     AudioDeviceIOProcID audioInputProcID;
     AudioDeviceIOProcID audioOutputProcID;
 

--- a/src/sound/coreaudio-mac/sound.h
+++ b/src/sound/coreaudio-mac/sound.h
@@ -132,6 +132,7 @@ protected:
     QString CheckInputDeviceCapabilities ( const int iInDevIdx );
     QString CheckOutputDeviceCapabilities ( const int iOutDevIdx );
     void    ApplyDeviceSelection ( const int iInDevIdx, const int iOutDevIdx );
+    void    SetDeviceNotifications ( const AudioDeviceID DeviceID, const bool bEnable );
     void    UpdateChSelection();
     void    GetAvailableInOutDevices();
 

--- a/src/sound/soundbase.cpp
+++ b/src/sound/soundbase.cpp
@@ -168,17 +168,17 @@ QString CSoundBase::SetDev ( const QString strDevName )
         }
 
         // try to load and initialize any valid driver
-        QVector<QString> vsErrorList = LoadAndInitializeFirstValidDriver();
+        QVector<CDriverInitError> vErrorList = LoadAndInitializeFirstValidDriver();
 
-        if ( !vsErrorList.isEmpty() )
+        if ( !vErrorList.isEmpty() )
         {
             // create error message with all details
             QString sErrorMessage =
                 tr ( "<b>%1 couldn't find a usable %2 audio device.</b><br><br>" ).arg ( APP_NAME ).arg ( strSystemDriverTechniqueName );
 
-            for ( int i = 0; i < lNumDevs; i++ )
+            for ( const CDriverInitError& DriverInitError : vErrorList )
             {
-                sErrorMessage += "<b>" + GetDeviceName ( i ) + "</b>: " + vsErrorList[i] + "<br><br>";
+                sErrorMessage += "<b>" + DriverInitError.strDevName + "</b>: " + DriverInitError.strError + "<br><br>";
             }
 
 #if defined( _WIN32 ) && !defined( WITH_JACK )
@@ -202,9 +202,9 @@ QString CSoundBase::SetDev ( const QString strDevName )
     return strReturn;
 }
 
-QVector<QString> CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup )
+QVector<CDriverInitError> CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup )
 {
-    QVector<QString> vsErrorList;
+    QVector<CDriverInitError> vErrorList;
 
     // load and initialize first valid ASIO driver
     bool bValidDriverDetected = false;
@@ -216,7 +216,7 @@ QVector<QString> CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpe
         // try to load and initialize current driver, store error message
         const QString strCurError = LoadAndInitializeDriver ( GetDeviceName ( iDriverCnt ), bOpenDriverSetup );
 
-        vsErrorList.append ( strCurError );
+        vErrorList.append ( CDriverInitError ( GetDeviceName ( iDriverCnt ), strCurError ) );
 
         if ( strCurError.isEmpty() )
         {
@@ -227,14 +227,14 @@ QVector<QString> CSoundBase::LoadAndInitializeFirstValidDriver ( const bool bOpe
             strCurDevName = GetDeviceName ( iDriverCnt );
 
             // empty error list shows that init was successful
-            vsErrorList.clear();
+            vErrorList.clear();
         }
 
         // try next driver
         iDriverCnt++;
     }
 
-    return vsErrorList;
+    return vErrorList;
 }
 
 /******************************************************************************\

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -119,6 +119,19 @@ public:
         return strCurDevName;
     }
 
+    // Separate input/output device selection: sound APIs which handle the input
+    // and the output device independently of each other (i.e. CoreAudio on macOS)
+    // return true here and offer one device list per direction. For all other
+    // APIs a device is a single entity and the combined list above is used.
+    // Note that even with separate lists the selected device is still identified
+    // by one single (combined) device name, see GetDev()/SetDev().
+    virtual bool        IsInOutDevSelectionSeparate() const { return false; }
+    virtual QStringList GetInputDevNames() { return QStringList(); }
+    virtual QStringList GetOutputDevNames() { return QStringList(); }
+    virtual QString     GetInputDev() { return QString(); }
+    virtual QString     GetOutputDev() { return QString(); }
+    virtual QString     SetInOutDev ( const QString& /* strInDevName */, const QString& /* strOutDevName */ ) { return QString(); }
+
     virtual int     GetNumInputChannels() { return 2; }
     virtual QString GetInputChannelName ( const int ) { return "Default"; }
     virtual void    SetLeftInputChannel ( const int ) {}

--- a/src/sound/soundbase.h
+++ b/src/sound/soundbase.h
@@ -84,6 +84,15 @@ public:
     int          iChannel;
 };
 
+// name of a device which could not be initialized together with the reason why
+class CDriverInitError
+{
+public:
+    CDriverInitError ( const QString& strNDevName = "", const QString& strNError = "" ) : strDevName ( strNDevName ), strError ( strNError ) {}
+    QString strDevName;
+    QString strError;
+};
+
 /* Classes ********************************************************************/
 class CSoundBase : public QThread
 {
@@ -157,11 +166,15 @@ public:
                                     int iMuteMyselfCC );
 
 protected:
-    virtual QString  LoadAndInitializeDriver ( QString, bool ) { return ""; }
-    virtual void     UnloadCurrentDriver() {}
-    QVector<QString> LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup = false );
-    void             ParseCommandLineArgument ( const QString& strMIDISetup );
-    QString          GetDeviceName ( const int iDiD ) { return strDriverNames[iDiD]; }
+    virtual QString LoadAndInitializeDriver ( QString, bool ) { return ""; }
+    virtual void    UnloadCurrentDriver() {}
+
+    // returns an empty list if a driver could be initialized, otherwise the
+    // error message of each driver which was tried
+    virtual QVector<CDriverInitError> LoadAndInitializeFirstValidDriver ( const bool bOpenDriverSetup = false );
+
+    void    ParseCommandLineArgument ( const QString& strMIDISetup );
+    QString GetDeviceName ( const int iDiD ) { return strDriverNames[iDiD]; }
 
     static void GetSelCHAndAddCH ( const int iSelCH, const int iNumInChan, int& iSelCHOut, int& iSelAddCHOut )
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -617,6 +617,7 @@ CAboutDlg::CAboutDlg ( QWidget* parent ) : CBaseDlg ( parent )
         "<p>Thai Pangsakulyanont (<a href=\"https://github.com/dtinth\">dtinth</a>)</p>"
         "<p>Peter Goderie (<a href=\"https://github.com/pgScorpio\">pgScorpio</a>)</p>"
         "<p>Dan Garton (<a href=\"https://github.com/danryu\">danryu</a>)</p>"
+        "<p>John Shipman (<a href=\"https://github.com/jshipman42\">jshipman42</a>)</p>"
         "<br>" +
         tr ( "For details on the contributions check out the %1" )
             .arg ( "<a href=\"https://github.com/jamulussoftware/jamulus/graphs/contributors\">" + tr ( "Github Contributors list" ) + "</a>." ) );


### PR DESCRIPTION
**Disclosure**

This change was implemented with Claude (Claude Code); the commits carry `Co-Authored-By: Claude Opus 5` trailers. I set the goal and the constraints, reviewed the result, and ran it against my own setup (12 input-capable and 15 output-capable CoreAudio devices) before opening this.

Before submitting, the diff went through several independent review passes by both Claude and Codex, and their findings were addressed in the commits where they originated. Noting it for transparency, not as a substitute for your review.

**Short description of changes**

Fixes the incomplete audio device list on macOS reported in #3216, by enumerating the input and output devices separately instead of listing every combination of the two.

The macOS device list contains one entry per *combination* of input and output device (`in: <input>/out: <output>`), which was a deliberate simplification so that a single combo box was enough:

```cpp
// we add combined entries for input and output for each device so that we
// do not need two combo boxes in the GUI for input and output (therefore
// all possible combinations are required which can be a large number)
```

The number of entries grows quadratically while the list is capped at `MAX_NUMBER_SOUND_CARDS`, so beyond roughly a dozen devices the enumeration stops early and the remaining combinations are silently absent from the combo box. This is the cause @softins identified in #3216:

> This prevents array out of bounds, but causes all the I/O combinations beyond this number just to be ignored.
> I agree a better solution would be setting In and Out devices separately, even if just for Mac.

On my machine (12 input-capable and 15 output-capable CoreAudio devices) the combined list needs 181 entries against the limit of 129. Split per direction, the two lists hold 13 and 16.

**Approach**

This follows what was agreed in #3216 — split selection on macOS, unchanged single-device selection everywhere else — with one deviation. @ann0see suggested an `#ifdef`:

> macOS/iOS (maybe also android) would show "device" -> new UI
> Everything else would show "Driver" -> current UI

I made it a runtime capability instead: `CSoundBase::IsInOutDevSelectionSeparate()` returns `false` by default, CoreAudio overrides it to `true`, and the settings dialog shows one form or the other accordingly. The GUI code stays single-source rather than split by platform, and iOS or a future WASAPI/portaudio backend (#821) can adopt the split by overriding one method. ASIO, JACK, oboe and iOS are untouched and keep the combined list and the single "Audio Device" combo box.

This is also the *"bigger refactoring with the sound card abstraction"* @ann0see anticipated in #3216, kept as small as it can be: the base class gains six virtuals that all default to no-op, and one existing method changes its return type to report a device name with each driver error.

**On `MAX_NUMBER_SOUND_CARDS`**

It stays at 129, and this PR removes the reason to raise it. @ann0see noted that bumping it *"could have performance implications"* — that concern is well founded. Building the combined list calls `GetAudioDeviceInfos()` for both devices of every pair, including the pairs it then discards, and the enumeration runs on every device change and dialog refresh. Measured by @mcfnord below, that is `12N² + 96` CoreAudio property queries against `6N + 96` after this change; on my 15 devices, 2796 against 186. (An earlier version of this description said ~360 against 27, which counted `GetAudioDeviceInfos()` calls over valid combinations rather than property queries, and understated the difference.)

The constant now bounds the devices per direction rather than the combinations, so it is no longer reachable in practice. Only its comment changes, because it documented the combination arithmetic (`// e.g. 16 inputs, 8 outputs + default entry`).

**Compatibility**

The selected device is still identified by one single combined name, so `auddev_base64` keeps its format and previously stored values — including the legacy `System Default In/Out Devices` entry — load unchanged. In the other direction there is one new case: selecting the system default for only one of the two directions produces a name an older version cannot resolve, in which case it warns and falls back to a valid device, exactly as it does for a device that has been unplugged.

**Scope**

Device selection only. The channel mapping, the `Audio Channels` setting and the mono/stereo handling proposed in the older discussion (#681, now https://github.com/orgs/jamulussoftware/discussions/1039) are deliberately not touched.

**Known limitation (pre-existing, not addressed here)**

Selecting the system default device for a direction does not follow a later change of the macOS default device. `deviceNotification()` maps `kAudioHardwarePropertyDefaultInputDevice`/`DefaultOutputDevice` to `RS_ONLY_RESTART`, and `CClient::OnSndCrdReinitRequest()` deliberately skips `Sound.SetDev()` for that reset type, so the driver is not reloaded and the previously resolved device stays in use until a reload happens for another reason. This behaves exactly as it did before this PR; changing it means changing the notification handling, which seemed better kept separate from a device-enumeration change. Happy to follow up if you would like it fixed.

**Commits**

Six, separable so they can be reviewed or taken independently. Two of them stand alone:

- *compare the device IDs when re-registering the notifications* — the check whether the selected device changed compared device *names*, but the device behind the `System Default` entry can change while its name does not. Reloading the driver then kept the previous device IDs, and since the IO callback compares the device it is called for against them, it would discard the audio of the device it had just been started on. This covers the reload paths only, see the limitation above.
- *only reset the channel mapping of the direction which changed* — this also keys the device notifications on the device ID rather than on the direction, because one device can serve both directions and CoreAudio then keeps a single registration for it.

The last commit adds the author to the in-app contributor list, as asked for in CONTRIBUTING.md; happy to drop it if you would rather it were separate.

CHANGELOG: macOS: Fixed audio devices missing from the device list, and split the device selection into separate input and output menus

**Context: Fixes an issue?**

Fixes: #3216

Earlier background: #681, moved to https://github.com/orgs/jamulussoftware/discussions/1039 in 2021.

**Does this change need documentation? What needs to be documented and how?**

Yes, a small update to the Software Manual: on macOS the "Audio Device" setting becomes two settings, "Input Device" and "Output Device". Happy to open a PR on the website repo if this is accepted.

**Status of this Pull Request**

Working implementation.

**What is missing until this pull request can be merged?**

Review, and testing on macOS setups other than mine. I have tested on macOS 26.5 / Qt 6.11 (arm64): selecting devices per direction, channel mapping preserved for the direction that did not change, settings written by the previous version loading unchanged, and the fallback when a stored device is no longer present. Every commit builds on its own.

@heepm — you reported #3216 and offered to help test; if you still have the aggregate-device setup from that thread, this would be the ideal case to confirm, since every device should now appear in the lists.

The other platforms are compile-tested only, through the `autobuild` workflow on my fork: Windows, Windows JACK, macOS, macOS Legacy, iOS, Android and Linux amd64/arm64/armhf all pass, including CodeQL. I have no ASIO or JACK hardware to confirm at runtime that those paths behave as before, though they are unchanged by design.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above

<!-- AUTOBUILD: Please build all targets -->
