### PR TITLE
AGENTS.md follow-up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Linux: `qmake && make` (use `qmake-qt5` on Fedora). Headless server: `qmake "CON
 
 macOS: `qmake QMAKE_APPLE_DEVICE_ARCHS=arm64 QT_ARCH=arm64 -spec macx-xcode Jamulus.pro` (Use `x86_64` on Intel Macs; `macx-clang` if using `make`). Then `xcodebuild build`, and `macdeployqt ./{Debug,Release}/Jamulus.app`.
 
-**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs the plain `qmake && make` build — a `serveronly` binary rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
+**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs `qmake && make` build ; `serveronly` rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
 
 ## Never Do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Linux: `qmake && make` (use `qmake-qt5` on Fedora). Headless server: `qmake "CON
 
 macOS: `qmake QMAKE_APPLE_DEVICE_ARCHS=arm64 QT_ARCH=arm64 -spec macx-xcode Jamulus.pro` (Use `x86_64` on Intel Macs; `macx-clang` if using `make`). Then `xcodebuild build`, and `macdeployqt ./{Debug,Release}/Jamulus.app`.
 
-**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
+**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs the plain `qmake && make` build — a `serveronly` binary rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
 
 ## Never Do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,10 @@ macOS: `qmake QMAKE_APPLE_DEVICE_ARCHS=arm64 QT_ARCH=arm64 -spec macx-xcode Jamu
 
 ## PR expectations
 
-- One logical change per PR — no unrelated cleanup or reformatting of untouched code. Discuss features in an issue before implementing. See `CONTRIBUTING.md`.
+- No unrelated cleanup or reformatting of untouched code. Discuss features in an issue before implementing.
 - Branch names starting with `autobuild` trigger CI builds on your fork.
 - Follow `.github/pull_request_template.md`. Include `CHANGELOG:` line. Add `AUTOBUILD: Please build all targets` for skipped targets (iOS, Windows JACK, Linux armhf/arm64) if touched; see `.github/workflows/autobuild.yml`.
-- Builds? Tested? Smallest change possible? Self reviewed against "Priority order" above?
+- Self reviewed against "Priority order" above?
 - Disclose AI-generated text at the end of Comments/PRs. (e.g: `> 🤖 Used AI: <model>, <harness>`) — never in code comments.
 
 ## Read when relevant

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Linux: `qmake && make` (use `qmake-qt5` on Fedora). Headless server: `qmake "CON
 
 macOS: `qmake QMAKE_APPLE_DEVICE_ARCHS=arm64 QT_ARCH=arm64 -spec macx-xcode Jamulus.pro` (Use `x86_64` on Intel Macs; `macx-clang` if using `make`). Then `xcodebuild build`, and `macdeployqt ./{Debug,Release}/Jamulus.app`.
 
-**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs `qmake && make` build ; `serveronly` rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
+**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs `qmake && make` build; `serveronly` rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
 
 ## Never Do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Linux: `qmake && make` (use `qmake-qt5` on Fedora). Headless server: `qmake "CON
 
 macOS: `qmake QMAKE_APPLE_DEVICE_ARCHS=arm64 QT_ARCH=arm64 -spec macx-xcode Jamulus.pro` (Use `x86_64` on Intel Macs; `macx-clang` if using `make`). Then `xcodebuild build`, and `macdeployqt ./{Debug,Release}/Jamulus.app`.
 
-**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs `qmake && make` build; `serveronly` rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
+**Testing:** run headless server (args `-s -n`), connect a client (e.g. via: `-n -c localhost`; may need jackd running on Linux. Run dummy Jack via: `jackd -d dummy`), exercise the change; use the JSON-RPC API (`docs/JSON-RPC.md`) where possible. Connecting a client needs a non-`serveronly` build (Build section above); `serveronly` rejects `-c`. State what you tested in the PR with evidence. GitHub Actions builds multiple platforms — on failure read the failing step's log.
 
 ## Never Do
 

--- a/docs/agents/COMMENTING.md
+++ b/docs/agents/COMMENTING.md
@@ -4,4 +4,4 @@
 - Comment only when you add evidence or an answer the thread lacks, in the shortest form that carries it; wait out an active human exchange, re-read the thread just before posting — it may have moved while you drafted — and treat a maintainer's stated preference about engagement as the rule.
 - If a posted comment proves wrong or incomplete, edit it in place so the error leaves the page; new evidence on the same finding also belongs in the existing comment, not a new one.
 - Open a new issue only for a defect you can reproduce, with the reproduction in the body; open a new PR only after a maintainer has agreed the change is wanted; leave starting discussions to humans.
-- Disclose AI-generated text
+- Disclose AI-generated text — the form is in `AGENTS.md`, PR expectations.


### PR DESCRIPTION
**🤖 AI:** Follow-up to #3785, on [the invitation there](https://github.com/jamulussoftware/jamulus/pull/3785#issuecomment-5318449069). Three one-line changes; each traces to a point raised in that review, each stands alone, and any can be dropped if it fails the stable-and-general bar.

Nothing here adds a rule to `AGENTS.md`: 3 insertions against 3 deletions, so the file gains no line and ends at 654 words against 651 on `main`. On [#3910](https://github.com/jamulussoftware/jamulus/pull/3910#discussion_r3807153374) the point was made that `CONTRIBUTING.md` is the primary source of truth, with `AGENTS.md` as the guidance to it — so a rule stated only in the agent file is the defect, not the fix. Three candidates that would otherwise have landed here are held for `CONTRIBUTING.md`: wire-format compatibility, the clang-format lists that have to move together, and treating a code comment or a commit message as a claim like any other.

**Short description of changes**

`AGENTS.md`:

- **Testing** names the build it needs. The Build line's `CONFIG+=headless serveronly` binary rejects the Testing line's client — built from [`11a28d57`](https://github.com/jamulussoftware/jamulus/commit/11a28d57e33506fc84cb9b5ee02097931c1e35a3) and run: `./Jamulus -n -c localhost` → `Client only option(s) '--connect' used.  See '--help' for help`, exit 1. One clause closes the contradiction ([raised in review](https://github.com/jamulussoftware/jamulus/pull/3785#discussion_r3786158433), [pljones preferring the plain build](https://github.com/jamulussoftware/jamulus/pull/3785#discussion_r3786765454)).
- Duplicates cut, per [the 2026-07-28 brevity pass](https://github.com/jamulussoftware/jamulus/pull/3785#issuecomment-5110039562): "One logical change per PR" and "Builds? Tested? Smallest change possible?" repeat line 5 and the Testing and Always lines, in a file prepended to every prompt.

`docs/agents/COMMENTING.md`: the last bullet was the fragment "Disclose AI-generated text" and now names where the form is stated, rather than carrying a second copy of it.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Follow-up to #3785.

**Does this change need documentation? What needs to be documented and how?**

No — it is documentation.

**Status of this Pull Request**

Ready for review. One commit per change, so any line is droppable in isolation.

**What is missing until this pull request can be merged?**

Maintainer judgment on which lines clear the "stable and general" bar.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want — the one testable claim (a `serveronly` binary rejects `-c`) was built and run; output above. No code is changed.
-  [x] My code follows the style guide — Markdown only.
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above

---

🤖 *This message was written by AI and reviewed by @mcfnord.*
