### PR TITLE
Fix startup crash from an out-of-range customdirectoryindex

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -783,7 +783,7 @@ void CClientSettings::ReadSettingsFromXML ( const QDomDocument& IniXMLDocument, 
 
     // custom directory index
     if ( ( eDirectoryType == AT_CUSTOM ) &&
-         GetNumericIniSet ( IniXMLDocument, "client", "customdirectoryindex", 0, MAX_NUM_SERVER_ADDR_ITEMS, iValue ) )
+         GetNumericIniSet ( IniXMLDocument, "client", "customdirectoryindex", 0, MAX_NUM_SERVER_ADDR_ITEMS - 1, iValue ) )
     {
         iCustomDirectoryIndex = iValue;
     }


### PR DESCRIPTION
**🤖 AI:** Fixes #3917, which @pljones asked for a PR on. The client accepts a `customdirectoryindex` of `MAX_NUM_SERVER_ADDR_ITEMS` out of the settings file and then uses it as a subscript into a vector holding exactly that many elements, so the one value past the end crashes the client at startup. The range check is one wider than the object it guards.

**Short description of changes**

One line in [`CClientSettings::ReadSettingsFromXML`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/settings.cpp#L785-L787): the upper bound becomes `MAX_NUM_SERVER_ADDR_ITEMS - 1`. [`GetNumericIniSet`'s bound is inclusive](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/settings.cpp#L144), [`MAX_NUM_SERVER_ADDR_ITEMS` is 12](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/global.h#L218) and [`vstrDirectoryAddress` holds 12 elements](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/settings.h#L178), so 12 was accepted and 12 is out of range. The two unguarded subscripts are in [`CConnectDlg::RequestServerList`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/connectdlg.cpp#L320) and the [`jamulusclient/getCurrentDirectory`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/clientrpc.cpp#L211) RPC method, so it is not GUI-only.

The client's own writer only ever [emits `0..11`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/settings.cpp#L1006), so reaching this needs a hand-edited or corrupted settings file. The range check exists to make that safe.

Both arms, built from the same tree with and without this one line, Qt 5.15.13, gcc 13.3, `QT_QPA_PLATFORM=offscreen`, settings file carrying [`directorytype` 7 (`AT_CUSTOM`)](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/util.h#L620) and [`winviscon` 1](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/settings.cpp#L821):

| `customdirectoryindex` in the file | `main` | with this change |
|---|---|---|
| 11 | connect dialog drawn, value kept | connect dialog drawn, value kept |
| 12 | **SIGSEGV, exit 139**, dialog never drawn | connect dialog drawn, value falls back to 0 |

The fallback is visible in the settings file the client writes back on exit: `0` where 12 was rejected, `11` where 11 was accepted.

CHANGELOG: Client: Fixed a startup crash caused by an out-of-range custom directory index in the settings file.

**Context: Fixes an issue?**

Fixes: #3917

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Ready for review.

**What is missing until this pull request can be merged?**

Review.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want — evidence above
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above

---

🤖 *This message was written by AI and reviewed by @mcfnord.*
