### PR TITLE
Put UI header files in their own directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Makefile.*
 *.user.*
 *.o
 moc_*.cpp
+ui/
 ui_*.h
 moc_predefs.h
 .qm/

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@ Makefile.*
 *.user.*
 *.o
 moc_*.cpp
-ui/
-ui_*.h
 moc_predefs.h
+/ui/
+ui_*.h
 .qm/
 *.qm
 qmake_qmake_qm_files.qrc

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -380,6 +380,8 @@ win32 {
 # It doesn't work with multiple targets or architectures.
 RESOURCES += src/resources.qrc
 
+UI_DIR += ui
+
 FORMS_GUI = src/aboutdlgbase.ui \
     src/serverdlgbase.ui
 
@@ -1213,9 +1215,9 @@ android {
     for (abi, ANDROID_ABIS) {
         DISTCLEAN_DIRS += debug-$${abi} release-$${abi}
     }
-    DISTCLEAN_DIRS += .qm
+    DISTCLEAN_DIRS += ui .qm
 } else {
-    DISTCLEAN_DIRS += debug release .qm
+    DISTCLEAN_DIRS += debug release ui .qm
 }
 
 win32 {

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -381,7 +381,7 @@ win32 {
 RESOURCES += src/resources.qrc
 
 # store ui_*.h files in a directory instead of project root
-UI_DIR += ui
+UI_DIR = ui
 
 # A tree built in place before UI_DIR was set still has ui_*.h in its root, and
 # they must be deleted before creating the new Makefiles.
@@ -1223,9 +1223,9 @@ android {
     for (abi, ANDROID_ABIS) {
         DISTCLEAN_DIRS += debug-$${abi} release-$${abi}
     }
-    DISTCLEAN_DIRS += ui .qm
+    DISTCLEAN_DIRS += $$UI_DIR .qm
 } else {
-    DISTCLEAN_DIRS += debug release ui .qm
+    DISTCLEAN_DIRS += debug release $$UI_DIR .qm
 }
 
 win32 {

--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -380,7 +380,15 @@ win32 {
 # It doesn't work with multiple targets or architectures.
 RESOURCES += src/resources.qrc
 
+# store ui_*.h files in a directory instead of project root
 UI_DIR += ui
+
+# A tree built in place before UI_DIR was set still has ui_*.h in its root, and
+# they must be deleted before creating the new Makefiles.
+STALE_UI_HEADERS = $$files(ui_*.h)
+for (stale, STALE_UI_HEADERS) {
+    system($$QMAKE_DEL_FILE $$stale)
+}
 
 FORMS_GUI = src/aboutdlgbase.ui \
     src/serverdlgbase.ui


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Update `Jamulus.pro` to store the generated `ui_*.h` files in their own `ui` directory instead of letting them clutter up the project root.

CHANGELOG: Build: Use a separate ui directory for generated ui header files.

**Context: Fixes an issue?**

No, just helps keep the project root cleaner

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Tested and ready

**What is missing until this pull request can be merged?**

Review

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [x] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
