### PR TITLE
Make bIsIdentified atomic

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -239,7 +239,7 @@ protected:
 
     std::atomic<bool> bIsEnabled;
     bool              bIsServer;
-    bool              bIsIdentified;
+    std::atomic<bool> bIsIdentified;
 
     int iNetwFrameSizeFact;
     int iNetwFrameSize;


### PR DESCRIPTION
**🤖 AI:** Requested by @pljones by email, as the follow-up point on #3930. `bIsIdentified` is written on the socket thread and read on the mix path with no lock common to the two, which ThreadSanitizer reports as a data race. It becomes `std::atomic<bool>`, matching `bIsEnabled` two lines above it.

**Short description of changes**

One line: [the `bIsIdentified` declaration](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.h#L242) becomes `std::atomic<bool>`. `<atomic>` is already included, and [`bIsEnabled`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.h#L240) and [`iConTimeOut`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.h#L235) are already declared this way, so no call site changes.

The socket-thread writer is [`ResetInfo`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.h#L112-L116) from [`CServer::InitChannel`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/server.cpp#L1496) on every new connection, reached under `CServer::Mutex` from [`CServer::PutAudioData`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/server.cpp#L1586); [`SetChanInfo`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.cpp#L365) also writes it, but on the main thread, from `CServer::OnProtocolMessageReceived`. The racing read is the [early return in `PrepAndSendPacket`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.cpp#L692), reached from [`MixEncodeTransmitData`](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/server.cpp#L1289) — which `OnTimer` runs [after releasing that mutex](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/server.cpp#L766), and on the pool threads when [multithreading is on](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/server.cpp#L783). The [other read](https://github.com/jamulussoftware/jamulus/blob/508f1f3d3ea41b0da76da128ee5d3f3f1b2fafc7/src/channel.cpp#L580) is on the socket thread and is not part of this.

ThreadSanitizer, server under 8-bot connect/send/disconnect churn with recording on, trimmed to the two stacks:

```
WARNING: ThreadSanitizer: data race
  Write of size 1 at 0x7ffffffac352 by thread T2 'CSocketThread':
    #0 CChannel::ResetInfo() src/channel.cpp:364
    #1 CServer::InitChannel(int, CHostAddress const&) src/server.cpp:1496
    #2 CServer::FindChannel(CHostAddress const&, bool) src/server.cpp:1473
    #3 CServer::PutAudioData(...) src/server.cpp:1592
    #4 CSocket::ProcessPacket(CHostAddress const&, int) src/socket.cpp:696
  Previous read of size 1 at 0x7ffffffac352 by main thread:
    #0 CChannel::PrepAndSendPacket(...) src/channel.cpp:719
    #1 CServer::MixEncodeTransmitData(int, int) src/server.cpp:1289
    #2 CServer::OnTimer() src/server.cpp:766
```

Those line numbers are from a build carrying #3930, where `ResetInfo` is out of line — `main` alone cannot answer the question, because with recording on the use-after-free that #3930 closes ends the run at about 55 s, before this race samples. Two 600-second runs of the same rig, one binary each:

| build | data-race reports | reports naming `PrepAndSendPacket` |
|---|---:|---:|
| #3930 | 90 | **1** |
| #3930 + this change | 80 | **0** |

An earlier pair of runs on the same two binaries gave the same 1 and 0.

No misbehaviour has been observed from the race itself. The flag is read once per channel per mix cycle and the worst case is one packet sent or skipped on a stale value.

Nothing is added to the audio deadline path. In the generated code, gcc 13.3 `-O2` x86-64, the mix-path read goes from `cmpb $0x0,0x7b2(%rdi)` to `movzbl 0x7b2(%rdi),%eax` plus `test %al,%al` — no lock prefix, no fence — and `PrepAndSendPacket` disassembles to 101 instructions either way. The one locked instruction the change introduces is the store, `xchg %al,(%r12)` in `SetChanInfo`, on the socket thread.

CHANGELOG: SKIP

**Context: Fixes an issue?**

Follow-up to #3930, which takes the channel `Mutex` around the writers. This closes the read side, which no lock covers. The two are independent and can merge in either order.

**Does this change need documentation? What needs to be documented and how?**

No.

**Status of this Pull Request**

Ready for review.

**What is missing until this pull request can be merged?**

Review.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want — evidence above
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above

---

🤖 *This message was written by AI and reviewed by @mcfnord.*

