### PR TITLE
Return "ok" from setSkillLevel when skillLevel is null

### DIFF
--- a/src/clientrpc.cpp
+++ b/src/clientrpc.cpp
@@ -305,6 +305,7 @@ CClientRpc::CClientRpc ( CClient* pClient, CClientSettings* pSettings, CRpcServe
         {
             pClient->ChannelInfo.eSkillLevel = SL_NOT_SET;
             pClient->SetRemoteInfo();
+            response["result"] = "ok";
             return;
         }
 


### PR DESCRIPTION
**🤖 AI:** Fixes #3919, assigned by @pljones for 4.1.0. `jamulusclient/setSkillLevel` documents `null` as [a valid value](https://github.com/jamulussoftware/jamulus/blob/c002c51f38cd75ea9c28834756ee453dad5adc25/docs/JSON-RPC.md#L370) that clears the skill level, and documents its result as [always `"ok"`](https://github.com/jamulussoftware/jamulus/blob/c002c51f38cd75ea9c28834756ee453dad5adc25/src/clientrpc.cpp#L301). The [`null` branch](https://github.com/jamulussoftware/jamulus/blob/c002c51f38cd75ea9c28834756ee453dad5adc25/src/clientrpc.cpp#L304-L308) clears the level and returns without setting `response["result"]`, so the reply carries neither `result` nor `error`, which the [JSON-RPC 2.0 response object](https://www.jsonrpc.org/specification#response_object) forbids. A client that waits for `result` waits forever on a valid call.

**Short description of changes**

One line: `response["result"] = "ok";` before the `return` in the `null` branch, the same statement [`setName`](https://github.com/jamulussoftware/jamulus/blob/c002c51f38cd75ea9c28834756ee453dad5adc25/src/clientrpc.cpp#L295) and the string branch of this method already end with.

Both arms built from the same tree with and without this line, Qt 5.15.13, gcc 13.3, x86-64, client headless (`-n -i /dev/null`, `QT_QPA_PLATFORM=offscreen`), raw reply lines from the RPC socket:

| `skillLevel` | `main` | with this change |
|---|---|---|
| `null` | `{"id":1,"jsonrpc":"2.0"}` | `{"id":1,"jsonrpc":"2.0","result":"ok"}` |
| `"expert"` | `{"id":2,"jsonrpc":"2.0","result":"ok"}` | same |
| `42` | `-32602`, `Invalid params: skillLevel is not a string` | same |
| `"guru"` | `-32602`, `Invalid params: skillLevel is not beginner, intermediate or expert` | same |

CHANGELOG: Client: `jamulusclient/setSkillLevel` now returns `"ok"` when called with `null`, instead of a JSON-RPC response with neither `result` nor `error`.

**Context: Fixes an issue?**

Fixes: #3919

**Does this change need documentation? What needs to be documented and how?**

No. The documented behaviour is what the code now does.

**Status of this Pull Request**

Ready for review.

**What is missing until this pull request can be merged?**

Review.

## Checklist

-  [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [x] I tested my code and it does what I want — evidence above
-  [x] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency)
-  [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
-  [x] I've filled all the content above

---

🤖 *This message was written by AI and reviewed by @mcfnord.*
